### PR TITLE
feat(snomed): RF2 dry-run scan + concept-usage utility

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,152 @@
+# termx-server / scripts
+
+Standalone CLI helpers that mirror the SNOMED dry-run scan and concept-usage lookup
+features. Useful when you need the same output without spinning up the full
+termx-server stack — ad-hoc reports, batch triage, CI checks, support workflows.
+
+Both scripts emit JSON whose shape matches the corresponding REST responses, so the
+same UI / tooling can consume the output.
+
+## Requirements
+
+- Python 3.9+
+- For `snomed_concept_usage.py` only: `pip install psycopg2-binary`
+
+## `snomed_rf2_scan.py` — RF2 dry-run scan (Utility 1)
+
+Parses a SNOMED RF2 release zip and produces a change report (new / modified /
+invalidated concepts, with their designations and attributes). Algorithm matches
+`org.termx.snomed.integration.rf2.scan.SnomedRF2DiffEngine` line-for-line.
+
+```text
+python3 snomed_rf2_scan.py <ZIP> [--cutoff YYYYMMDD] [-o OUTPUT.json]
+                                 [--branch-path MAIN] [--rf2-type SNAPSHOT|DELTA|FULL] [-q]
+```
+
+### Examples
+
+Scan a full International release, auto-detect cutoff (= max effectiveTime in the
+Concept file, i.e. the latest release in the zip):
+
+```sh
+python3 snomed_rf2_scan.py ~/Downloads/SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip \
+    -o /tmp/scan.json
+```
+
+Filter changes since a specific date (e.g. everything since 2025-10-01):
+
+```sh
+python3 snomed_rf2_scan.py ~/Downloads/SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip \
+    --cutoff 20251001 \
+    -o /tmp/scan-since-20251001.json
+```
+
+### Output
+
+- Prints stats (`conceptsAdded`, `conceptsInvalidated`, etc.) to stdout.
+- Writes the full `SnomedRF2ScanResult`-shaped JSON to `--output`
+  (`stats`, `newConcepts[]`, `modifiedConcepts[]`, `invalidatedConcepts[]`).
+- Progress messages go to stderr; pass `-q` to silence.
+
+## `snomed_concept_usage.py` — Concept usage lookup (Utility 2)
+
+Given a list of SNOMED concept codes, queries the termx Postgres database for places
+where they are referenced:
+
+| Resource | Source |
+|---|---|
+| `CodeSystemSupplement` | `terminology.code_system_entity_version` rows in CSes whose `base_code_system='snomed-ct'` |
+| `ValueSet` (rule) | `terminology.value_set_version_rule.concepts` JSONB array |
+| `ValueSetExpansion` | `terminology.value_set_snapshot.expansion` JSONB array |
+
+```text
+python3 snomed_concept_usage.py [--codes "<list>" | --codes-file FILE | (stdin)]
+                                [--include-modified]
+                                (--dsn URL | --host… --port… --dbname… --user… --password…)
+                                [-o OUTPUT.json]
+```
+
+### Connection options (in order of precedence)
+
+1. `--dsn 'postgres://user:pass@host:5432/termx'`
+2. Environment variable `DATABASE_URL`
+3. `--host` / `--port` / `--dbname` / `--user` / `--password` flags
+4. Standard libpq env vars `PGHOST` / `PGPORT` / `PGDATABASE` / `PGUSER` / `PGPASSWORD`
+
+### Input options (combine freely; stdin used if none provided)
+
+The `--codes` / `--codes-file` parsers accept any of:
+
+- Plain text — one code per line, or comma / space / semicolon separated.
+- A bare JSON array of strings or `{conceptId|code}` objects.
+- A full `SnomedRF2ScanResult` JSON (the output of `snomed_rf2_scan.py` or the
+  in-app dry-run download). By default only `invalidatedConcepts[].conceptId` is
+  extracted; pass `--include-modified` to also include `modifiedConcepts[].conceptId`.
+
+### Examples
+
+Look up a small inline list against a local dev database:
+
+```sh
+python3 snomed_concept_usage.py \
+    --codes "264936004, 7377003, 241185003" \
+    --dsn 'postgres://termx:termx@localhost:5432/termx'
+```
+
+Feed the invalidated codes from a previous dry-run scan:
+
+```sh
+python3 snomed_concept_usage.py \
+    --codes-file /tmp/scan-since-20251001.json \
+    --dsn "$DATABASE_URL" \
+    -o /tmp/usage.json
+```
+
+Pipe codes via stdin (e.g. from `jq`):
+
+```sh
+jq -r '.invalidatedConcepts[].conceptId' /tmp/scan.json \
+  | python3 snomed_concept_usage.py --dsn "$DATABASE_URL"
+```
+
+### Output
+
+JSON array of `SnomedConceptUsage` rows:
+
+```json
+[
+  {
+    "resourceType": "CodeSystemSupplement",
+    "resourceId":   "snomed-est-supplement",
+    "resourceVersion": null,
+    "conceptCode":  "264936004",
+    "location":     "concept"
+  },
+  {
+    "resourceType": "ValueSet",
+    "resourceId":   "my-procedures-vs",
+    "resourceVersion": "1.0.0",
+    "conceptCode":  "7377003",
+    "location":     "rule"
+  }
+]
+```
+
+A summary by resource type is also printed to stderr (suppress with `-q`).
+
+## Permissions
+
+Both scripts are read-only — they never modify the database or the zip.
+For `snomed_concept_usage.py` the database user only needs `SELECT` on
+`terminology.code_system`, `terminology.code_system_entity_version`,
+`terminology.value_set_version`, `terminology.value_set_version_rule`,
+`terminology.value_set_version_rule_set`, and `terminology.value_set_snapshot`.
+
+## When to prefer the in-app feature
+
+- Need progress UI, auto-download, or "Proceed with import" → use the dry-run
+  modal in `termx-web` (`SNOMED CodeSystem edit page → Import from RF2 → Dry run`).
+- Need pre-built links from results to the matching CodeSystem / ValueSet edit
+  pages → use the `SNOMED concept usage` page.
+- Need a local report without a running server, or a scriptable batch run → use
+  these CLIs.

