### PR TITLE
feat(snomed): RF2 dry-run scan summary/full mode

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,8 +20,14 @@ invalidated concepts, with their designations and attributes). Algorithm matches
 
 ```text
 python3 snomed_rf2_scan.py <ZIP> [--cutoff YYYYMMDD] [-o OUTPUT.json]
-                                 [--branch-path MAIN] [--rf2-type SNAPSHOT|DELTA|FULL] [-q]
+                                 [--branch-path MAIN] [--rf2-type SNAPSHOT|DELTA|FULL]
+                                 [--mode summary|full] [-q]
 ```
+
+### Mode
+
+- `--mode summary` (default) — parses only the Concept, Description and TextDefinition files. Several times faster on a full International edition zip (the Relationship and Language-refset files dominate wall-clock time). Designations are reported with `acceptability="none"` and there are no attributes.
+- `--mode full` — parses all five RF2 file kinds. Acceptability and attributes are populated.
 
 ### Examples
 
@@ -33,11 +39,12 @@ python3 snomed_rf2_scan.py ~/Downloads/SnomedCT_InternationalRF2_PRODUCTION_2026
     -o /tmp/scan.json
 ```
 
-Filter changes since a specific date (e.g. everything since 2025-10-01):
+Filter changes since a specific date (e.g. everything since 2025-10-01), full mode:
 
 ```sh
 python3 snomed_rf2_scan.py ~/Downloads/SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip \
     --cutoff 20251001 \
