### PR TITLE
fix(snomed): RF2 upload cache — avoid huge bytea load + use soft-delete

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
@@ -39,8 +39,17 @@ public class SnomedRF2UploadCacheRepository extends BaseRepository {
     jdbcTemplate.update(sql, id);
   }
 
+  public void setScanLorqueId(Long id, Long lorqueId) {
+    String sql = "update sys.snomed_rf2_upload set scan_lorque_id = ? where id = ?";
+    jdbcTemplate.update(sql, lorqueId, id);
+  }
+
   public void cleanup(int daysOld) {
-    String sql = "delete from sys.snomed_rf2_upload where started < current_timestamp - (? || ' days')::interval";
+    // Soft-delete and clear zip_data: the schema GRANTs in sys-schema.xml don't include DELETE
+    // for the app user, and what we actually need is to reclaim the bytea (which can be hundreds
+    // of MB per row). The empty-string assignment lets PostgreSQL release the TOAST chunks.
+    String sql = "update sys.snomed_rf2_upload set sys_status = 'C', zip_data = ''::bytea "
+        + "where sys_status = 'A' and started < current_timestamp - (? || ' days')::interval";
     jdbcTemplate.update(sql, String.valueOf(daysOld));
   }
 }

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
@@ -34,12 +34,7 @@ public class SnomedRF2UploadCacheService {
 
   @Transactional
   public void attachLorqueId(Long uploadId, Long lorqueId) {
-    SnomedRF2Upload upload = repository.load(uploadId);
-    if (upload == null) {
-      return;
-    }
-    upload.setScanLorqueId(lorqueId);
-    repository.save(upload);
+    repository.setScanLorqueId(uploadId, lorqueId);
   }
 
   public SnomedRF2Upload load(Long id) {


### PR DESCRIPTION
## Summary

Fixes two production bugs surfaced by the dry-run scan in [#97](https://github.com/termx-health/termx-server/pull/97) when uploading a real International-edition snapshot zip (~500 MB):

### 1. \`invalid memory alloc request size 1151208987\`
\`SnomedRF2UploadCacheService.attachLorqueId\` loaded the full \`snomed_rf2_upload\` row (including the ~500 MB \`zip_data\` bytea) just to set one column. Postgres failed to allocate ~1.1 GB to ship the bytea back through TOAST + JDBC. Replaced with a dedicated \`SnomedRF2UploadCacheRepository.setScanLorqueId(uploadId, lorqueId)\` method that issues \`UPDATE sys.snomed_rf2_upload SET scan_lorque_id = ? WHERE id = ?\`. No bytea round-trip.

### 2. \`permission denied for table snomed_rf2_upload\` (cleanup scheduler)
\`sys-schema.xml\` grants only \`SELECT, INSERT, UPDATE\` on the \`sys\` schema to the app user — the project's standard is soft-delete. My cleanup used \`DELETE\`. Switched the scheduled cleanup to:

\`\`\`sql
update sys.snomed_rf2_upload
   set sys_status = 'C', zip_data = ''::bytea
 where sys_status = 'A'
   and started < current_timestamp - (? || ' days')::interval
\`\`\`

Setting \`zip_data = ''::bytea\` triggers TOAST chunk release, so the disk space is reclaimed; the audit row remains.

## Verification

\`./gradlew :snomed:compileJava :termx-api:compileJava :termx-core:compileJava\` — \`BUILD SUCCESSFUL\` locally on Java 25. The lookup-and-resave path is no longer reachable for any large bytea.