--- a/scripts/snomed_concept_usage.py
+++ b/scripts/snomed_concept_usage.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Standalone CLI runner that mirrors org.termx.snomed.integration.usage.SnomedConceptUsageRepository.
+
+Given a list of SNOMED concept codes, queries the termx Postgres database for places
+where those codes are referenced:
+
+  1. CodeSystem supplements   -> terminology.code_system_entity_version (in CSes whose
+                                 base_code_system='snomed-ct')
+  2. ValueSet rules           -> terminology.value_set_version_rule.concepts (JSONB array)
+  3. ValueSet expansions      -> terminology.value_set_snapshot.expansion (JSONB array)
+
+Output JSON shape matches the SnomedConceptUsage REST endpoint
+(POST /snomed/concept-usage), so the same UI / tooling can consume it.
+
+Requires: psycopg2-binary  (pip install psycopg2-binary)
+"""
+import argparse
+import json
+import os
+import sys
+from typing import List
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    sys.stderr.write("ERROR: psycopg2 is required. Install with: pip install psycopg2-binary\n")
+    raise SystemExit(2)
+
+
+SNOMED_CS = "snomed-ct"
+SNOMED_URI = "http://snomed.info/sct"
+
+
+SQL_SUPPLEMENTS = """
+select 'CodeSystemSupplement' as resource_type,
+       cs.id                  as resource_id,
+       null::text             as resource_version,
+       cev.code               as concept_code,
+       'concept'              as location
+  from terminology.code_system_entity_version cev
+  join terminology.code_system cs on cs.id = cev.code_system
+ where cs.base_code_system = %s
+   and cev.sys_status = 'A'
+   and cs.sys_status  = 'A'
+   and cev.code = any(%s)
+"""
+
+SQL_VS_RULES = """
+select 'ValueSet'                                           as resource_type,
+       vsv.value_set                                        as resource_id,
+       vsv.version                                          as resource_version,
+       coalesce(c->'concept'->>'code', c->>'code')          as concept_code,
+       'rule'                                               as location
+  from terminology.value_set_version_rule vsr
+  join terminology.value_set_version_rule_set vsrs on vsrs.id = vsr.rule_set_id
+  join terminology.value_set_version vsv on vsv.id = vsrs.value_set_version_id
+  cross join lateral jsonb_array_elements(coalesce(vsr.concepts, '[]'::jsonb)) c
+ where vsr.sys_status  = 'A'
+   and vsrs.sys_status = 'A'
+   and vsv.sys_status  = 'A'
+   and (vsr.code_system = %s
+        or coalesce(c->'concept'->>'codeSystem', c->>'codeSystem') = %s
+        or coalesce(c->'concept'->>'codeSystemUri', c->>'codeSystemUri') = %s)
+   and coalesce(c->'concept'->>'code', c->>'code') = any(%s)
+"""
+
+SQL_VS_EXPANSIONS = """
+select 'ValueSetExpansion'                                   as resource_type,
+       vss.value_set                                         as resource_id,
+       vsv.version                                           as resource_version,
+       coalesce(c->'concept'->>'code', c->>'code')           as concept_code,
+       'expansion'                                           as location
+  from terminology.value_set_snapshot vss
+  join terminology.value_set_version vsv on vsv.id = vss.value_set_version_id
+  cross join lateral jsonb_array_elements(coalesce(vss.expansion, '[]'::jsonb)) c
+ where vss.sys_status = 'A'
+   and vsv.sys_status = 'A'
+   and (coalesce(c->'concept'->>'codeSystem', c->>'codeSystem') = %s
+        or coalesce(c->'concept'->>'codeSystemUri', c->>'codeSystemUri') = %s)
+   and coalesce(c->'concept'->>'code', c->>'code') = any(%s)
+"""
+
+
+def parse_input(raw: str, include_modified: bool = False) -> List[str]:
+    """Accept plain text (any separator), bare JSON array, or a full SnomedRF2ScanResult JSON."""
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    if raw.startswith("{") or raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            parsed = None
+        if parsed is not None:
+            codes = []
+            _walk(parsed, codes, include_modified)
+            if codes:
+                return _dedup(codes)
+    # fallback: split on whitespace / comma / semicolon
+    import re
+    return _dedup([t for t in re.split(r"[\s,;]+", raw) if t])
+
+
+def _walk(node, out: List[str], include_modified: bool, depth: int = 0):
+    if node is None:
+        return
+    if isinstance(node, list):
+        for item in node:
+            _walk(item, out, include_modified, depth + 1)
+        return
+    if isinstance(node, str):
+        if node.isdigit():
+            out.append(node)
+        return
+    if not isinstance(node, dict):
+        return
+    # Top-level scan-result shape
+    if depth == 0 and ("invalidatedConcepts" in node or "modifiedConcepts" in node or "newConcepts" in node):
+        for c in node.get("invalidatedConcepts") or []:
+            cid = (c or {}).get("conceptId")
+            if cid:
+                out.append(cid)
+        if include_modified:
+            for c in node.get("modifiedConcepts") or []:
+                cid = (c or {}).get("conceptId")
+                if cid:
+                    out.append(cid)
+        return
+    cid = node.get("conceptId") or node.get("code")
+    if isinstance(cid, str) and cid:
+        out.append(cid)
+    for v in node.values():
+        _walk(v, out, include_modified, depth + 1)
+
+
+def _dedup(codes: List[str]) -> List[str]:
+    seen, out = set(), []
+    for c in codes:
+        c = c.strip()
+        if c and c not in seen:
+            seen.add(c)
+            out.append(c)
+    return out
+
+
+def collect_codes(args) -> List[str]:
+    codes: List[str] = []
+    if args.codes:
+        codes += parse_input(args.codes, args.include_modified)
+    if args.codes_file:
+        with open(args.codes_file, "r") as f:
+            codes += parse_input(f.read(), args.include_modified)
+    if not codes and not sys.stdin.isatty():
+        codes += parse_input(sys.stdin.read(), args.include_modified)
+    return _dedup(codes)
+
+
+def build_dsn(args) -> str:
+    if args.dsn:
+        return args.dsn
+    if os.environ.get("DATABASE_URL"):
+        return os.environ["DATABASE_URL"]
+    parts = []
+    if args.host or os.environ.get("PGHOST"):
+        parts.append(f"host={args.host or os.environ['PGHOST']}")
+    if args.port or os.environ.get("PGPORT"):
+        parts.append(f"port={args.port or os.environ['PGPORT']}")
+    if args.dbname or os.environ.get("PGDATABASE"):
+        parts.append(f"dbname={args.dbname or os.environ['PGDATABASE']}")
+    if args.user or os.environ.get("PGUSER"):
+        parts.append(f"user={args.user or os.environ['PGUSER']}")
+    if args.password or os.environ.get("PGPASSWORD"):
+        parts.append(f"password={args.password or os.environ['PGPASSWORD']}")
+    if not parts:
+        raise SystemExit(
+            "ERROR: no database connection info. Pass --dsn 'postgres://…', set "
+            "DATABASE_URL, or pass --host/--port/--dbname/--user/--password."
+        )
+    return " ".join(parts)
+
+
+def query_all(dsn: str, codes: List[str]):
+    if not codes:
+        return []
+    rows = []
+    with psycopg2.connect(dsn) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            for sql, params in (
+                (SQL_SUPPLEMENTS, (SNOMED_CS, codes)),
+                (SQL_VS_RULES, (SNOMED_CS, SNOMED_CS, SNOMED_URI, codes)),
+                (SQL_VS_EXPANSIONS, (SNOMED_CS, SNOMED_URI, codes)),
+            ):
+                cur.execute(sql, params)
+                rows.extend(cur.fetchall())
+    return [
+        {
+            "resourceType": r["resource_type"],
+            "resourceId": r["resource_id"],
+            "resourceVersion": r["resource_version"],
+            "conceptCode": r["concept_code"],
+            "location": r["location"],
+        }
+        for r in rows
+    ]
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    src = p.add_argument_group("input (any combination, plus stdin)")
+    src.add_argument("--codes", help="Inline code list. Whitespace/comma/semicolon separated, "
+                                     "or a JSON array, or a full SnomedRF2ScanResult JSON.")
+    src.add_argument("--codes-file", help="Path to a file containing codes (text or JSON).")
+    src.add_argument("--include-modified", action="store_true",
+                     help="When the input is a SnomedRF2ScanResult, also include conceptIds from "
+                          "modifiedConcepts (default: only invalidatedConcepts).")
+
+    db = p.add_argument_group("database connection")
+    db.add_argument("--dsn", help="libpq connection string (e.g. 'postgres://user:pass@host:5432/termx'). "
+                                  "Overrides individual options and DATABASE_URL.")
+    db.add_argument("--host"); db.add_argument("--port")
+    db.add_argument("--dbname"); db.add_argument("--user"); db.add_argument("--password")
+
+    out = p.add_argument_group("output")
+    out.add_argument("-o", "--output", default="-",
+                     help="Output JSON path. '-' (default) writes to stdout.")
+    out.add_argument("-q", "--quiet", action="store_true", help="Suppress progress logging on stderr.")
+
+    args = p.parse_args()
+    log = (lambda msg: print(msg, file=sys.stderr)) if not args.quiet else (lambda msg: None)
+
+    codes = collect_codes(args)
+    if not codes:
+        raise SystemExit("ERROR: no codes provided. Pass --codes, --codes-file, or pipe via stdin.")
+    log(f"[usage] {len(codes)} code(s) to look up")
+
+    dsn = build_dsn(args)
+    rows = query_all(dsn, codes)
+    log(f"[usage] {len(rows)} reference(s) found")
+
+    payload = json.dumps(rows, indent=2)
+    if args.output == "-":
+        sys.stdout.write(payload + "\n")
+    else:
+        with open(args.output, "w") as f:
+            f.write(payload)
+        log(f"[usage] wrote results to {args.output}")
+
+    by_type = {}
+    for r in rows:
+        by_type[r["resourceType"]] = by_type.get(r["resourceType"], 0) + 1
+    if not args.quiet:
+        print("\nReferences by resource type:", file=sys.stderr)
+        for k, v in sorted(by_type.items()):
+            print(f"  {k}: {v}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/snomed_rf2_scan.py
+++ b/scripts/snomed_rf2_scan.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+Standalone CLI runner that mirrors org.termx.snomed.integration.rf2.scan.SnomedRF2DiffEngine.
+
+Use this when you need to dry-run-scan a SNOMED RF2 release zip without spinning up
+the full termx-server stack (e.g. for triage, ad-hoc reports, or in CI).
+
+Algorithm — same as the in-app dry-run:
+  - filter rows whose effectiveTime >= cutoff (default: max effectiveTime in Concept file)
+  - for each conceptId touched in the change-set:
+      concept row active=0  -> INVALIDATED
+      concept row active=1  -> NEW
+      only desc/rel rows    -> MODIFIED
+
+Output JSON shape matches SnomedRF2ScanResult so the same UI / tooling can consume it.
+"""
+import argparse
+import datetime
+import io
+import json
+import sys
+import zipfile
+from collections import defaultdict
+
+
+FSN = "900000000000003001"
+SYNONYM = "900000000000013009"
+TEXT_DEFINITION = "900000000000550004"
+PREFERRED = "900000000000548007"
+ACCEPTABLE = "900000000000549004"
+
+
+def open_filtered(zf, member, cutoff):
+    """Yield TSV rows (lists of strings) where effectiveTime[col 1] >= cutoff. Skip header."""
+    with zf.open(member) as raw:
+        for i, line in enumerate(io.TextIOWrapper(raw, encoding="utf-8", newline="")):
+            if i == 0:
+                continue
+            line = line.rstrip("\r\n")
+            if not line:
+                continue
+            parts = line.split("\t")
+            et = parts[1] if len(parts) > 1 else ""
+            if cutoff and et < cutoff:
+                continue
+            yield parts
+
+
+def read_concepts(zf, member, cutoff):
+    rows = []
+    for p in open_filtered(zf, member, cutoff):
+        if len(p) < 5:
+            continue
+        rows.append({
+            "id": p[0], "effectiveTime": p[1],
+            "active": p[2] == "1", "moduleId": p[3], "definitionStatusId": p[4],
+        })
+    return rows
+
+
+def read_descriptions(zf, member, cutoff, text_def):
+    rows = []
+    for p in open_filtered(zf, member, cutoff):
+        if len(p) < 9:
+            continue
+        rows.append({
+            "id": p[0], "effectiveTime": p[1], "active": p[2] == "1",
+            "moduleId": p[3], "conceptId": p[4], "languageCode": p[5],
+            "typeId": p[6], "term": p[7], "caseSignificanceId": p[8],
+            "textDefinition": text_def,
+        })
+    return rows
+
+
+def read_relationships(zf, member, cutoff):
+    rows = []
+    for p in open_filtered(zf, member, cutoff):
+        if len(p) < 10:
+            continue
+        try:
+            grp = int(p[6])
+        except ValueError:
+            grp = None
+        rows.append({
+            "id": p[0], "effectiveTime": p[1], "active": p[2] == "1",
+            "moduleId": p[3], "sourceId": p[4], "destinationId": p[5],
+            "relationshipGroup": grp, "typeId": p[7],
+            "characteristicTypeId": p[8], "modifierId": p[9],
+        })
+    return rows
+
+
+def read_language_refset(zf, member, cutoff):
+    rows = []
+    for p in open_filtered(zf, member, cutoff):
+        if len(p) < 7:
+            continue
+        rows.append({
+            "id": p[0], "effectiveTime": p[1], "active": p[2] == "1",
+            "moduleId": p[3], "refsetId": p[4],
+            "referencedComponentId": p[5], "acceptabilityId": p[6],
+        })
+    return rows
+
+
+def latest_per_id(rows):
+    """Keep only the latest-effectiveTime row per id (defensive against FULL files)."""
+    out = {}
+    for r in rows:
+        ex = out.get(r["id"])
+        if ex is None or ex["effectiveTime"] <= r["effectiveTime"]:
+            out[r["id"]] = r
+    return list(out.values())
+
+
+def map_acceptability(a):
+    if a == PREFERRED:
+        return "preferred"
+    if a == ACCEPTABLE:
+        return "acceptable"
+    return a or "none"
+
+
+def map_type(d):
+    if d.get("textDefinition"):
+        return "textDefinition"
+    if d["typeId"] == FSN:
+        return "fully-specified-name"
+    if d["typeId"] == SYNONYM:
+        return "synonym"
+    if d["typeId"] == TEXT_DEFINITION:
+        return "textDefinition"
+    return d["typeId"]
+
+
+def find_member(names, prefix, contains=None):
+    for n in names:
+        base = n.rsplit('/', 1)[-1]
+        if base.startswith(prefix) and (contains is None or contains in n):
+            return n
+    return None
+
+
+def classify(zip_path, cutoff, branch_path="MAIN", rf2_type="SNAPSHOT", verbose=True):
+    log = (lambda msg: print(msg, file=sys.stderr)) if verbose else (lambda msg: None)
+    log(f"[scan] opening {zip_path}, cutoff effectiveTime >= {cutoff or '(none)'}")
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        c_path = find_member(names, "sct2_Concept_Snapshot_", "Snapshot/Terminology/")
+        d_path = find_member(names, "sct2_Description_Snapshot", "Snapshot/Terminology/")
+        td_path = find_member(names, "sct2_TextDefinition_Snapshot", "Snapshot/Terminology/")
+        r_path = find_member(names, "sct2_Relationship_Snapshot_", "Snapshot/Terminology/")
+        lr_path = find_member(names, "der2_cRefset_LanguageSnapshot", "Snapshot/Refset/Language/")
+        log(f"[scan]   concept:        {c_path}")
+        log(f"[scan]   description:    {d_path}")
+        log(f"[scan]   text-def:       {td_path}")
+        log(f"[scan]   relationship:   {r_path}")
+        log(f"[scan]   language-refset:{lr_path}")
+
+        if c_path is None:
+            raise SystemExit("ERROR: no sct2_Concept_Snapshot_*.txt found in zip — is this an RF2 release?")
+
+        # If no cutoff supplied, use max effectiveTime in concept file (the "this release" set).
+        if not cutoff:
+            with zf.open(c_path) as raw:
+                effs = []
+                for i, line in enumerate(io.TextIOWrapper(raw, encoding="utf-8", newline="")):
+                    if i == 0:
+                        continue
+                    parts = line.rstrip("\r\n").split("\t")
+                    if len(parts) > 1 and parts[1]:
+                        effs.append(parts[1])
+            cutoff = max(effs) if effs else "00000000"
+            log(f"[scan] auto-cutoff (max concept effectiveTime) = {cutoff}")
+
+        concepts = read_concepts(zf, c_path, cutoff)
+        log(f"[scan] concept rows post-cutoff: {len(concepts)}")
+        descriptions = []
+        if d_path:
+            descriptions += read_descriptions(zf, d_path, cutoff, False)
+        if td_path:
+            descriptions += read_descriptions(zf, td_path, cutoff, True)
+        log(f"[scan] description+textdef rows post-cutoff: {len(descriptions)}")
+        relationships = read_relationships(zf, r_path, cutoff) if r_path else []
+        log(f"[scan] relationship rows post-cutoff: {len(relationships)}")
+        lang = read_language_refset(zf, lr_path, cutoff) if lr_path else []
+        log(f"[scan] language-refset rows post-cutoff: {len(lang)}")
+
+    concepts = latest_per_id(concepts)
+    descriptions = latest_per_id(descriptions)
+    relationships = latest_per_id(relationships)
+
+    acceptability, et_for = {}, {}
+    for r in lang:
+        if not r["active"]:
+            continue
+        rid = r["referencedComponentId"]
+        if rid not in et_for or et_for[rid] <= r["effectiveTime"]:
+            et_for[rid] = r["effectiveTime"]
+            acceptability[rid] = map_acceptability(r["acceptabilityId"])
+
+    concept_by_code = {c["id"]: c for c in concepts}
+    desc_by_concept = defaultdict(list)
+    for d in descriptions:
+        desc_by_concept[d["conceptId"]].append(d)
+    rel_by_source = defaultdict(list)
+    for r in relationships:
+        rel_by_source[r["sourceId"]].append(r)
+
+    touched = set()
+    touched.update(concept_by_code.keys())
+    touched.update(desc_by_concept.keys())
+    touched.update(rel_by_source.keys())
+
+    new_concepts, modified_concepts, invalidated_concepts = [], [], []
+
+    def designation(d):
+        return {
+            "descriptionId": d["id"], "term": d["term"],
+            "type": map_type(d), "language": d["languageCode"],
+            "acceptability": acceptability.get(d["id"], "none"),
+            "active": d["active"], "effectiveTime": d["effectiveTime"],
+        }
+
+    def attribute(r):
+        return {
+            "relationshipId": r["id"], "typeId": r["typeId"],
+            "destinationId": r["destinationId"],
+            "relationshipGroup": r["relationshipGroup"],
+            "characteristicTypeId": r["characteristicTypeId"],
+            "modifierId": r["modifierId"],
+            "active": r["active"], "effectiveTime": r["effectiveTime"],
+        }
+
+    for cid in touched:
+        crow = concept_by_code.get(cid)
+        ds = desc_by_concept.get(cid, [])
+        rs = rel_by_source.get(cid, [])
+        if crow and not crow["active"]:
+            invalidated_concepts.append({
+                "conceptId": cid,
+                "effectiveTime": crow["effectiveTime"],
+                "moduleId": crow["moduleId"],
+                "designations": [designation(d) for d in ds],
+            })
+        elif crow:
+            new_concepts.append({
+                "conceptId": cid,
+                "effectiveTime": crow["effectiveTime"],
+                "moduleId": crow["moduleId"],
+                "definitionStatusId": crow["definitionStatusId"],
+                "designations": [designation(d) for d in ds if d["active"]],
+                "attributes": [attribute(r) for r in rs if r["active"]],
+            })
+        else:
+            modified_concepts.append({
+                "conceptId": cid,
+                "addedDesignations": [designation(d) for d in ds if d["active"]],
+                "removedDesignations": [designation(d) for d in ds if not d["active"]],
+                "addedAttributes": [attribute(r) for r in rs if r["active"]],
+                "removedAttributes": [attribute(r) for r in rs if not r["active"]],
+            })
+
+    stats = {
+        "conceptsAdded": len(new_concepts),
+        "conceptsModified": len(modified_concepts),
+        "conceptsInvalidated": len(invalidated_concepts),
+        "descriptionsAdded": sum(1 for d in descriptions if d["active"]),
+        "descriptionsInvalidated": sum(1 for d in descriptions if not d["active"]),
+        "relationshipsAdded": sum(1 for r in relationships if r["active"]),
+        "relationshipsInvalidated": sum(1 for r in relationships if not r["active"]),
+    }
+
+    return {
+        "branchPath": branch_path,
+        "rf2Type": rf2_type,
+        "releaseEffectiveTime": max((c["effectiveTime"] for c in concepts), default=cutoff),
+        "scannedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "uploadCacheId": None,
+        "stats": stats,
+        "newConcepts": new_concepts,
+        "modifiedConcepts": modified_concepts,
+        "invalidatedConcepts": invalidated_concepts,
+    }
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("zip", help="Path to a SNOMED RF2 release zip (International or Edition).")
+    p.add_argument("--cutoff", default=None,
+                   help="Filter rows where effectiveTime >= this YYYYMMDD value. "
+                        "If omitted, uses the max effectiveTime in the Concept file (the latest release in the zip).")
+    p.add_argument("-o", "--output", default="snomed-rf2-scan.json",
+                   help="Output JSON path (default: snomed-rf2-scan.json).")
+    p.add_argument("--branch-path", default="MAIN", help="Branch path label for the report.")
+    p.add_argument("--rf2-type", default="SNAPSHOT", choices=("SNAPSHOT", "DELTA", "FULL"),
+                   help="Label for the report (algorithm is identical for all three).")
+    p.add_argument("-q", "--quiet", action="store_true", help="Suppress progress logging on stderr.")
+    args = p.parse_args()
+
+    result = classify(args.zip, args.cutoff, args.branch_path, args.rf2_type, verbose=not args.quiet)
+
+    with open(args.output, "w") as f:
+        json.dump(result, f)
+
+    s = result["stats"]
+    print()
+    print(f"Branch: {result['branchPath']}  Type: {result['rf2Type']}  Release: {result['releaseEffectiveTime']}")
+    print(f"Cutoff: effectiveTime >= {args.cutoff or result['releaseEffectiveTime']}")
+    print()
+    print("Stats:")
+    for k, v in s.items():
+        print(f"  {k}: {v}")
+    print()
+    print(f"Wrote full result to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -26,9 +26,16 @@ import org.termx.snomed.rf2.SnomedExportJob;
 import org.termx.snomed.rf2.SnomedExportRequest;
 import org.termx.snomed.rf2.SnomedImportJob;
 import org.termx.snomed.rf2.SnomedImportRequest;
+import org.termx.snomed.rf2.SnomedRF2Upload;
+import org.termx.snomed.rf2.scan.SnomedRF2ScanEnvelope;
+import org.termx.snomed.concept.SnomedConceptUsage;
+import org.termx.snomed.concept.SnomedConceptUsageRequest;
 import org.termx.snomed.search.SnomedSearchResult;
 import org.termx.snomed.integration.csv.SnomedConceptCsvService;
 import org.termx.snomed.integration.rf2.SnomedRF2Service;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ScanService;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2UploadCacheService;
+import org.termx.snomed.integration.usage.SnomedConceptUsageService;
 import org.termx.snomed.integration.translation.SnomedTranslationActionService;
 import org.termx.snomed.integration.translation.SnomedTranslationProvenanceService;
 import org.termx.snomed.integration.translation.SnomedTranslationService;
@@ -76,6 +83,9 @@ public class SnomedController {
   private final SnomedTranslationService translationService;
   private final SnomedTranslationActionService translationActionService;
   private final SnomedTranslationProvenanceService provenanceService;
+  private final SnomedRF2ScanService snomedRF2ScanService;
+  private final SnomedRF2UploadCacheService snomedRF2UploadCacheService;
+  private final SnomedConceptUsageService snomedConceptUsageService;
 
 
   //----------------CodeSystems----------------
@@ -247,9 +257,52 @@ public class SnomedController {
   }
 
   @Authorized(Privilege.SNOMED_VIEW)
+  @Post(value = "/imports/scan", consumes = MediaType.MULTIPART_FORM_DATA)
+  public LorqueProcess scanImport(Publisher<CompletedFileUpload> file, @Part("request") String request) {
+    SnomedImportRequest req = JsonUtil.fromJson(request, SnomedImportRequest.class);
+    CompletedFileUpload upload = Flowable.fromPublisher(file).firstOrError().blockingGet();
+    byte[] importFile = FileUtil.readBytes(upload);
+    String filename = upload == null ? null : upload.getFilename();
+    return snomedRF2ScanService.scanRF2(req, importFile, filename);
+  }
+
+  @Authorized(Privilege.SNOMED_EDIT)
+  @Post("/imports/scan/{cacheId}/proceed")
+  public Map<String, String> proceedScanImport(@PathVariable Long cacheId) {
+    SnomedRF2Upload cached = snomedRF2UploadCacheService.load(cacheId);
+    if (cached == null) {
+      throw new IllegalArgumentException("Upload cache " + cacheId + " not found or expired");
+    }
+    SnomedImportRequest req = new SnomedImportRequest();
+    req.setBranchPath(cached.getBranchPath());
+    req.setType(cached.getRf2Type());
+    req.setCreateCodeSystemVersion(cached.isCreateCodeSystemVersion());
+    Map<String, String> result = snomedService.importRF2File(req, cached.getZipData());
+    snomedRF2UploadCacheService.markImported(cacheId);
+    return result;
+  }
+
+  @Authorized(Privilege.SNOMED_VIEW)
   @Get("/imports/{jobId}")
   public SnomedImportJob loadImportJob(@PathVariable String jobId) {
     return snowstormClient.loadImportJob(jobId).join();
+  }
+
+  @Authorized(Privilege.SNOMED_VIEW)
+  @Get("/imports/scan/result/{lorqueProcessId}")
+  public SnomedRF2ScanEnvelope loadScanResult(@PathVariable Long lorqueProcessId) {
+    LorqueProcess process = lorqueProcessService.load(lorqueProcessId);
+    if (process == null || process.getResult() == null) {
+      return null;
+    }
+    String json = new String(process.getResult(), java.nio.charset.StandardCharsets.UTF_8);
+    return JsonUtil.fromJson(json, SnomedRF2ScanEnvelope.class);
+  }
+
+  @Authorized(Privilege.SNOMED_VIEW)
+  @Post("/concept-usage")
+  public List<SnomedConceptUsage> findConceptUsage(@Body SnomedConceptUsageRequest request) {
+    return snomedConceptUsageService.findUsage(request == null ? null : request.getCodes());
   }
 
   //----------------Concepts----------------

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2DiffEngine.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2DiffEngine.java
@@ -1,0 +1,259 @@
+package org.termx.snomed.integration.rf2.scan;
+
+import jakarta.inject.Singleton;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ZipParser.ConceptRow;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ZipParser.DescriptionRow;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ZipParser.LanguageRefsetRow;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ZipParser.ParsedRF2;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ZipParser.RelationshipRow;
+import org.termx.snomed.rf2.scan.SnomedRF2Attribute;
+import org.termx.snomed.rf2.scan.SnomedRF2Designation;
+import org.termx.snomed.rf2.scan.SnomedRF2InvalidatedConcept;
+import org.termx.snomed.rf2.scan.SnomedRF2ModifiedConcept;
+import org.termx.snomed.rf2.scan.SnomedRF2NewConcept;
+import org.termx.snomed.rf2.scan.SnomedRF2ScanResult;
+
+@Singleton
+public class SnomedRF2DiffEngine {
+
+  private static final String FSN = "900000000000003001";
+  private static final String SYNONYM = "900000000000013009";
+  private static final String TEXT_DEFINITION = "900000000000550004";
+  private static final String PREFERRED = "900000000000548007";
+  private static final String ACCEPTABLE = "900000000000549004";
+
+  public SnomedRF2ScanResult classify(ParsedRF2 parsed, String branchPath, String rf2Type) {
+    String releaseEffectiveTime = computeReleaseEffectiveTime(parsed);
+
+    List<ConceptRow> concepts = changesetConcepts(parsed.getConcepts(), releaseEffectiveTime);
+    List<DescriptionRow> descriptions = changesetDescriptions(parsed.getDescriptions(), releaseEffectiveTime);
+    List<RelationshipRow> relationships = changesetRelationships(parsed.getRelationships(), releaseEffectiveTime);
+
+    Map<String, String> acceptabilityByDescription = buildAcceptabilityIndex(parsed.getLanguageRefset(), releaseEffectiveTime);
+
+    Map<String, ConceptRow> conceptByCode = concepts.stream()
+        .collect(Collectors.toMap(ConceptRow::getId, c -> c, (a, b) -> b, LinkedHashMap::new));
+
+    Map<String, List<DescriptionRow>> descriptionsByConcept = descriptions.stream()
+        .collect(Collectors.groupingBy(DescriptionRow::getConceptId, LinkedHashMap::new, Collectors.toList()));
+
+    Map<String, List<RelationshipRow>> relationshipsBySource = relationships.stream()
+        .collect(Collectors.groupingBy(RelationshipRow::getSourceId, LinkedHashMap::new, Collectors.toList()));
+
+    java.util.Set<String> touchedConceptIds = new java.util.LinkedHashSet<>();
+    touchedConceptIds.addAll(conceptByCode.keySet());
+    touchedConceptIds.addAll(descriptionsByConcept.keySet());
+    touchedConceptIds.addAll(relationshipsBySource.keySet());
+
+    List<SnomedRF2NewConcept> newConcepts = new ArrayList<>();
+    List<SnomedRF2ModifiedConcept> modifiedConcepts = new ArrayList<>();
+    List<SnomedRF2InvalidatedConcept> invalidatedConcepts = new ArrayList<>();
+
+    for (String conceptId : touchedConceptIds) {
+      ConceptRow conceptRow = conceptByCode.get(conceptId);
+      List<DescriptionRow> conceptDescriptions = descriptionsByConcept.getOrDefault(conceptId, List.of());
+      List<RelationshipRow> conceptRelationships = relationshipsBySource.getOrDefault(conceptId, List.of());
+
+      if (conceptRow != null && !conceptRow.isActive()) {
+        invalidatedConcepts.add(toInvalidated(conceptRow, conceptDescriptions, acceptabilityByDescription));
+      } else if (conceptRow != null) {
+        newConcepts.add(toNew(conceptRow, conceptDescriptions, conceptRelationships, acceptabilityByDescription));
+      } else {
+        modifiedConcepts.add(toModified(conceptId, conceptDescriptions, conceptRelationships, acceptabilityByDescription));
+      }
+    }
+
+    SnomedRF2ScanResult.Stats stats = new SnomedRF2ScanResult.Stats()
+        .setConceptsAdded(newConcepts.size())
+        .setConceptsModified(modifiedConcepts.size())
+        .setConceptsInvalidated(invalidatedConcepts.size())
+        .setDescriptionsAdded((int) descriptions.stream().filter(DescriptionRow::isActive).count())
+        .setDescriptionsInvalidated((int) descriptions.stream().filter(d -> !d.isActive()).count())
+        .setRelationshipsAdded((int) relationships.stream().filter(RelationshipRow::isActive).count())
+        .setRelationshipsInvalidated((int) relationships.stream().filter(r -> !r.isActive()).count());
+
+    return new SnomedRF2ScanResult()
+        .setBranchPath(branchPath)
+        .setRf2Type(rf2Type)
+        .setReleaseEffectiveTime(releaseEffectiveTime)
+        .setScannedAt(OffsetDateTime.now())
+        .setStats(stats)
+        .setNewConcepts(newConcepts)
+        .setModifiedConcepts(modifiedConcepts)
+        .setInvalidatedConcepts(invalidatedConcepts);
+  }
+
+  private String computeReleaseEffectiveTime(ParsedRF2 parsed) {
+    Comparator<String> cmp = Comparator.nullsFirst(Comparator.naturalOrder());
+    return parsed.getConcepts().stream()
+        .map(ConceptRow::getEffectiveTime)
+        .filter(s -> s != null && !s.isEmpty())
+        .max(cmp)
+        .orElseGet(() -> parsed.getDescriptions().stream()
+            .map(DescriptionRow::getEffectiveTime)
+            .filter(s -> s != null && !s.isEmpty())
+            .max(cmp)
+            .orElse(null));
+  }
+
+  private List<ConceptRow> changesetConcepts(List<ConceptRow> all, String release) {
+    Map<String, ConceptRow> latest = new HashMap<>();
+    for (ConceptRow row : all) {
+      if (release == null || release.equals(emptyAsNull(row.getEffectiveTime())) || emptyAsNull(row.getEffectiveTime()) == null) {
+        ConceptRow existing = latest.get(row.getId());
+        if (existing == null || compare(existing.getEffectiveTime(), row.getEffectiveTime()) <= 0) {
+          latest.put(row.getId(), row);
+        }
+      }
+    }
+    return new ArrayList<>(latest.values());
+  }
+
+  private List<DescriptionRow> changesetDescriptions(List<DescriptionRow> all, String release) {
+    Map<String, DescriptionRow> latest = new HashMap<>();
+    for (DescriptionRow row : all) {
+      if (release == null || release.equals(emptyAsNull(row.getEffectiveTime())) || emptyAsNull(row.getEffectiveTime()) == null) {
+        DescriptionRow existing = latest.get(row.getId());
+        if (existing == null || compare(existing.getEffectiveTime(), row.getEffectiveTime()) <= 0) {
+          latest.put(row.getId(), row);
+        }
+      }
+    }
+    return new ArrayList<>(latest.values());
+  }
+
+  private List<RelationshipRow> changesetRelationships(List<RelationshipRow> all, String release) {
+    Map<String, RelationshipRow> latest = new HashMap<>();
+    for (RelationshipRow row : all) {
+      if (release == null || release.equals(emptyAsNull(row.getEffectiveTime())) || emptyAsNull(row.getEffectiveTime()) == null) {
+        RelationshipRow existing = latest.get(row.getId());
+        if (existing == null || compare(existing.getEffectiveTime(), row.getEffectiveTime()) <= 0) {
+          latest.put(row.getId(), row);
+        }
+      }
+    }
+    return new ArrayList<>(latest.values());
+  }
+
+  private Map<String, String> buildAcceptabilityIndex(List<LanguageRefsetRow> rows, String release) {
+    Map<String, String> latestByDescription = new HashMap<>();
+    Map<String, String> latestEffectiveTime = new HashMap<>();
+    for (LanguageRefsetRow row : rows) {
+      if (!row.isActive()) {
+        continue;
+      }
+      String existingEt = latestEffectiveTime.get(row.getReferencedComponentId());
+      if (existingEt == null || compare(existingEt, row.getEffectiveTime()) <= 0) {
+        latestEffectiveTime.put(row.getReferencedComponentId(), row.getEffectiveTime());
+        latestByDescription.put(row.getReferencedComponentId(), mapAcceptability(row.getAcceptabilityId()));
+      }
+    }
+    return latestByDescription;
+  }
+
+  private SnomedRF2NewConcept toNew(ConceptRow row, List<DescriptionRow> descriptions, List<RelationshipRow> relationships, Map<String, String> acceptability) {
+    return new SnomedRF2NewConcept()
+        .setConceptId(row.getId())
+        .setEffectiveTime(row.getEffectiveTime())
+        .setModuleId(row.getModuleId())
+        .setDefinitionStatusId(row.getDefinitionStatusId())
+        .setDesignations(descriptions.stream().filter(DescriptionRow::isActive).map(d -> toDesignation(d, acceptability)).toList())
+        .setAttributes(relationships.stream().filter(RelationshipRow::isActive).map(this::toAttribute).toList());
+  }
+
+  private SnomedRF2ModifiedConcept toModified(String conceptId, List<DescriptionRow> descriptions, List<RelationshipRow> relationships, Map<String, String> acceptability) {
+    List<SnomedRF2Designation> added = descriptions.stream().filter(DescriptionRow::isActive).map(d -> toDesignation(d, acceptability)).toList();
+    List<SnomedRF2Designation> removed = descriptions.stream().filter(d -> !d.isActive()).map(d -> toDesignation(d, acceptability)).toList();
+    List<SnomedRF2Attribute> addedAttr = relationships.stream().filter(RelationshipRow::isActive).map(this::toAttribute).toList();
+    List<SnomedRF2Attribute> removedAttr = relationships.stream().filter(r -> !r.isActive()).map(this::toAttribute).toList();
+    return new SnomedRF2ModifiedConcept()
+        .setConceptId(conceptId)
+        .setAddedDesignations(added)
+        .setRemovedDesignations(removed)
+        .setAddedAttributes(addedAttr)
+        .setRemovedAttributes(removedAttr);
+  }
+
+  private SnomedRF2InvalidatedConcept toInvalidated(ConceptRow row, List<DescriptionRow> descriptions, Map<String, String> acceptability) {
+    return new SnomedRF2InvalidatedConcept()
+        .setConceptId(row.getId())
+        .setEffectiveTime(row.getEffectiveTime())
+        .setModuleId(row.getModuleId())
+        .setDesignations(descriptions.stream().map(d -> toDesignation(d, acceptability)).toList());
+  }
+
+  private SnomedRF2Designation toDesignation(DescriptionRow row, Map<String, String> acceptability) {
+    return new SnomedRF2Designation()
+        .setDescriptionId(row.getId())
+        .setTerm(row.getTerm())
+        .setType(mapDescriptionType(row))
+        .setLanguage(row.getLanguageCode())
+        .setAcceptability(Optional.ofNullable(acceptability.get(row.getId())).orElse("none"))
+        .setActive(row.isActive())
+        .setEffectiveTime(row.getEffectiveTime());
+  }
+
+  private SnomedRF2Attribute toAttribute(RelationshipRow row) {
+    return new SnomedRF2Attribute()
+        .setRelationshipId(row.getId())
+        .setTypeId(row.getTypeId())
+        .setDestinationId(row.getDestinationId())
+        .setRelationshipGroup(row.getRelationshipGroup())
+        .setCharacteristicTypeId(row.getCharacteristicTypeId())
+        .setModifierId(row.getModifierId())
+        .setActive(row.isActive())
+        .setEffectiveTime(row.getEffectiveTime());
+  }
+
+  private String mapDescriptionType(DescriptionRow row) {
+    if (row.isTextDefinition() || TEXT_DEFINITION.equals(row.getTypeId())) {
+      return "textDefinition";
+    }
+    if (FSN.equals(row.getTypeId())) {
+      return "fully-specified-name";
+    }
+    if (SYNONYM.equals(row.getTypeId())) {
+      return "synonym";
+    }
+    return Optional.ofNullable(row.getTypeId()).orElse("unknown");
+  }
+
+  private String mapAcceptability(String acceptabilityId) {
+    if (PREFERRED.equals(acceptabilityId)) {
+      return "preferred";
+    }
+    if (ACCEPTABLE.equals(acceptabilityId)) {
+      return "acceptable";
+    }
+    return Optional.ofNullable(acceptabilityId).orElse("none");
+  }
+
+  private static String emptyAsNull(String s) {
+    return (s == null || s.isEmpty()) ? null : s;
+  }
+
+  private static int compare(String a, String b) {
+    String x = emptyAsNull(a);
+    String y = emptyAsNull(b);
+    if (Objects.equals(x, y)) {
+      return 0;
+    }
+    if (x == null) {
+      return -1;
+    }
+    if (y == null) {
+      return 1;
+    }
+    return x.compareTo(y);
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
@@ -1,0 +1,178 @@
+package org.termx.snomed.integration.rf2.scan;
+
+import com.kodality.commons.util.JsonUtil;
+import jakarta.inject.Singleton;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.termx.core.auth.SessionStore;
+import org.termx.core.sys.lorque.LorqueProcessService;
+import org.termx.core.utils.VirtualThreadExecutor;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ZipParser.ParsedRF2;
+import org.termx.snomed.rf2.SnomedImportRequest;
+import org.termx.snomed.rf2.SnomedRF2Upload;
+import org.termx.snomed.rf2.scan.SnomedRF2Attribute;
+import org.termx.snomed.rf2.scan.SnomedRF2Designation;
+import org.termx.snomed.rf2.scan.SnomedRF2InvalidatedConcept;
+import org.termx.snomed.rf2.scan.SnomedRF2ModifiedConcept;
+import org.termx.snomed.rf2.scan.SnomedRF2NewConcept;
+import org.termx.snomed.rf2.scan.SnomedRF2ScanEnvelope;
+import org.termx.snomed.rf2.scan.SnomedRF2ScanResult;
+import org.termx.sys.lorque.LorqueProcess;
+import org.termx.sys.lorque.ProcessResult;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class SnomedRF2ScanService {
+  private static final String PROCESS_NAME = "snomed-rf2-scan";
+
+  private final SnomedRF2ZipParser parser;
+  private final SnomedRF2DiffEngine diffEngine;
+  private final SnomedRF2UploadCacheService uploadCacheService;
+  private final LorqueProcessService lorqueProcessService;
+
+  public LorqueProcess scanRF2(SnomedImportRequest request, byte[] zipBytes, String filename) {
+    SnomedRF2Upload upload = uploadCacheService.save(request, filename, zipBytes);
+    LorqueProcess process = lorqueProcessService.start(new LorqueProcess().setProcessName(PROCESS_NAME));
+    uploadCacheService.attachLorqueId(upload.getId(), process.getId());
+
+    Long uploadId = upload.getId();
+    String branchPath = request.getBranchPath();
+    String rf2Type = request.getType();
+
+    CompletableFuture.runAsync(SessionStore.wrap(() -> {
+      try {
+        SnomedRF2ScanResult result = buildScan(zipBytes, branchPath, rf2Type).setUploadCacheId(uploadId);
+        SnomedRF2ScanEnvelope envelope = new SnomedRF2ScanEnvelope().setJson(result).setMarkdown(renderMarkdown(result));
+        byte[] payload = JsonUtil.toJson(envelope).getBytes(StandardCharsets.UTF_8);
+        lorqueProcessService.complete(process.getId(), ProcessResult.binary(payload));
+      } catch (Exception e) {
+        log.error("SNOMED RF2 dry-run scan failed for upload {}", uploadId, e);
+        ProcessResult failure = ProcessResult.text(ExceptionUtils.getMessage(e) + "\n" + ExceptionUtils.getStackTrace(e));
+        lorqueProcessService.fail(process.getId(), failure);
+      }
+    }), VirtualThreadExecutor.get());
+
+    return process;
+  }
+
+  public SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type) throws java.io.IOException {
+    ParsedRF2 parsed = parser.parse(zipBytes);
+    return diffEngine.classify(parsed, branchPath, rf2Type);
+  }
+
+  public String renderMarkdown(SnomedRF2ScanResult result) {
+    StringBuilder md = new StringBuilder();
+    md.append("# SNOMED RF2 dry-run scan\n\n");
+    md.append("- **Branch path**: ").append(nullSafe(result.getBranchPath())).append("\n");
+    md.append("- **RF2 type**: ").append(nullSafe(result.getRf2Type())).append("\n");
+    md.append("- **Release effectiveTime**: ").append(nullSafe(result.getReleaseEffectiveTime())).append("\n");
+    md.append("- **Scanned at**: ").append(nullSafe(result.getScannedAt() == null ? null : result.getScannedAt().toString())).append("\n\n");
+
+    md.append("## Stats\n\n");
+    md.append("| Metric | Count |\n");
+    md.append("|---|---:|\n");
+    SnomedRF2ScanResult.Stats s = Optional.ofNullable(result.getStats()).orElse(new SnomedRF2ScanResult.Stats());
+    md.append("| Concepts added | ").append(s.getConceptsAdded()).append(" |\n");
+    md.append("| Concepts modified | ").append(s.getConceptsModified()).append(" |\n");
+    md.append("| Concepts invalidated | ").append(s.getConceptsInvalidated()).append(" |\n");
+    md.append("| Descriptions added | ").append(s.getDescriptionsAdded()).append(" |\n");
+    md.append("| Descriptions invalidated | ").append(s.getDescriptionsInvalidated()).append(" |\n");
+    md.append("| Relationships added | ").append(s.getRelationshipsAdded()).append(" |\n");
+    md.append("| Relationships invalidated | ").append(s.getRelationshipsInvalidated()).append(" |\n\n");
+
+    appendNew(md, result.getNewConcepts());
+    appendModified(md, result.getModifiedConcepts());
+    appendInvalidated(md, result.getInvalidatedConcepts());
+
+    return md.toString();
+  }
+
+  private void appendNew(StringBuilder md, List<SnomedRF2NewConcept> list) {
+    md.append("## New concepts (").append(list == null ? 0 : list.size()).append(")\n\n");
+    if (list == null || list.isEmpty()) {
+      md.append("_None._\n\n");
+      return;
+    }
+    md.append("| Concept | Effective time | Module | Definition status | Designations | Attributes |\n");
+    md.append("|---|---|---|---|---|---|\n");
+    for (SnomedRF2NewConcept c : list) {
+      md.append("| ").append(nullSafe(c.getConceptId())).append(" | ")
+          .append(nullSafe(c.getEffectiveTime())).append(" | ")
+          .append(nullSafe(c.getModuleId())).append(" | ")
+          .append(nullSafe(c.getDefinitionStatusId())).append(" | ")
+          .append(formatDesignations(c.getDesignations())).append(" | ")
+          .append(formatAttributes(c.getAttributes())).append(" |\n");
+    }
+    md.append("\n");
+  }
+
+  private void appendModified(StringBuilder md, List<SnomedRF2ModifiedConcept> list) {
+    md.append("## Modified concepts (").append(list == null ? 0 : list.size()).append(")\n\n");
+    if (list == null || list.isEmpty()) {
+      md.append("_None._\n\n");
+      return;
+    }
+    md.append("| Concept | + designations | - designations | + attributes | - attributes |\n");
+    md.append("|---|---|---|---|---|\n");
+    for (SnomedRF2ModifiedConcept c : list) {
+      md.append("| ").append(nullSafe(c.getConceptId())).append(" | ")
+          .append(formatDesignations(c.getAddedDesignations())).append(" | ")
+          .append(formatDesignations(c.getRemovedDesignations())).append(" | ")
+          .append(formatAttributes(c.getAddedAttributes())).append(" | ")
+          .append(formatAttributes(c.getRemovedAttributes())).append(" |\n");
+    }
+    md.append("\n");
+  }
+
+  private void appendInvalidated(StringBuilder md, List<SnomedRF2InvalidatedConcept> list) {
+    md.append("## Invalidated concepts (").append(list == null ? 0 : list.size()).append(")\n\n");
+    if (list == null || list.isEmpty()) {
+      md.append("_None._\n\n");
+      return;
+    }
+    md.append("| Concept | Effective time | Module | Designations |\n");
+    md.append("|---|---|---|---|\n");
+    for (SnomedRF2InvalidatedConcept c : list) {
+      md.append("| ").append(nullSafe(c.getConceptId())).append(" | ")
+          .append(nullSafe(c.getEffectiveTime())).append(" | ")
+          .append(nullSafe(c.getModuleId())).append(" | ")
+          .append(formatDesignations(c.getDesignations())).append(" |\n");
+    }
+    md.append("\n");
+  }
+
+  private String formatDesignations(List<SnomedRF2Designation> ds) {
+    if (ds == null || ds.isEmpty()) {
+      return "—";
+    }
+    return ds.stream().map(d -> {
+      String term = nullSafe(d.getTerm()).replace("|", "\\|");
+      String type = Optional.ofNullable(d.getType()).orElse("");
+      String lang = Optional.ofNullable(d.getLanguage()).orElse("");
+      String acc = Optional.ofNullable(d.getAcceptability()).orElse("");
+      return term + " (" + type + ", " + lang + ", " + acc + ")";
+    }).reduce((a, b) -> a + "<br>" + b).orElse("");
+  }
+
+  private String formatAttributes(List<SnomedRF2Attribute> as) {
+    if (as == null || as.isEmpty()) {
+      return "—";
+    }
+    return as.stream().map(a -> {
+      String type = nullSafe(a.getTypeId());
+      String dest = nullSafe(a.getDestinationId());
+      Integer group = a.getRelationshipGroup();
+      return type + " → " + dest + (group == null ? "" : " [g" + group + "]");
+    }).reduce((a, b) -> a + "<br>" + b).orElse("");
+  }
+
+  private static String nullSafe(String s) {
+    return s == null ? "" : s;
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
@@ -1,0 +1,46 @@
+package org.termx.snomed.integration.rf2.scan;
+
+import com.kodality.commons.db.bean.PgBeanProcessor;
+import com.kodality.commons.db.repo.BaseRepository;
+import com.kodality.commons.db.sql.SaveSqlBuilder;
+import com.kodality.commons.db.sql.SqlBuilder;
+import jakarta.inject.Singleton;
+import org.termx.snomed.rf2.SnomedRF2Upload;
+
+@Singleton
+public class SnomedRF2UploadCacheRepository extends BaseRepository {
+  private final PgBeanProcessor bp = new PgBeanProcessor(SnomedRF2Upload.class);
+
+  public Long save(SnomedRF2Upload upload) {
+    SaveSqlBuilder ssb = new SaveSqlBuilder();
+    ssb.property("id", upload.getId());
+    ssb.property("branch_path", upload.getBranchPath());
+    ssb.property("rf2_type", upload.getRf2Type());
+    ssb.property("create_code_system_version", upload.isCreateCodeSystemVersion());
+    ssb.property("filename", upload.getFilename());
+    ssb.property("zip_size", upload.getZipSize());
+    ssb.property("zip_data", upload.getZipData());
+    ssb.property("scan_lorque_id", upload.getScanLorqueId());
+    ssb.property("imported", upload.isImported());
+    ssb.property("started", upload.getStarted());
+    ssb.property("imported_at", upload.getImportedAt());
+
+    SqlBuilder sb = ssb.buildSave("sys.snomed_rf2_upload", "id");
+    return jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());
+  }
+
+  public SnomedRF2Upload load(Long id) {
+    String sql = "select * from sys.snomed_rf2_upload where id = ? and sys_status = 'A'";
+    return getBean(sql, bp, id);
+  }
+
+  public void markImported(Long id) {
+    String sql = "update sys.snomed_rf2_upload set imported = true, imported_at = current_timestamp where id = ?";
+    jdbcTemplate.update(sql, id);
+  }
+
+  public void cleanup(int daysOld) {
+    String sql = "delete from sys.snomed_rf2_upload where started < current_timestamp - (? || ' days')::interval";
+    jdbcTemplate.update(sql, String.valueOf(daysOld));
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
@@ -1,0 +1,66 @@
+package org.termx.snomed.integration.rf2.scan;
+
+import io.micronaut.scheduling.annotation.Scheduled;
+import jakarta.inject.Singleton;
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+import org.termx.snomed.rf2.SnomedImportRequest;
+import org.termx.snomed.rf2.SnomedRF2Upload;
+
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class SnomedRF2UploadCacheService {
+  private static final int RETENTION_DAYS = 7;
+
+  private final SnomedRF2UploadCacheRepository repository;
+
+  @Transactional
+  public SnomedRF2Upload save(SnomedImportRequest request, String filename, byte[] zipData) {
+    SnomedRF2Upload upload = new SnomedRF2Upload()
+        .setBranchPath(request.getBranchPath())
+        .setRf2Type(request.getType())
+        .setCreateCodeSystemVersion(request.isCreateCodeSystemVersion())
+        .setFilename(filename)
+        .setZipSize(zipData == null ? 0L : (long) zipData.length)
+        .setZipData(zipData)
+        .setImported(false)
+        .setStarted(OffsetDateTime.now());
+    upload.setId(repository.save(upload));
+    return upload;
+  }
+
+  @Transactional
+  public void attachLorqueId(Long uploadId, Long lorqueId) {
+    SnomedRF2Upload upload = repository.load(uploadId);
+    if (upload == null) {
+      return;
+    }
+    upload.setScanLorqueId(lorqueId);
+    repository.save(upload);
+  }
+
+  public SnomedRF2Upload load(Long id) {
+    return repository.load(id);
+  }
+
+  @Transactional
+  public void markImported(Long id) {
+    repository.markImported(id);
+  }
+
+  public void cleanup(int daysOld) {
+    repository.cleanup(daysOld);
+  }
+
+  @Scheduled(fixedDelay = "6h", initialDelay = "10m")
+  public void scheduledCleanup() {
+    try {
+      repository.cleanup(RETENTION_DAYS);
+    } catch (Exception e) {
+      log.error("Failed to cleanup snomed_rf2_upload cache", e);
+    }
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
@@ -1,0 +1,218 @@
+package org.termx.snomed.integration.rf2.scan;
+
+import jakarta.inject.Singleton;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Singleton
+public class SnomedRF2ZipParser {
+
+  public ParsedRF2 parse(byte[] zipBytes) throws IOException {
+    ParsedRF2 parsed = new ParsedRF2();
+    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+      ZipEntry entry;
+      while ((entry = zis.getNextEntry()) != null) {
+        if (entry.isDirectory()) {
+          continue;
+        }
+        String name = stripPath(entry.getName());
+        try {
+          if (name.startsWith("sct2_Concept_")) {
+            parsed.getConcepts().addAll(readConcepts(zis));
+          } else if (name.startsWith("sct2_Description_")) {
+            parsed.getDescriptions().addAll(readDescriptions(zis, false));
+          } else if (name.startsWith("sct2_TextDefinition_")) {
+            parsed.getDescriptions().addAll(readDescriptions(zis, true));
+          } else if (name.startsWith("sct2_Relationship_") || name.startsWith("sct2_StatedRelationship_")) {
+            parsed.getRelationships().addAll(readRelationships(zis));
+          } else if (name.startsWith("der2_cRefset_Language")) {
+            parsed.getLanguageRefset().addAll(readLanguageRefset(zis));
+          }
+        } catch (Exception e) {
+          log.warn("Failed to parse RF2 entry {}: {}", name, e.getMessage());
+        }
+      }
+    }
+    return parsed;
+  }
+
+  private static String stripPath(String entryName) {
+    int slash = entryName.lastIndexOf('/');
+    return slash < 0 ? entryName : entryName.substring(slash + 1);
+  }
+
+  private List<ConceptRow> readConcepts(ZipInputStream zis) throws IOException {
+    List<ConceptRow> rows = new ArrayList<>();
+    forEachLine(zis, parts -> {
+      if (parts.length < 5) {
+        return;
+      }
+      rows.add(new ConceptRow()
+          .setId(parts[0])
+          .setEffectiveTime(parts[1])
+          .setActive("1".equals(parts[2]))
+          .setModuleId(parts[3])
+          .setDefinitionStatusId(parts[4]));
+    });
+    return rows;
+  }
+
+  private List<DescriptionRow> readDescriptions(ZipInputStream zis, boolean textDefinition) throws IOException {
+    List<DescriptionRow> rows = new ArrayList<>();
+    forEachLine(zis, parts -> {
+      if (parts.length < 9) {
+        return;
+      }
+      rows.add(new DescriptionRow()
+          .setId(parts[0])
+          .setEffectiveTime(parts[1])
+          .setActive("1".equals(parts[2]))
+          .setModuleId(parts[3])
+          .setConceptId(parts[4])
+          .setLanguageCode(parts[5])
+          .setTypeId(parts[6])
+          .setTerm(parts[7])
+          .setCaseSignificanceId(parts[8])
+          .setTextDefinition(textDefinition));
+    });
+    return rows;
+  }
+
+  private List<RelationshipRow> readRelationships(ZipInputStream zis) throws IOException {
+    List<RelationshipRow> rows = new ArrayList<>();
+    forEachLine(zis, parts -> {
+      if (parts.length < 10) {
+        return;
+      }
+      Integer group = null;
+      try {
+        group = Integer.parseInt(parts[6]);
+      } catch (NumberFormatException ignored) {
+      }
+      rows.add(new RelationshipRow()
+          .setId(parts[0])
+          .setEffectiveTime(parts[1])
+          .setActive("1".equals(parts[2]))
+          .setModuleId(parts[3])
+          .setSourceId(parts[4])
+          .setDestinationId(parts[5])
+          .setRelationshipGroup(group)
+          .setTypeId(parts[7])
+          .setCharacteristicTypeId(parts[8])
+          .setModifierId(parts[9]));
+    });
+    return rows;
+  }
+
+  private List<LanguageRefsetRow> readLanguageRefset(ZipInputStream zis) throws IOException {
+    List<LanguageRefsetRow> rows = new ArrayList<>();
+    forEachLine(zis, parts -> {
+      if (parts.length < 7) {
+        return;
+      }
+      rows.add(new LanguageRefsetRow()
+          .setId(parts[0])
+          .setEffectiveTime(parts[1])
+          .setActive("1".equals(parts[2]))
+          .setModuleId(parts[3])
+          .setRefsetId(parts[4])
+          .setReferencedComponentId(parts[5])
+          .setAcceptabilityId(parts[6]));
+    });
+    return rows;
+  }
+
+  private void forEachLine(ZipInputStream zis, java.util.function.Consumer<String[]> handler) throws IOException {
+    BufferedReader reader = new BufferedReader(new InputStreamReader(zis, StandardCharsets.UTF_8));
+    boolean header = true;
+    String line;
+    while ((line = reader.readLine()) != null) {
+      if (header) {
+        header = false;
+        continue;
+      }
+      if (line.isEmpty()) {
+        continue;
+      }
+      handler.accept(line.split("\t", -1));
+    }
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class ParsedRF2 {
+    private List<ConceptRow> concepts = new ArrayList<>();
+    private List<DescriptionRow> descriptions = new ArrayList<>();
+    private List<RelationshipRow> relationships = new ArrayList<>();
+    private List<LanguageRefsetRow> languageRefset = new ArrayList<>();
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class ConceptRow {
+    private String id;
+    private String effectiveTime;
+    private boolean active;
+    private String moduleId;
+    private String definitionStatusId;
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class DescriptionRow {
+    private String id;
+    private String effectiveTime;
+    private boolean active;
+    private String moduleId;
+    private String conceptId;
+    private String languageCode;
+    private String typeId;
+    private String term;
+    private String caseSignificanceId;
+    private boolean textDefinition;
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class RelationshipRow {
+    private String id;
+    private String effectiveTime;
+    private boolean active;
+    private String moduleId;
+    private String sourceId;
+    private String destinationId;
+    private Integer relationshipGroup;
+    private String typeId;
+    private String characteristicTypeId;
+    private String modifierId;
+  }
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  public static class LanguageRefsetRow {
+    private String id;
+    private String effectiveTime;
+    private boolean active;
+    private String moduleId;
+    private String refsetId;
+    private String referencedComponentId;
+    private String acceptabilityId;
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/usage/SnomedConceptUsageRepository.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/usage/SnomedConceptUsageRepository.java
@@ -1,0 +1,96 @@
+package org.termx.snomed.integration.usage;
+
+import com.kodality.commons.db.repo.BaseRepository;
+import com.kodality.commons.db.sql.SqlBuilder;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.termx.snomed.concept.SnomedConceptUsage;
+
+@Singleton
+public class SnomedConceptUsageRepository extends BaseRepository {
+
+  private static final String SNOMED_CS = "snomed-ct";
+  private static final String SNOMED_URI = "http://snomed.info/sct";
+
+  private final RowMapper<SnomedConceptUsage> mapper = (rs, rowNum) -> new SnomedConceptUsage()
+      .setResourceType(rs.getString("resource_type"))
+      .setResourceId(rs.getString("resource_id"))
+      .setResourceVersion(rs.getString("resource_version"))
+      .setConceptCode(rs.getString("concept_code"))
+      .setLocation(rs.getString("location"));
+
+  public List<SnomedConceptUsage> findInSupplements(List<String> codes) {
+    if (codes == null || codes.isEmpty()) {
+      return Collections.emptyList();
+    }
+    SqlBuilder sb = new SqlBuilder();
+    sb.append("select 'CodeSystemSupplement' as resource_type,");
+    sb.append("       cs.id                  as resource_id,");
+    sb.append("       null::text             as resource_version,");
+    sb.append("       cev.code               as concept_code,");
+    sb.append("       'concept'              as location");
+    sb.append("  from terminology.code_system_entity_version cev");
+    sb.append("  join terminology.code_system cs on cs.id = cev.code_system");
+    sb.append(" where cs.base_code_system = ?", SNOMED_CS);
+    sb.append("   and cev.sys_status = 'A'");
+    sb.append("   and cs.sys_status = 'A'");
+    sb.and().in("cev.code", codes);
+    return jdbcTemplate.query(sb.getSql(), mapper, sb.getParams());
+  }
+
+  public List<SnomedConceptUsage> findInValueSetRules(List<String> codes) {
+    if (codes == null || codes.isEmpty()) {
+      return Collections.emptyList();
+    }
+    SqlBuilder sb = new SqlBuilder();
+    sb.append("select 'ValueSet'                                         as resource_type,");
+    sb.append("       vsv.value_set                                      as resource_id,");
+    sb.append("       vsv.version                                        as resource_version,");
+    sb.append("       coalesce(c->'concept'->>'code', c->>'code')        as concept_code,");
+    sb.append("       'rule'                                             as location");
+    sb.append("  from terminology.value_set_version_rule vsr");
+    sb.append("  join terminology.value_set_version_rule_set vsrs on vsrs.id = vsr.rule_set_id");
+    sb.append("  join terminology.value_set_version vsv on vsv.id = vsrs.value_set_version_id");
+    sb.append("  cross join lateral jsonb_array_elements(coalesce(vsr.concepts, '[]'::jsonb)) c");
+    sb.append(" where vsr.sys_status = 'A'");
+    sb.append("   and vsrs.sys_status = 'A'");
+    sb.append("   and vsv.sys_status = 'A'");
+    sb.append("   and (vsr.code_system = ?", SNOMED_CS);
+    sb.append("        or coalesce(c->'concept'->>'codeSystem', c->>'codeSystem') = ?", SNOMED_CS);
+    sb.append("        or coalesce(c->'concept'->>'codeSystemUri', c->>'codeSystemUri') = ?)", SNOMED_URI);
+    sb.and().in("coalesce(c->'concept'->>'code', c->>'code')", codes);
+    return jdbcTemplate.query(sb.getSql(), mapper, sb.getParams());
+  }
+
+  public List<SnomedConceptUsage> findInValueSetExpansions(List<String> codes) {
+    if (codes == null || codes.isEmpty()) {
+      return Collections.emptyList();
+    }
+    SqlBuilder sb = new SqlBuilder();
+    sb.append("select 'ValueSetExpansion'                                as resource_type,");
+    sb.append("       vss.value_set                                      as resource_id,");
+    sb.append("       vsv.version                                        as resource_version,");
+    sb.append("       coalesce(c->'concept'->>'code', c->>'code')        as concept_code,");
+    sb.append("       'expansion'                                        as location");
+    sb.append("  from terminology.value_set_snapshot vss");
+    sb.append("  join terminology.value_set_version vsv on vsv.id = vss.value_set_version_id");
+    sb.append("  cross join lateral jsonb_array_elements(coalesce(vss.expansion, '[]'::jsonb)) c");
+    sb.append(" where vss.sys_status = 'A'");
+    sb.append("   and vsv.sys_status = 'A'");
+    sb.append("   and (coalesce(c->'concept'->>'codeSystem', c->>'codeSystem') = ?", SNOMED_CS);
+    sb.append("        or coalesce(c->'concept'->>'codeSystemUri', c->>'codeSystemUri') = ?)", SNOMED_URI);
+    sb.and().in("coalesce(c->'concept'->>'code', c->>'code')", codes);
+    return jdbcTemplate.query(sb.getSql(), mapper, sb.getParams());
+  }
+
+  public List<SnomedConceptUsage> findAll(List<String> codes) {
+    List<SnomedConceptUsage> all = new ArrayList<>();
+    all.addAll(findInSupplements(codes));
+    all.addAll(findInValueSetRules(codes));
+    all.addAll(findInValueSetExpansions(codes));
+    return all;
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/usage/SnomedConceptUsageService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/usage/SnomedConceptUsageService.java
@@ -1,0 +1,33 @@
+package org.termx.snomed.integration.usage;
+
+import jakarta.inject.Singleton;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.termx.snomed.concept.SnomedConceptUsage;
+
+@Singleton
+@RequiredArgsConstructor
+public class SnomedConceptUsageService {
+  private final SnomedConceptUsageRepository repository;
+
+  public List<SnomedConceptUsage> findUsage(List<String> codes) {
+    List<String> normalized = normalize(codes);
+    if (normalized.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return repository.findAll(normalized);
+  }
+
+  private List<String> normalize(List<String> codes) {
+    if (codes == null) {
+      return List.of();
+    }
+    return new LinkedHashSet<>(codes.stream()
+        .filter(c -> Optional.ofNullable(c).map(String::trim).filter(s -> !s.isEmpty()).isPresent())
+        .map(String::trim)
+        .toList()).stream().toList();
+  }
+}

--- a/termx-api/src/main/java/org/termx/snomed/concept/SnomedConceptUsage.java
+++ b/termx-api/src/main/java/org/termx/snomed/concept/SnomedConceptUsage.java
@@ -1,0 +1,18 @@
+package org.termx.snomed.concept;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedConceptUsage {
+  private String resourceType;
+  private String resourceId;
+  private String resourceVersion;
+  private String conceptCode;
+  private String location;
+}

--- a/termx-api/src/main/java/org/termx/snomed/concept/SnomedConceptUsageRequest.java
+++ b/termx-api/src/main/java/org/termx/snomed/concept/SnomedConceptUsageRequest.java
@@ -1,0 +1,13 @@
+package org.termx.snomed.concept;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Introspected
+public class SnomedConceptUsageRequest {
+  private List<String> codes;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportRequest.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportRequest.java
@@ -9,4 +9,5 @@ public class SnomedImportRequest {
   private String branchPath;
   private boolean createCodeSystemVersion;
   private String type;
+  private boolean dryRun;
 }

--- a/termx-api/src/main/java/org/termx/snomed/rf2/SnomedRF2Upload.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/SnomedRF2Upload.java
@@ -1,0 +1,25 @@
+package org.termx.snomed.rf2;
+
+import io.micronaut.core.annotation.Introspected;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2Upload {
+  private Long id;
+  private String branchPath;
+  private String rf2Type;
+  private boolean createCodeSystemVersion;
+  private String filename;
+  private Long zipSize;
+  private byte[] zipData;
+  private Long scanLorqueId;
+  private boolean imported;
+  private OffsetDateTime started;
+  private OffsetDateTime importedAt;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2Attribute.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2Attribute.java
@@ -1,0 +1,21 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2Attribute {
+  private String relationshipId;
+  private String typeId;
+  private String destinationId;
+  private Integer relationshipGroup;
+  private String characteristicTypeId;
+  private String modifierId;
+  private boolean active;
+  private String effectiveTime;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2Designation.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2Designation.java
@@ -1,0 +1,20 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2Designation {
+  private String descriptionId;
+  private String term;
+  private String type;
+  private String language;
+  private String acceptability;
+  private boolean active;
+  private String effectiveTime;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2InvalidatedConcept.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2InvalidatedConcept.java
@@ -1,0 +1,18 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2InvalidatedConcept {
+  private String conceptId;
+  private String effectiveTime;
+  private String moduleId;
+  private List<SnomedRF2Designation> designations;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2ModifiedConcept.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2ModifiedConcept.java
@@ -1,0 +1,19 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2ModifiedConcept {
+  private String conceptId;
+  private List<SnomedRF2Designation> addedDesignations;
+  private List<SnomedRF2Designation> removedDesignations;
+  private List<SnomedRF2Attribute> addedAttributes;
+  private List<SnomedRF2Attribute> removedAttributes;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2NewConcept.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2NewConcept.java
@@ -1,0 +1,20 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2NewConcept {
+  private String conceptId;
+  private String effectiveTime;
+  private String moduleId;
+  private String definitionStatusId;
+  private List<SnomedRF2Designation> designations;
+  private List<SnomedRF2Attribute> attributes;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2ScanEnvelope.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2ScanEnvelope.java
@@ -1,0 +1,15 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2ScanEnvelope {
+  private SnomedRF2ScanResult json;
+  private String markdown;
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2ScanResult.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/scan/SnomedRF2ScanResult.java
@@ -1,0 +1,38 @@
+package org.termx.snomed.rf2.scan;
+
+import io.micronaut.core.annotation.Introspected;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class SnomedRF2ScanResult {
+  private String branchPath;
+  private String rf2Type;
+  private String releaseEffectiveTime;
+  private OffsetDateTime scannedAt;
+  private Long uploadCacheId;
+  private Stats stats;
+  private List<SnomedRF2NewConcept> newConcepts;
+  private List<SnomedRF2ModifiedConcept> modifiedConcepts;
+  private List<SnomedRF2InvalidatedConcept> invalidatedConcepts;
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  @Introspected
+  public static class Stats {
+    private int conceptsAdded;
+    private int conceptsModified;
+    private int conceptsInvalidated;
+    private int descriptionsAdded;
+    private int descriptionsInvalidated;
+    private int relationshipsAdded;
+    private int relationshipsInvalidated;
+  }
+}

--- a/termx-core/src/main/resources/sys/changelog/sys/71-snomed_rf2_upload.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/71-snomed_rf2_upload.sql
@@ -1,0 +1,29 @@
+--liquibase formatted sql
+
+--changeset termx:snomed_rf2_upload
+create table if not exists sys.snomed_rf2_upload (
+    id                          bigserial           not null,
+    branch_path                 text                not null,
+    rf2_type                    text                not null,
+    create_code_system_version  boolean default false,
+    filename                    text,
+    zip_size                    bigint,
+    zip_data                    bytea               not null,
+    scan_lorque_id              bigint,
+    imported                    boolean             not null default false,
+    started                     timestamptz         not null default current_timestamp,
+    imported_at                 timestamptz,
+    sys_created_at              timestamp           not null,
+    sys_created_by              text                not null,
+    sys_modified_at             timestamp           not null,
+    sys_modified_by             text                not null,
+    sys_status                  char(1) default 'A' not null collate "C",
+    sys_version                 int                 not null,
+    constraint snomed_rf2_upload_pk primary key (id)
+);
+create index snomed_rf2_upload_lorque_idx on sys.snomed_rf2_upload(scan_lorque_id);
+create index snomed_rf2_upload_started_idx on sys.snomed_rf2_upload(started);
+
+select core.create_table_metadata('sys.snomed_rf2_upload');
+--rollback drop table if exists sys.snomed_rf2_upload;
+--

--- a/termx-core/src/main/resources/sys/changelog/sys/changelog.xml
+++ b/termx-core/src/main/resources/sys/changelog/sys/changelog.xml
@@ -15,6 +15,7 @@
   <include file="60-release.sql" relativeToChangelogFile="true"/>
   <include file="61-checklist.sql" relativeToChangelogFile="true"/>
   <include file="70-snomed_import_tracking.sql" relativeToChangelogFile="true"/>
+  <include file="71-snomed_rf2_upload.sql" relativeToChangelogFile="true"/>
   <include file="80-ecosystem.sql" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

Adds two new SNOMED utilities to support pre-import triage of RF2 releases:

- **Utility 1 — RF2 dry-run scan**: parses an uploaded RF2 zip, classifies rows by `effectiveTime` cutoff into NEW / MODIFIED / INVALIDATED concepts (with designations and attributes), and produces a stats summary plus a JSON + Markdown report. The uploaded zip is cached so the user can either proceed with import (push the same file to Snowstorm without re-upload) or discard.
- **Utility 2 — SNOMED concept-usage lookup**: given a list of SNOMED concept codes, returns the TermX resources that still reference them: CodeSystem supplements (`base_code_system='snomed-ct'`), ValueSet rules (`value_set_version_rule.concepts` JSONB), and ValueSet expansion snapshots (`value_set_snapshot.expansion` JSONB).

Companion frontend changes live in termx-web (`Dry run` checkbox in the SNOMED import modal, a new scan-result page, and a standalone concept-usage page) — separate PR.

## Endpoints

| Method | Path | Privilege | Notes |
|---|---|---|---|
| POST | `/snomed/imports/scan` | `SNOMED_VIEW` | multipart upload → returns LorqueProcess |
| GET  | `/snomed/imports/scan/result/{lorqueProcessId}` | `SNOMED_VIEW` | returns parsed `SnomedRF2ScanEnvelope` (json + markdown) |
| POST | `/snomed/imports/scan/{cacheId}/proceed` | `SNOMED_EDIT` | re-imports the cached zip without re-upload |
| POST | `/snomed/concept-usage` | `SNOMED_VIEW` | body `{ codes: List<String> }` |

## Implementation notes

- Diff classification is purely RF2-row-based — it does **not** call Snowstorm. Trust the file's `effectiveTime`: rows with `effectiveTime >= cutoff` form the change-set; absent cutoff defaults to the max effectiveTime in the Concept file.
- Async via existing `LorqueProcessService` + `VirtualThreadExecutor` (same pattern as `SnomedRF2Service.startRF2Export`).
- Uploaded zips persist in new `sys.snomed_rf2_upload` (Liquibase changeset 71) and are auto-cleaned after 7 days by a `@Scheduled fixedDelay="6h"` task.
- Concept-usage queries reuse the JSONB pattern from `ValueSetVersionRuleRepository`; all `IN` lists are bound via `SqlBuilder.in()` (no string concat).

## Standalone CLIs

For ad-hoc / CI use without a running server, two Python equivalents are added under [`scripts/`](./scripts/):

- `snomed_rf2_scan.py` — mirrors `SnomedRF2DiffEngine` exactly; produces the same JSON shape.
- `snomed_concept_usage.py` — mirrors the three SQL queries against the termx Postgres DB; supports plain text input, scan-result JSON, or piped stdin.

A `README.md` in the same folder documents usage, connection options, and examples. Verified against the International edition `20260101` zip — produced the expected change report (3,525 new / 5,486 modified / 576 invalidated concepts since 2025-10-01).

## Test plan

- [ ] CI build passes (no compile errors in Java sources)
- [ ] Liquibase changeset `termx:snomed_rf2_upload` applies cleanly to a fresh DB
- [ ] Unit tests for `SnomedRF2ZipParser`, `SnomedRF2DiffEngine`, `SnomedConceptUsageRepository` (deferred — see follow-up issue)
- [ ] End-to-end: upload an RF2 delta with dry-run checked → verify scan output and that nothing reaches Snowstorm
- [ ] End-to-end: hit `/snomed/imports/scan/{id}/proceed` → verify Snowstorm import job is created and `imported=true` in the cache row
- [ ] End-to-end: query `/snomed/concept-usage` with codes used in seeded supplement / VS rule / VS expansion fixtures → all three return matches