### PR TITLE
Add inline ValueSet $expand support with dependency fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ version=3.0-SNAPSHOT
 org.gradle.caching=true
 
 micronautVersion=4.6.2
-commonsVersion=1-SNAPSHOT
+commonsVersion=1.9
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -13,6 +13,7 @@ import org.termx.core.sys.provenance.ProvenanceService;
 import org.termx.terminology.terminology.valueset.ValueSetService;
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService;
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository;
 import org.termx.ts.valueset.*;
 import com.kodality.zmei.fhir.FhirMapper;
 import com.kodality.zmei.fhir.resource.other.Parameters;
@@ -30,6 +31,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   private final ProvenanceService provenanceService;
   private final ValueSetVersionService valueSetVersionService;
   private final ValueSetVersionConceptService valueSetVersionConceptService;
+  private final ValueSetVersionConceptRepository valueSetVersionConceptRepository;
   private final ValueSetFhirMapper mapper;
 
   public String getResourceType() {
@@ -64,8 +66,18 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   }
 
   public com.kodality.zmei.fhir.resource.terminology.ValueSet run(Parameters req) {
+    // 1. Try inline valueSet parameter first
+    com.kodality.zmei.fhir.resource.terminology.ValueSet inlineVs = req.findParameter("valueSet")
+        .filter(pp -> pp.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.ValueSet)
+        .map(pp -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) pp.getResource())
+        .orElse(null);
+    if (inlineVs != null) {
+      return expandInline(inlineVs, req);
+    }
+
+    // 2. Fall back to url-based lookup (existing logic)
     String url = req.findParameter("url").map(pp -> pp.getValueUrl() != null ? pp.getValueUrl() : pp.getValueString())
-        .orElseThrow(() -> new FhirException(400, IssueType.INVALID, "parameter url required"));
+        .orElseThrow(() -> new FhirException(400, IssueType.INVALID, "parameter 'url' or 'valueSet' required"));
     String versionNr = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(null);
 
     ValueSetQueryParams vsParams = new ValueSetQueryParams();
@@ -116,6 +128,79 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     }
 
     return mapper.toFhir(vs, version, provenances, snapshot, req);
+  }
+
+  private com.kodality.zmei.fhir.resource.terminology.ValueSet expandInline(
+      com.kodality.zmei.fhir.resource.terminology.ValueSet inlineVs, Parameters req) {
+    // Serialize the inline ValueSet to JSON
+    String valueSetJson = FhirMapper.toJson(inlineVs);
+
+    // Call the JSON-based expand SQL function
+    List<ValueSetVersionConcept> expandedConcepts = valueSetVersionConceptRepository.expandFromJson(valueSetJson);
+
+    // Extract parameters
+    String displayLanguage = req == null ? null : req.findParameter("displayLanguage").map(ParametersParameter::getValueCode)
+        .orElse(req.findParameter("displayLanguage").map(ParametersParameter::getValueString).orElse(null));
+    boolean includeDesignations = req != null && req.findParameter("includeDesignations")
+        .map(pr -> pr.getValueBoolean() != null && pr.getValueBoolean() || "true".equals(pr.getValueString()))
+        .orElse(false);
+
+    // Apply paging
+    Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
+        .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
+    if (offset != null) {
+      expandedConcepts = offset > expandedConcepts.size() ? List.of() : expandedConcepts.subList(offset, expandedConcepts.size());
+    }
+    Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
+        .orElse(req.findParameter("count").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
+    if (count != null) {
+      expandedConcepts = expandedConcepts.stream().limit(count).toList();
+    }
+
+    // Build response ValueSet with expansion
+    com.kodality.zmei.fhir.resource.terminology.ValueSet response = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
+    response.setUrl(inlineVs.getUrl());
+    response.setVersion(inlineVs.getVersion());
+    response.setName(inlineVs.getName());
+    response.setTitle(inlineVs.getTitle());
+    response.setStatus(inlineVs.getStatus());
+    response.setCompose(inlineVs.getCompose());
+
+    // Build expansion
+    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion expansion = 
+        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion();
+    expansion.setTimestamp(java.time.OffsetDateTime.now());
+    expansion.setTotal(expandedConcepts.size());
+    if (offset != null) {
+      expansion.setOffset(offset);
+    }
+
+    // Map concepts to expansion contains
+    List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains> contains = 
+        expandedConcepts.stream().map(concept -> {
+          com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains contain = 
+              new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains();
+          contain.setSystem(concept.getConcept().getCodeSystemUri());
+          contain.setCode(concept.getConcept().getCode());
+          if (concept.getDisplay() != null) {
+            contain.setDisplay(concept.getDisplay().getName());
+          }
+          if (includeDesignations && concept.getAdditionalDesignations() != null) {
+            contain.setDesignation(concept.getAdditionalDesignations().stream()
+                .map(d -> {
+                  com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation designation = 
+                      new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation();
+                  designation.setLanguage(d.getLanguage());
+                  designation.setValue(d.getName());
+                  return designation;
+                }).toList());
+          }
+          return contain;
+        }).toList();
+    expansion.setContains(contains);
+
+    response.setExpansion(expansion);
+    return response;
   }
 
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptRepository.java
@@ -22,4 +22,9 @@ public class ValueSetVersionConceptRepository extends BaseRepository {
     SqlBuilder sb = new SqlBuilder("select * from terminology.value_set_expand(?::bigint)", valueSetVersionId);
     return getBeans(sb.getSql(), bp, sb.getParams());
   }
+
+  public List<ValueSetVersionConcept> expandFromJson(String valueSetJson) {
+    SqlBuilder sb = new SqlBuilder("select * from terminology.value_set_expand(?::text)", valueSetJson);
+    return getBeans(sb.getSql(), bp, sb.getParams());
+  }
 }


### PR DESCRIPTION
This commit implements support for inline ValueSet expansion via the FHIR $expand operation, allowing callers to pass a complete ValueSet resource instead of just a URL. This enables expansion of ad-hoc ValueSets that don't exist in the TermX database.

Key changes:
- Lock com.kodality.commons dependency to v1.9 (fixes NoSuchMethodError in Docker)
- Add expandFromJson() method to ValueSetVersionConceptRepository
- Add inline valueSet parameter handling to ValueSetExpandOperation
- Implement expandInline() to serialize, expand, and format FHIR response

The dependency fix resolves the Docker deployment error:
  NoSuchMethodError: 'void com.kodality.commons.db.bean.PgBeanProcessor.registerColumnHandler(...)'
by locking the snapshot dependency (1-SNAPSHOT -> 1.9) to ensure consistent versions across local and Docker environments.

This enables htx-router to delegate complex expansions to TermX by sending the ValueSet body inline when CodeSystems are not available in local NPM packages.

Made-with: Cursor