### PR TITLE
fix(snomed): swallow Snowstorm-import HttpClientError stack in logs

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/ApiError.java
+++ b/snomed/src/main/java/org/termx/snomed/ApiError.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 public enum ApiError {
   SN101("SN101", "Branch name is required"),
   SN102("SN102", "Branch name can contain only: A-Z charaters, numbers, slash and hyphen"),
+  SN201("SN201", "Snowstorm rejected the import request: HTTP {{status}} ({{url}})"),
   ;
 
   private String code;

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
@@ -1,5 +1,7 @@
 package org.termx.snomed.integration;
 
+import com.kodality.commons.client.HttpClientError;
+import com.kodality.commons.exception.ApiException;
 import org.termx.snomed.ApiError;
 import org.termx.snomed.client.SnowstormClient;
 import org.termx.snomed.codesystem.SnomedCodeSystem;
@@ -17,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionException;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -118,13 +121,20 @@ public class SnomedService {
 
   @Transactional
   public Map<String, String> importRF2File(SnomedImportRequest req, byte[] importFile) {
-    String jobId = snowstormClient.createImportJob(req).join();
+    String jobId;
+    try {
+      jobId = snowstormClient.createImportJob(req).join();
+    } catch (CompletionException e) {
+      throw rethrowSnowstormImportFailure(e);
+    }
     try {
       snowstormClient.uploadRF2File(jobId, importFile).join();
     } catch (FileNotFoundException e) {
-      e.printStackTrace();
+      log.warn("SNOMED RF2 upload to Snowstorm failed: {}", e.getMessage());
+    } catch (CompletionException e) {
+      throw rethrowSnowstormImportFailure(e);
     }
-    
+
     SnomedImportTracking tracking = new SnomedImportTracking()
         .setSnowstormJobId(jobId)
         .setBranchPath(req.getBranchPath())
@@ -133,10 +143,28 @@ public class SnomedService {
         .setStarted(OffsetDateTime.now())
         .setNotified(false);
     trackingRepository.save(tracking);
-    
+
     log.info("Created SNOMED import tracking record for Snowstorm job: {}", jobId);
-    
+
     return Map.of("jobId", jobId);
+  }
+
+  /**
+   * Convert a CompletableFuture failure from the Snowstorm client into a clean ApiException.
+   * Logs a one-line warn (no stack) so the dev-server log isn't polluted by the full Netty
+   * trace every time Snowstorm rejects an import (e.g. auth misconfiguration). The frontend
+   * still receives a structured error with the upstream status and URL.
+   */
+  private ApiException rethrowSnowstormImportFailure(CompletionException e) {
+    Throwable cause = e.getCause() != null ? e.getCause() : e;
+    if (cause instanceof HttpClientError hce) {
+      int status = hce.getResponse() == null ? 0 : hce.getResponse().statusCode();
+      String url = hce.getRequest() == null ? "(unknown)" : hce.getRequest().uri().toString();
+      log.warn("Snowstorm import call failed: HTTP {} {}", status, url);
+      return ApiError.SN201.toApiException(Map.of("status", status, "url", url));
+    }
+    // Unknown async failure — keep the full stack so it surfaces as a real bug.
+    throw e;
   }
 
   public List<SnomedCodeSystem> loadCodeSystems() {


### PR DESCRIPTION
## Summary

Every Confirm-without-dry-run against a Snowstorm that rejects auth was producing a full ~40-line Netty/CompletableFuture stack trace at ERROR level via \`DefaultExceptionHandler.handleHttpClientError\`. The trace carries no diagnostic value once you know the upstream returned 4xx — the URL and status are enough.

\`SnomedService.importRF2File\` now catches the \`CompletionException\` wrapping \`HttpClientError\` around both Snowstorm calls (\`createImportJob\` + \`uploadRF2File\`), unwraps it, logs a single WARN line of the form

\`\`\`
Snowstorm import call failed: HTTP 403 https://snomed.termx.org/snowstorm/snomed-ct/imports
\`\`\`

and rethrows as \`ApiError.SN201.toApiException\` with \`status\` + \`url\` params.

Because \`ApiClientException\` carries \`httpStatus=400\`, \`DefaultExceptionHandler.handleApiException\` takes the **debug-level** branch instead of the error-with-stack branch — no more stack spam.

Frontend behaviour is unchanged: the frontend already extracts \`{code, message}\` from the kodality Issue array (PR #58), so the user still sees a clear

> *SN201 Snowstorm rejected the import request: HTTP 403 (https://…/snowstorm/snomed-ct/imports)*

notification.

Genuine async failures that aren't \`HttpClientError\` (network timeout, NPE in the client lib, etc.) still propagate untouched, so real bugs continue to surface with their full stack.

## New error code

\`SN201\` — *"Snowstorm rejected the import request: HTTP {{status}} ({{url}})"*

Added to \`org.termx.snomed.ApiError\` next to the existing \`SN101\` / \`SN102\`.

## Verification

\`./gradlew :snomed:compileJava\` — \`BUILD SUCCESSFUL\`.

## Test plan

- [ ] CI build passes
- [ ] Trigger a Snowstorm 403 — server log shows one \`WARN  ... Snowstorm import call failed: HTTP 403 …\` line, no \`com.kodality.commons.client.HttpClientError ... at ...\` stack.
- [ ] Frontend notification shows the SN201 message with the upstream URL/status.