### PR TITLE
Stop rejecting standard FHIR result params + bump kefhir to R5.5.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.5.1
+kefhirVersion=R5.5.2
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev

--- a/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -38,6 +39,18 @@ import org.hl7.fhir.r5.model.Narrative.NarrativeStatus;
 public abstract class BaseFhirMapper {
   public static final String SEPARATOR = "--";
   public static final String VERSION_IDENTIFIER_TYPE = "version";
+
+  private static final Set<String> NON_FILTER_PARAM_KEYS = Set.of(
+      SearchCriterion._SORT,
+      SearchCriterion._INCLUDE,
+      SearchCriterion._REVINCLUDE,
+      SearchCriterion._SUMMARY,
+      SearchCriterion._ELEMENTS,
+      SearchCriterion._CONTAINED,
+      SearchCriterion._CONTAINEDTYPE,
+      "_pretty",
+      "_format"
+  );
 
   public static String[] parseCompositeId(String id) {
     id = URLDecoder.decode(id, StandardCharsets.UTF_8);
@@ -55,6 +68,7 @@ public abstract class BaseFhirMapper {
 
   public static Map<String, String> getSimpleParams(SearchCriterion fhir) {
     return fhir.getRawParams().keySet().stream()
+        .filter(k -> !NON_FILTER_PARAM_KEYS.contains(k))
         .filter(k -> CollectionUtils.isNotEmpty(fhir.getRawParams().get(k)))
         .collect(Collectors.toMap(k -> k, k -> fhir.getRawParams().get(k).get(0)));
   }

--- a/termx-core/src/test/groovy/org/termx/core/fhir/BaseFhirMapperSpec.groovy
+++ b/termx-core/src/test/groovy/org/termx/core/fhir/BaseFhirMapperSpec.groovy
@@ -1,0 +1,50 @@
+package org.termx.core.fhir
+
+import com.kodality.kefhir.core.model.search.SearchCriterion
+import spock.lang.Specification
+
+class BaseFhirMapperSpec extends Specification {
+
+  def 'getSimpleParams filters FHIR result/ignore params and preserves the rest'() {
+    given:
+    def raw = [
+        'url'           : ['https://example.org/ValueSet/foo'],
+        '_count'        : ['10'],
+        '_page'         : ['2'],
+        '_summary'      : ['false'],
+        '_elements'     : ['name,status'],
+        '_sort'         : ['name'],
+        '_include'      : ['ValueSet:reference'],
+        '_revinclude'   : ['ConceptMap:source'],
+        '_contained'    : ['true'],
+        '_containedType': ['contained'],
+        '_pretty'       : ['true'],
+        '_format'       : ['json'],
+        'publisher'     : ['HL7'],
+    ]
+    def criterion = new SearchCriterion('ValueSet', [], raw)
+
+    when:
+    def simple = BaseFhirMapper.getSimpleParams(criterion)
+
+    then:
+    simple == [
+        'url'      : 'https://example.org/ValueSet/foo',
+        '_count'   : '10',
+        '_page'    : '2',
+        'publisher': 'HL7',
+    ]
+  }
+
+  def 'getSimpleParams skips empty value lists'() {
+    given:
+    def raw = ['url': [], '_summary': ['true'], 'publisher': ['HL7']]
+    def criterion = new SearchCriterion('ValueSet', [], raw)
+
+    when:
+    def simple = BaseFhirMapper.getSimpleParams(criterion)
+
+    then:
+    simple == ['publisher': 'HL7']
+  }
+}


### PR DESCRIPTION
Two related changes that together fix the user-visible 500 on `_summary` and add full FHIR `_summary` shaping.

## 1. Stop rejecting standard FHIR result params (mapper fix)

Fixes a 500 we hit when the tx-router does upstream discovery: it issues `GET /ValueSet?url=…&_count=1&_summary=false` against TermX to find which server owns a canonical URL. TermX returns `500 OperationOutcome "Search by '_summary' not supported"`.

Root cause: `BaseFhirMapper.getSimpleParams` returns **every** raw query parameter, including FHIR-standard result modifiers (`_summary`, `_elements`, `_sort`, `_include`, `_revinclude`, `_contained`, `_containedType`) and ignore params (`_pretty`, `_format`). Each per-resource mapper then iterates those entries through a switch and `throws ApiClientException("Search by '<key>' not supported")` on any unrecognised key. Any FHIR-conformant client adding `_sort`, `_elements`, etc. to a search hits the same default branch.

Filter the standard FHIR result/ignore params out of `getSimpleParams` so they never reach the per-resource switches. `_count` and `_page` are deliberately preserved — the existing `case SearchCriterion._COUNT -> params.setLimit(fhir.getCount());` and `_PAGE` branches handle pagination via `SearchCriterion.getCount()` / `getOffset()` and must keep firing.

Six callers benefit automatically (no switch edits needed):
- `ValueSetFhirMapper.fromFhir`, `fromFhirVSVersionParams`
- `CodeSystemFhirMapper.fromFhir` (two sites)
- `ConceptMapFhirMapper.fromFhir`
- `StructureMapResourceStorage`, `StructureDefinitionResourceStorage`, `ProvenanceFhirResourceStorage` inner mappers

## 2. Bump kefhir to R5.5.2

Pulls in the framework-level `_summary=true|text|data` shaping from termx-health/kefhir#3 (merged + republished as `R5.5.2` in termx-health/kefhir#4). After this lands:
- `_summary=true` → keep only `isSummary` and mandatory elements; SUBSETTED tag added.
- `_summary=text` → keep only `id`, `meta`, `text`, mandatory.
- `_summary=data` → drop only the root narrative.
- `_summary=count` → unchanged (count-only Bundle, was already supported).
- `_summary=false` / absent → unchanged (full body).

The two changes work in tandem: kefhir strips elements *after* the storage returns the resource, so the storage mapper still needs to ignore `_summary` as a filter — that's what change 1 does.

## Test plan

- [x] `BaseFhirMapperSpec` — new Spock test asserts `_summary`, `_elements`, `_sort`, `_include`, `_revinclude`, `_contained`, `_containedType`, `_pretty`, `_format` are filtered, `_count` / `_page` preserved, arbitrary search params (e.g. `publisher`) preserved.
- [x] `terminology:CodeSystemFhirMapperSpec` — existing tests still pass.
- [x] `terminology:compileJava`, `modeler:compileJava` — both downstream consumers compile against `kefhirVersion=R5.5.2`.
- [ ] Smoke test against the deployed server:
    - `curl -is 'https://tx.hl7.lt/api/fhir/ValueSet?url=https://termx.org/fhir/ValueSet/publisher&_count=1&_summary=false'` — expect 200 with a Bundle (was 500 before).
    - `curl -is 'https://tx.hl7.lt/api/fhir/ValueSet/\$expand?url=https://termx.org/fhir/ValueSet/publisher&includeDesignations=true&defaultLanguage=en'` — end-to-end through tx-router; expect the expanded ValueSet.
    - `curl -is 'https://tx.hl7.lt/api/fhir/ValueSet?publisher=HL7&_count=5'` — regression: normal search still works.
    - `curl -s 'https://tx.hl7.lt/api/fhir/CodeSystem/<id>?_summary=true' | jq 'has(\"concept\"), has(\"text\"), .meta.tag'` — expect `false`, `false`, SUBSETTED tag present.
    - `curl -s 'https://tx.hl7.lt/api/fhir/CodeSystem/<id>?_summary=text' | jq 'keys'` — only `id`, `meta`, `text` and mandatories.
    - `curl -s 'https://tx.hl7.lt/api/fhir/CodeSystem/<id>?_summary=data' | jq 'has(\"text\"), has(\"concept\")'` — `false`, `true`.
    - `curl -s 'https://tx.hl7.lt/api/fhir/ValueSet?_summary=count'` — regression: count-only Bundle still works.