### PR TITLE
Bump kefhirVersion to R5.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.5.2
+kefhirVersion=R5.6
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev


### PR DESCRIPTION
Pulls in the `SummaryPathIndex` fix from termx-health/kefhir#5: drops ancestor closure so `_summary=true` / `_summary=text` actually strip the heavy collection elements (`CodeSystem.concept`, `ValueSet.compose`, `ValueSet.expansion`, `ConceptMap.group.element`).

## Why

Smoke-testing the R5.5.2 build on `dev.termx.org` showed `_summary=true` returning a CodeSystem with `concept` still populated and the `SUBSETTED` tag added — the framework was running, just over-eager. Root cause was `modifierExtension` being marked `isSummary=true` on every FHIR element by spec, combined with my ancestor closure on the keep set: every element with a `modifierExtension` descendant got promoted into the summary set, defeating `_summary=true`.

The kefhir fix removes the closure; an element is kept iff its OWN `isSummary=true` (or it's mandatory, or it's id/meta/text for `_summary=text`). The walker still descends naturally into kept parents.

## Test plan

- [x] `terminology:compileJava` against `R5.6` succeeds.
- [ ] After deploy:
    - `curl -s 'https://dev.termx.org/api/fhir/CodeSystem/administrative-gender--6.0.0?_summary=true' | jq 'has(\"concept\"), has(\"text\"), has(\"description\"), .meta.tag'`
      expect: `false`, `false`, `false`, SUBSETTED present
    - `curl -s 'https://dev.termx.org/api/fhir/CodeSystem/administrative-gender--6.0.0?_summary=text' | jq 'has(\"concept\"), has(\"text\"), .meta.tag'`
      expect: `false`, `true`, SUBSETTED present
    - `curl -s 'https://dev.termx.org/api/fhir/ValueSet/<id>?_summary=true' | jq 'has(\"compose\"), has(\"expansion\")'`
      expect: `false`, `false`