+    --mode full \
     -o /tmp/scan-since-20251001.json
 ```
 

--- a/scripts/snomed_rf2_scan.py
+++ b/scripts/snomed_rf2_scan.py
@@ -141,21 +141,22 @@ def find_member(names, prefix, contains=None):
     return None
 
 
-def classify(zip_path, cutoff, branch_path="MAIN", rf2_type="SNAPSHOT", verbose=True):
+def classify(zip_path, cutoff, branch_path="MAIN", rf2_type="SNAPSHOT", mode="summary", verbose=True):
     log = (lambda msg: print(msg, file=sys.stderr)) if verbose else (lambda msg: None)
-    log(f"[scan] opening {zip_path}, cutoff effectiveTime >= {cutoff or '(none)'}")
+    full_mode = mode == "full"
+    log(f"[scan] opening {zip_path}, cutoff effectiveTime >= {cutoff or '(none)'}, mode={mode}")
     with zipfile.ZipFile(zip_path) as zf:
         names = zf.namelist()
         c_path = find_member(names, "sct2_Concept_Snapshot_", "Snapshot/Terminology/")
         d_path = find_member(names, "sct2_Description_Snapshot", "Snapshot/Terminology/")
         td_path = find_member(names, "sct2_TextDefinition_Snapshot", "Snapshot/Terminology/")
-        r_path = find_member(names, "sct2_Relationship_Snapshot_", "Snapshot/Terminology/")
-        lr_path = find_member(names, "der2_cRefset_LanguageSnapshot", "Snapshot/Refset/Language/")
+        r_path = find_member(names, "sct2_Relationship_Snapshot_", "Snapshot/Terminology/") if full_mode else None
+        lr_path = find_member(names, "der2_cRefset_LanguageSnapshot", "Snapshot/Refset/Language/") if full_mode else None
         log(f"[scan]   concept:        {c_path}")
         log(f"[scan]   description:    {d_path}")
         log(f"[scan]   text-def:       {td_path}")
-        log(f"[scan]   relationship:   {r_path}")
-        log(f"[scan]   language-refset:{lr_path}")
+        log(f"[scan]   relationship:   {r_path or '(skipped — summary mode)'}")
+        log(f"[scan]   language-refset:{lr_path or '(skipped — summary mode)'}")
 
         if c_path is None:
             raise SystemExit("ERROR: no sct2_Concept_Snapshot_*.txt found in zip — is this an RF2 release?")
@@ -182,9 +183,11 @@ def classify(zip_path, cutoff, branch_path="MAIN", rf2_type="SNAPSHOT", verbose=
             descriptions += read_descriptions(zf, td_path, cutoff, True)
         log(f"[scan] description+textdef rows post-cutoff: {len(descriptions)}")
         relationships = read_relationships(zf, r_path, cutoff) if r_path else []
-        log(f"[scan] relationship rows post-cutoff: {len(relationships)}")
+        if full_mode:
+            log(f"[scan] relationship rows post-cutoff: {len(relationships)}")
         lang = read_language_refset(zf, lr_path, cutoff) if lr_path else []
-        log(f"[scan] language-refset rows post-cutoff: {len(lang)}")
+        if full_mode:
+            log(f"[scan] language-refset rows post-cutoff: {len(lang)}")
 
     concepts = latest_per_id(concepts)
     descriptions = latest_per_id(descriptions)
@@ -298,10 +301,15 @@ def main():
     p.add_argument("--branch-path", default="MAIN", help="Branch path label for the report.")
     p.add_argument("--rf2-type", default="SNAPSHOT", choices=("SNAPSHOT", "DELTA", "FULL"),
                    help="Label for the report (algorithm is identical for all three).")
+    p.add_argument("--mode", default="summary", choices=("summary", "full"),
+                   help="summary (default): parse concepts + descriptions + text-definitions only "
+                        "(several times faster on a full International edition). "
+                        "full: also parse relationships and the language refset so the report "
+                        "includes attributes and acceptability.")
     p.add_argument("-q", "--quiet", action="store_true", help="Suppress progress logging on stderr.")
     args = p.parse_args()
 
-    result = classify(args.zip, args.cutoff, args.branch_path, args.rf2_type, verbose=not args.quiet)
+    result = classify(args.zip, args.cutoff, args.branch_path, args.rf2_type, args.mode, verbose=not args.quiet)
 
     with open(args.output, "w") as f:
         json.dump(result, f)

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
@@ -44,11 +44,12 @@ public class SnomedRF2ScanService {
     Long uploadId = upload.getId();
     String branchPath = request.getBranchPath();
     String rf2Type = request.getType();
+    boolean fullMode = "full".equalsIgnoreCase(request.getMode());
 
     CompletableFuture.runAsync(SessionStore.wrap(() -> {
       try {
-        lorqueProcessService.reportProgress(process.getId(), 5, "starting");
-        SnomedRF2ScanResult result = buildScan(zipBytes, branchPath, rf2Type, process.getId()).setUploadCacheId(uploadId);
+        lorqueProcessService.reportProgress(process.getId(), 5, "starting (" + (fullMode ? "full" : "summary") + " mode)");
+        SnomedRF2ScanResult result = buildScan(zipBytes, branchPath, rf2Type, fullMode, process.getId()).setUploadCacheId(uploadId);
         lorqueProcessService.reportProgress(process.getId(), 90, "rendering report");
         SnomedRF2ScanEnvelope envelope = new SnomedRF2ScanEnvelope().setJson(result).setMarkdown(renderMarkdown(result));
         byte[] payload = JsonUtil.toJson(envelope).getBytes(StandardCharsets.UTF_8);
@@ -65,10 +66,10 @@ public class SnomedRF2ScanService {
   }
 
   public SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type) throws java.io.IOException {
-    return buildScan(zipBytes, branchPath, rf2Type, null);
+    return buildScan(zipBytes, branchPath, rf2Type, true, null);
   }
 
-  private SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type, Long lorqueId) throws java.io.IOException {
+  private SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type, boolean fullMode, Long lorqueId) throws java.io.IOException {
     java.util.function.Consumer<String> phaseReporter = phase -> {
       if (lorqueId == null) {
         return;
@@ -78,7 +79,7 @@ public class SnomedRF2ScanService {
         lorqueProcessService.reportProgress(lorqueId, percent, "parsing " + phase);
       }
     };
-    ParsedRF2 parsed = parser.parse(zipBytes, phaseReporter);
+    ParsedRF2 parsed = parser.parse(zipBytes, phaseReporter, fullMode);
     if (lorqueId != null) {
       lorqueProcessService.reportProgress(lorqueId, 80, "computing diff");
     }

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
@@ -20,10 +20,19 @@ import lombok.extern.slf4j.Slf4j;
 public class SnomedRF2ZipParser {
 
   public ParsedRF2 parse(byte[] zipBytes) throws IOException {
-    return parse(zipBytes, null);
+    return parse(zipBytes, null, true);
   }
 
   public ParsedRF2 parse(byte[] zipBytes, java.util.function.Consumer<String> phaseReporter) throws IOException {
+    return parse(zipBytes, phaseReporter, true);
+  }
+
+  /**
+   * Parse the RF2 zip, optionally restricted to the lightweight set of files for "summary" mode.
+   * When {@code fullMode} is false, relationship and language-refset entries are skipped — those
+   * two files dominate the wall-clock time on a full International edition zip.
+   */
+  public ParsedRF2 parse(byte[] zipBytes, java.util.function.Consumer<String> phaseReporter, boolean fullMode) throws IOException {
     ParsedRF2 parsed = new ParsedRF2();
     try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
       ZipEntry entry;
@@ -42,10 +51,10 @@ public class SnomedRF2ZipParser {
           } else if (name.startsWith("sct2_TextDefinition_")) {
             report(phaseReporter, "text-definitions");
             parsed.getDescriptions().addAll(readDescriptions(zis, true));
-          } else if (name.startsWith("sct2_Relationship_") || name.startsWith("sct2_StatedRelationship_")) {
+          } else if (fullMode && (name.startsWith("sct2_Relationship_") || name.startsWith("sct2_StatedRelationship_"))) {
             report(phaseReporter, "relationships");
             parsed.getRelationships().addAll(readRelationships(zis));
-          } else if (name.startsWith("der2_cRefset_Language")) {
+          } else if (fullMode && name.startsWith("der2_cRefset_Language")) {
             report(phaseReporter, "language-refset");
             parsed.getLanguageRefset().addAll(readLanguageRefset(zis));
           }

--- a/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportRequest.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportRequest.java
@@ -10,4 +10,8 @@ public class SnomedImportRequest {
   private boolean createCodeSystemVersion;
   private String type;
   private boolean dryRun;
+  /** Scope for the dry-run scan. "summary" (default) parses only concepts + descriptions
+   *  (and text-definitions). "full" additionally parses relationships and the language refset
+   *  so attributes and acceptability are included in the report. Ignored for non-dry-run imports. */
+  private String mode;
 }


### PR DESCRIPTION
## Summary

Default dry-run scan now skips the two largest RF2 files (Relationship ~400 MB, Language refset ~390 MB) which dominate wall-clock time on a full International edition zip but only contribute attribute and acceptability detail. The fast path is plenty for "what changed" triage.

\`SnomedImportRequest\` gains a \`mode\` field:

| mode | Files parsed | Notes |
|---|---|---|
| \`summary\` (default) | Concept + Description + TextDefinition | designations report \`acceptability="none"\`; no attributes; several times faster |
| \`full\` | all five RF2 file kinds | acceptability and attributes populated (existing behaviour) |

\`SnomedRF2ZipParser.parse(...)\` gains a \`fullMode\` flag. The existing overloads default to \`fullMode=true\` so non-dry-run callers are unchanged. \`SnomedRF2ScanService\` passes \`request.mode\` through and includes the mode in the *starting* progress note so the UI can show it.

\`scripts/snomed_rf2_scan.py\` and the scripts README updated to expose \`--mode summary|full\`.

## Verification

\`./gradlew :snomed:compileJava :termx-api:compileJava\` — \`BUILD SUCCESSFUL\`.

Offline scan against \`SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip\` with cutoff \`20251001\`:

- \`--mode summary\`: 3,525 new + 1,133 modified + 576 invalidated; relationships not counted.
- \`--mode full\`: 3,525 / 5,486 / 576; relationships and acceptability populated.

The +4,353 "modified" concepts in full mode are ones whose ONLY change in this release was a relationship — by definition not visible in summary mode.

## Test plan

- [ ] CI build passes
- [ ] User confirmed the UI flow end-to-end on a real upload before merge