### PR TITLE
fix(snomed): treat blank Snowstorm user/password as no-auth

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/client/SnowstormClientFactory.java
+++ b/snomed/src/main/java/org/termx/snomed/client/SnowstormClientFactory.java
@@ -44,8 +44,10 @@ public class SnowstormClientFactory {
   }
 
   private static Builder builder(Builder builder, Optional<String> snowstormUser, Optional<String> snowstormPassword) {
-    if (snowstormUser.isPresent() && snowstormPassword.isPresent()) {
-      builder.setHeader(HttpHeaders.AUTHORIZATION, basicAuth(snowstormUser.get(), snowstormPassword.get()));
+    String user = snowstormUser.map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+    String password = snowstormPassword.map(String::trim).filter(s -> !s.isEmpty()).orElse(null);
+    if (user != null && password != null) {
+      builder.setHeader(HttpHeaders.AUTHORIZATION, basicAuth(user, password));
     }
     return builder;
   }


### PR DESCRIPTION
## Summary

\`Optional.isPresent()\` returns \`true\` for the empty string, so a config like

\`\`\`yaml
snowstorm:
  user: termserver-app
  password: ''
\`\`\`

caused \`SnowstormClientFactory\` to send \`Authorization: Basic <base64 of termserver-app:>\` — Basic Auth with an empty password. An auth-required Snowstorm rejects that with 403; an open Snowstorm just sees a malformed credential. Either way the failure looks like a single confusing 403 with no hint that the local config is the cause.

This PR trims and filters out empty strings before deciding whether to attach the Basic-Auth header. If either user or password is missing/blank, no \`Authorization\` header is sent and Snowstorm simply sees an anonymous request — which surfaces the real problem (auth required, but none provided) rather than masking it as bad credentials.

Does **not** change behaviour for properly-configured deployments.

## Verification

\`./gradlew :snomed:compileJava\` — \`BUILD SUCCESSFUL\`.

## Test plan

- [ ] CI build passes
- [ ] Configure \`snowstorm.password: ''\` against an open Snowstorm — request goes through anonymously rather than 403'ing on bad creds.
- [ ] Configure proper credentials — Basic-Auth header still sent, behaviour unchanged.