### PR TITLE
feat(lorque): progress reporting + SNOMED RF2 scan publishes phase progress

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
@@ -47,9 +47,12 @@ public class SnomedRF2ScanService {
 
     CompletableFuture.runAsync(SessionStore.wrap(() -> {
       try {
-        SnomedRF2ScanResult result = buildScan(zipBytes, branchPath, rf2Type).setUploadCacheId(uploadId);
+        lorqueProcessService.reportProgress(process.getId(), 5, "starting");
+        SnomedRF2ScanResult result = buildScan(zipBytes, branchPath, rf2Type, process.getId()).setUploadCacheId(uploadId);
+        lorqueProcessService.reportProgress(process.getId(), 90, "rendering report");
         SnomedRF2ScanEnvelope envelope = new SnomedRF2ScanEnvelope().setJson(result).setMarkdown(renderMarkdown(result));
         byte[] payload = JsonUtil.toJson(envelope).getBytes(StandardCharsets.UTF_8);
+        lorqueProcessService.reportProgress(process.getId(), 100, "done");
         lorqueProcessService.complete(process.getId(), ProcessResult.binary(payload));
       } catch (Exception e) {
         log.error("SNOMED RF2 dry-run scan failed for upload {}", uploadId, e);
@@ -62,8 +65,35 @@ public class SnomedRF2ScanService {
   }
 
   public SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type) throws java.io.IOException {
-    ParsedRF2 parsed = parser.parse(zipBytes);
+    return buildScan(zipBytes, branchPath, rf2Type, null);
+  }
+
+  private SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type, Long lorqueId) throws java.io.IOException {
+    java.util.function.Consumer<String> phaseReporter = phase -> {
+      if (lorqueId == null) {
+        return;
+      }
+      Integer percent = phasePercent(phase);
+      if (percent != null) {
+        lorqueProcessService.reportProgress(lorqueId, percent, "parsing " + phase);
+      }
+    };
+    ParsedRF2 parsed = parser.parse(zipBytes, phaseReporter);
+    if (lorqueId != null) {
+      lorqueProcessService.reportProgress(lorqueId, 80, "computing diff");
+    }
     return diffEngine.classify(parsed, branchPath, rf2Type);
+  }
+
+  private static Integer phasePercent(String phase) {
+    return switch (phase) {
+      case "concepts" -> 10;
+      case "descriptions" -> 30;
+      case "text-definitions" -> 45;
+      case "relationships" -> 55;
+      case "language-refset" -> 70;
+      default -> null;
+    };
   }
 
   public String renderMarkdown(SnomedRF2ScanResult result) {

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
@@ -20,6 +20,10 @@ import lombok.extern.slf4j.Slf4j;
 public class SnomedRF2ZipParser {
 
   public ParsedRF2 parse(byte[] zipBytes) throws IOException {
+    return parse(zipBytes, null);
+  }
+
+  public ParsedRF2 parse(byte[] zipBytes, java.util.function.Consumer<String> phaseReporter) throws IOException {
     ParsedRF2 parsed = new ParsedRF2();
     try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
       ZipEntry entry;
@@ -30,14 +34,19 @@ public class SnomedRF2ZipParser {
         String name = stripPath(entry.getName());
         try {
           if (name.startsWith("sct2_Concept_")) {
+            report(phaseReporter, "concepts");
             parsed.getConcepts().addAll(readConcepts(zis));
           } else if (name.startsWith("sct2_Description_")) {
+            report(phaseReporter, "descriptions");
             parsed.getDescriptions().addAll(readDescriptions(zis, false));
           } else if (name.startsWith("sct2_TextDefinition_")) {
+            report(phaseReporter, "text-definitions");
             parsed.getDescriptions().addAll(readDescriptions(zis, true));
           } else if (name.startsWith("sct2_Relationship_") || name.startsWith("sct2_StatedRelationship_")) {
+            report(phaseReporter, "relationships");
             parsed.getRelationships().addAll(readRelationships(zis));
           } else if (name.startsWith("der2_cRefset_Language")) {
+            report(phaseReporter, "language-refset");
             parsed.getLanguageRefset().addAll(readLanguageRefset(zis));
           }
         } catch (Exception e) {
@@ -46,6 +55,12 @@ public class SnomedRF2ZipParser {
       }
     }
     return parsed;
+  }
+
+  private static void report(java.util.function.Consumer<String> reporter, String phase) {
+    if (reporter != null) {
+      reporter.accept(phase);
+    }
   }
 
   private static String stripPath(String entryName) {

--- a/termx-api/src/main/java/org/termx/sys/lorque/LorqueProcess.java
+++ b/termx-api/src/main/java/org/termx/sys/lorque/LorqueProcess.java
@@ -18,4 +18,6 @@ public class LorqueProcess {
   private byte[] result;
   private String resultText;
   private String resultType;
+  private Integer progressPercent;
+  private String progressNote;
 }

--- a/termx-core/src/main/java/org/termx/core/sys/lorque/LorqueProcessRepository.java
+++ b/termx-core/src/main/java/org/termx/core/sys/lorque/LorqueProcessRepository.java
@@ -29,8 +29,15 @@ public class LorqueProcessRepository extends BaseRepository {
     ssb.property("finished", process.getFinished());
     ssb.property("result", process.getResult());
     ssb.property("result_type", process.getResultType());
+    ssb.property("progress_percent", process.getProgressPercent());
+    ssb.property("progress_note", process.getProgressNote());
     SqlBuilder sb = ssb.buildSave("sys.lorque_process", "id");
     return jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());
+  }
+
+  public void updateProgress(Long id, Integer percent, String note) {
+    String sql = "update sys.lorque_process set progress_percent = ?, progress_note = ? where id = ?";
+    jdbcTemplate.update(sql, percent, note, id);
   }
 
   public void cleanup(int daysInterval) {

--- a/termx-core/src/main/java/org/termx/core/sys/lorque/LorqueProcessService.java
+++ b/termx-core/src/main/java/org/termx/core/sys/lorque/LorqueProcessService.java
@@ -57,6 +57,10 @@ public class LorqueProcessService {
     return repository.getStatus(id);
   }
 
+  public void reportProgress(Long id, Integer percent, String note) {
+    repository.updateProgress(id, percent, note);
+  }
+
   @Transactional
   public LorqueProcess complete(Long id, ProcessResult result) {
     LorqueProcess process = load(id);

--- a/termx-core/src/main/resources/sys/changelog/sys/20-lorque_process.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/20-lorque_process.sql
@@ -24,3 +24,10 @@ select core.create_table_metadata('sys.lorque_process');
 --changeset kodality:grant-lorque_process-delete
 GRANT DELETE ON table sys.lorque_process TO ${app-username};
 --rollback select 1;
+
+--changeset termx:lorque_process-progress
+alter table sys.lorque_process add column if not exists progress_percent int;
+alter table sys.lorque_process add column if not exists progress_note text;
+--rollback alter table sys.lorque_process drop column if exists progress_percent;
+--rollback alter table sys.lorque_process drop column if exists progress_note;
+--


### PR DESCRIPTION
## Summary

Adds a real determinate progress channel to \`LorqueProcess\` so long-running async jobs can stream phase progress to the frontend, and uses it from \`SnomedRF2ScanService\`.

### Schema

New columns on \`sys.lorque_process\` (Liquibase changeset \`termx:lorque_process-progress\`):
- \`progress_percent\` (\`int\`)
- \`progress_note\` (\`text\`)

### API

- \`LorqueProcess\` DTO gains \`progressPercent\` / \`progressNote\` fields. Backwards compatible — existing callers that don't set them keep working.
- \`LorqueProcessRepository.updateProgress(id, percent, note)\` does a direct \`UPDATE\` so the (potentially huge) bytea \`result\` is never round-tripped just to report progress (same lesson as the snomed_rf2_upload bytea fix).
- \`LorqueProcessService.reportProgress(id, percent, note)\` wraps the repo call.

### Wiring in SnomedRF2ScanService

\`SnomedRF2ZipParser\` was extended with an optional \`Consumer<String> phaseReporter\` parameter; the scan service maps each phase to a percent + note and calls \`reportProgress\`:

| % | Note |
|---:|---|
| 5 | starting |
| 10 | parsing concepts |
| 30 | parsing descriptions |
| 45 | parsing text-definitions |
| 55 | parsing relationships |
| 70 | parsing language-refset |
| 80 | computing diff |
| 90 | rendering report |
| 100 | done |

Existing call sites that don't care about progress keep working via the non-progress overload of \`SnomedRF2ZipParser.parse()\` and \`SnomedRF2ScanService.buildScan()\`.

## Verification

\`./gradlew :snomed:compileJava :termx-api:compileJava :termx-core:compileJava\` — \`BUILD SUCCESSFUL\`.

## Test plan

- [ ] CI build passes
- [ ] Liquibase changeset \`termx:lorque_process-progress\` applies cleanly to a fresh DB and to a DB that already has the snomed_rf2_upload table
- [ ] Trigger a dry-run on the International edition zip — query \`select id, status, progress_percent, progress_note from sys.lorque_process where process_name = 'snomed-rf2-scan' order by id desc limit 1;\` mid-scan — values should advance through the phases above