### PR TITLE
fix: register $sync operations correctly so they don't fail at startup

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetSyncOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetSyncOperation.java
@@ -13,8 +13,8 @@ import org.termx.core.sys.job.logger.ImportLogger;
 import com.kodality.zmei.fhir.FhirMapper;
 import com.kodality.zmei.fhir.resource.other.Parameters;
 import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter;
-import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.util.CollectionUtils;
+import jakarta.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -23,7 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r4.model.ResourceType;
 
 @Slf4j
-@Factory
+@Singleton
 @RequiredArgsConstructor
 public class ValueSetSyncOperation implements TypeOperationDefinition {
   private final ImportLogger importLogger;

--- a/terminology/src/main/resources/conformance/OperationDefinition-CodeSystem-sync.json
+++ b/terminology/src/main/resources/conformance/OperationDefinition-CodeSystem-sync.json
@@ -10,7 +10,7 @@
   "status": "draft",
   "system": false,
   "version": "5.0.0",
-  "instance": true,
+  "instance": false,
   "resource": [
     "CodeSystem"
   ],

--- a/terminology/src/main/resources/conformance/OperationDefinition-ConceptMap-sync.json
+++ b/terminology/src/main/resources/conformance/OperationDefinition-ConceptMap-sync.json
@@ -10,7 +10,7 @@
   "status": "draft",
   "system": false,
   "version": "5.0.0",
-  "instance": true,
+  "instance": false,
   "resource": [
     "ConceptMap"
   ],

--- a/terminology/src/main/resources/conformance/OperationDefinition-ValueSet-sync.json
+++ b/terminology/src/main/resources/conformance/OperationDefinition-ValueSet-sync.json
@@ -10,7 +10,7 @@
   "status": "draft",
   "system": false,
   "version": "5.0.0",
-  "instance": true,
+  "instance": false,
   "resource": [
     "ValueSet"
   ],


### PR DESCRIPTION
Three errors were emitted at every server boot:

```
ERROR c.k.k.rest.KefhirEndpointInitializer  - Cannot find implementation for declared in capability statement operation 'http://hl7.org/fhir/OperationDefinition/ValueSet-sync'
ERROR c.k.k.rest.KefhirEndpointInitializer  - Cannot find implementation for declared in capability statement operation 'http://hl7.org/fhir/OperationDefinition/CodeSystem-sync'
ERROR c.k.k.rest.KefhirEndpointInitializer  - Cannot find implementation for declared in capability statement operation 'http://hl7.org/fhir/OperationDefinition/ConceptMap-sync'
```

The implementations exist and are correct ([ValueSetSyncOperation](terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetSyncOperation.java), [CodeSystemSyncOperation](terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemSyncOperation.java), [ConceptMapSyncOperation](terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapSyncOperation.java)). Two unrelated registration bugs were preventing them from being matched against the CapabilityStatement.

## 1. `ValueSetSyncOperation` was `@Factory`, not `@Singleton`

In Micronaut, `@Factory` marks a class as containing `@Bean` factory methods — **not** as a bean itself. So Micronaut never registered the class, and `KefhirEndpointInitializer.operations` (which scans `BaseOperationDefinition` beans) couldn't find a `sync` implementation for `ValueSet`.

Fixed by switching to `@Singleton`, matching `CodeSystemSyncOperation` and `ConceptMapSyncOperation` which were already correct.

## 2. `instance: true` declared in OperationDefinitions but no instance handler

All three `OperationDefinition-*-sync.json` files set `"instance": true`. None of the three implementations implements `InstanceOperationDefinition` — they're inherently type-level (the resource `id` and `url` are inside the `resources` parameter; an instance-path `id` would be unused).

`KefhirEndpointInitializer.validateOperation` requires both type and instance handlers when both are declared, and emits the same generic `Cannot find implementation` error for the missing instance side. So even after fix 1, all three would still error.

Fixed by setting `"instance": false` in all three OperationDefinitions to match what's actually implemented. If `POST /<Resource>/<id>/$sync` semantics are wanted later, that's a separate feature.

## Verification

After this lands and dev redeploys, the three `Cannot find implementation … *-sync` errors should disappear from the boot log. The fourth error (`Missing OperationDefinition for referenced … ConceptMap-closure`) is a separate issue tracked for a follow-up PR — the closure operation is genuinely unimplemented.

## Test plan

- [x] `terminology:compileJava` succeeds.
- [ ] After deploy: no `Cannot find implementation … *-sync` errors at startup; `POST /api/fhir/ValueSet/$sync` returns a `Parameters` with `jobId` (was previously a 404 since the operation wasn't even routed).