### PR TITLE
feat(privileges): add triage action (Phase A of GitHub-style permissions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,35 @@ cd termx-app
 ``` 
 In the development mode you can use application without authentication. The application use special dev token **Bearer token** `yupi` in request Authorization header.
 
+### Yupi privilege override (QA / migration testing)
+
+By default the `yupi` session is granted the full set of action wildcards (`*.*.view`, `*.*.triage`, `*.*.edit`, `*.*.publish`). To test the application as a user with a restricted privilege set -- for example, to verify that a `View`-only user no longer sees CodeSystem download links or wiki comments after the Phase A migration -- override the yupi privilege set with the `-PyupiPrivileges` Gradle flag (or directly with `-Dauth.dev.yupi.privileges=...`).
+
+```bash
+# View-only: page renders but downloads + comments are hidden.
+./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view'
+
+# View + Triage: downloads visible, comment thread visible, no edit.
+./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view,*.*.triage'
+
+# Resource-scoped view: only the icd-10 CodeSystem is viewable.
+./gradlew :termx-app:run -Pdev -PyupiPrivileges='icd-10.CodeSystem.view'
+```
+
+The value is a comma-separated list of dotted privilege strings (`{resource}.{type}.{action}`); whitespace and empty tokens are ignored. Common preset values and their expected UI effect are documented in [docs/specification/terminology-server/privileges-migration-guide.md](../docs/specification/terminology-server/privileges-migration-guide.md#qa-testing-with-the-yupi-privilege-override) and inline in [`YupiSessionProvider`](termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java).
+
+For ad-hoc per-request overrides without restarting the server, send a JSON-encoded `SessionInfo` directly in the header:
+
+```
+Authorization: Bearer yupi{"username":"qa","privileges":["*.CodeSystem.view"]}
+```
+
+**Frontend note.** The web UI (termx-web) fetches privileges from the backend's `/auth/userinfo` endpoint, so any `auth.dev.yupi.privileges` override is reflected in the UI automatically. After changing the override and restarting the server, **hard-refresh the browser** (Cmd/Ctrl-Shift-R) to drop the cached session. If you still see admin (`*.*.*`) after the refresh, check that:
+1. The frontend's `environment.yupiEnabled` is `true` (default in `environment.ts`).
+2. The backend started with `-Pdev` so `auth.dev.allowed=true` is set.
+3. The `-PyupiPrivileges` value made it onto the JVM command line (visible in `./gradlew :termx-app:run` output via `-Dauth.dev.yupi.privileges=...`).
+4. Hit `http://localhost:8200/auth/userinfo` directly in the browser. The response should show `"username": "yupi"` with the privileges you configured. If it shows a different username (e.g. `admin`) you are hitting the **mock** auth provider configured in `application-local.yml` -- the yupi provider is wired to take priority over mock since order=3 (yupi) < 5 (mock), so this should not happen, but if your `application-local.yml` is heavily customised, double-check that nothing else is intercepting `Bearer yupi`.
+
 ### Logging
 
 - **Local (verbose)**: Copy [`termx-app/src/main/resources/application-local.example.yml`](termx-app/src/main/resources/application-local.example.yml) to `termx-app/src/main/resources/application-local.yml` (that file is gitignored). Micronaut only loads `application-local.yml` when the **`local`** environment is active. Use **`./gradlew :termx-app:run -Pdev`** or **`./_run_local.sh`** (they set `dev,local`), or add **`-Dmicronaut.environments=dev,local`** to the JVM when running from the IDE. **`./gradlew run` without `-Pdev` does not load `application-local.yml`**, so `logger.levels` there will have no effect.

--- a/terminology/src/main/java/org/termx/terminology/Privilege.java
+++ b/terminology/src/main/java/org/termx/terminology/Privilege.java
@@ -2,6 +2,7 @@ package org.termx.terminology;
 
 public interface Privilege {
   String CS_VIEW = "CodeSystem.view";
+  String CS_TRIAGE = "CodeSystem.triage";
   String CS_EDIT = "CodeSystem.edit";
   String CS_PUBLISH = "CodeSystem.publish";
 
@@ -9,10 +10,12 @@ public interface Privilege {
   String DEF_PROP_EDIT = "DefinedProperty.edit";
 
   String VS_VIEW = "ValueSet.view";
+  String VS_TRIAGE = "ValueSet.triage";
   String VS_EDIT = "ValueSet.edit";
   String VS_PUBLISH = "ValueSet.publish";
 
   String MS_VIEW = "MapSet.view";
+  String MS_TRIAGE = "MapSet.triage";
   String MS_EDIT = "MapSet.edit";
   String MS_PUBLISH = "MapSet.publish";
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java
@@ -322,13 +322,13 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_TRIAGE)
   @Get(uri = "/{codeSystem}/versions/{version}/concepts/export{?params*}")
   public LorqueProcess exportConcepts(@PathVariable String codeSystem, @PathVariable String version, Map<String, String> params) {
     return conceptExportService.export(codeSystem, version, params.getOrDefault("format", "csv"));
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_TRIAGE)
   @Get(value = "/concepts/export-csv/result/{lorqueProcessId}", produces = "application/csv")
   public HttpResponse<?> getConceptExportCSV(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());
@@ -337,7 +337,7 @@ public class CodeSystemController {
         .contentType(MediaType.of("application/csv"));
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_TRIAGE)
   @Get(value = "/concepts/export-xlsx/result/{lorqueProcessId}", produces = "application/vnd.ms-excel")
   public HttpResponse<?> getConceptExportXLSX(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetController.java
@@ -294,13 +294,13 @@ public class MapSetController {
 
   //----------------MapSet Export----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_TRIAGE)
   @Get(uri = "/{mapSet}/versions/{version}/associations-export{?params*}")
   public LorqueProcess exportAssociations(@PathVariable String mapSet, @PathVariable String version, Map<String, String> params) {
     return mapSetExportService.export(mapSet, version, params.getOrDefault("format", "csv"));
   }
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_TRIAGE)
   @Get(value = "/associations-export-csv/result/{lorqueProcessId}", produces = "application/csv")
   public HttpResponse<?> getAssociationExportCSV(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());
@@ -309,7 +309,7 @@ public class MapSetController {
         .contentType(MediaType.of("application/csv"));
   }
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_TRIAGE)
   @Get(value = "/associations-export-xlsx/result/{lorqueProcessId}", produces = "application/vnd.ms-excel")
   public HttpResponse<?> getAssociationExportXLSX(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetController.java
@@ -241,13 +241,13 @@ public class ValueSetController {
     return jobLogResponse;
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_TRIAGE)
   @Get(uri = "/{valueSet}/versions/{version}/expansion-export{?params*}")
   public LorqueProcess exportConcepts(@PathVariable String valueSet, @PathVariable String version, Map<String, String> params) {
     return valueSetExportService.export(valueSet, version, params.getOrDefault("format", "csv"));
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_TRIAGE)
   @Get(value = "/expansion-export-csv/result/{lorqueProcessId}", produces = "application/csv")
   public HttpResponse<?> getConceptExportCSV(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());
@@ -256,7 +256,7 @@ public class ValueSetController {
         .contentType(MediaType.of("application/csv"));
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_TRIAGE)
   @Get(value = "/expansion-export-xlsx/result/{lorqueProcessId}", produces = "application/vnd.ms-excel")
   public HttpResponse<?> getConceptExportXLSX(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/CodeSystemDownloadAuthAnnotationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/CodeSystemDownloadAuthAnnotationTest.groovy
@@ -1,0 +1,45 @@
+package org.termx.terminology.terminology.codesystem
+
+import org.termx.core.auth.Authorized
+import org.termx.terminology.Privilege
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+/**
+ * Verifies that the three CodeSystem export endpoints are gated by CS_TRIAGE
+ * (per Phase A.2 of the GitHub-style permissions migration).
+ *
+ * Annotation-level test rather than HTTP-level: the auth runtime is exercised
+ * by AuthorizationFilterTest; here we just confirm the wire-up.
+ */
+class CodeSystemDownloadAuthAnnotationTest extends Specification {
+
+  def "exportConcepts is gated by CS_TRIAGE"() {
+    expect:
+    findMethod(CodeSystemController, "exportConcepts").getAnnotation(Authorized).value() ==
+        [Privilege.CS_TRIAGE] as String[]
+  }
+
+  def "getConceptExportCSV is gated by CS_TRIAGE"() {
+    expect:
+    findMethod(CodeSystemController, "getConceptExportCSV").getAnnotation(Authorized).value() ==
+        [Privilege.CS_TRIAGE] as String[]
+  }
+
+  def "getConceptExportXLSX is gated by CS_TRIAGE"() {
+    expect:
+    findMethod(CodeSystemController, "getConceptExportXLSX").getAnnotation(Authorized).value() ==
+        [Privilege.CS_TRIAGE] as String[]
+  }
+
+  def "CS_TRIAGE matches the expected dotted-string format"() {
+    expect:
+    Privilege.CS_TRIAGE == "CodeSystem.triage"
+  }
+
+  private static Method findMethod(Class<?> cls, String name) {
+    cls.declaredMethods.find { it.name == name } ?:
+        { throw new AssertionError("Method ${name} not found on ${cls.simpleName}") }()
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/mapset/MapSetDownloadAuthAnnotationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/mapset/MapSetDownloadAuthAnnotationTest.groovy
@@ -1,0 +1,36 @@
+package org.termx.terminology.terminology.mapset
+
+import org.termx.core.auth.Authorized
+import org.termx.terminology.Privilege
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+/**
+ * Verifies that the three MapSet associations-export endpoints are gated by MS_TRIAGE
+ * (per Phase A.2 of the GitHub-style permissions migration).
+ *
+ * Annotation-level test: the auth runtime is exercised by AuthorizationFilterTest;
+ * here we just confirm the wire-up.
+ */
+class MapSetDownloadAuthAnnotationTest extends Specification {
+
+  def "#methodName is gated by MS_TRIAGE"() {
+    expect:
+    findMethod(MapSetController, methodName).getAnnotation(Authorized).value().toList() ==
+        [Privilege.MS_TRIAGE]
+
+    where:
+    methodName << ["exportAssociations", "getAssociationExportCSV", "getAssociationExportXLSX"]
+  }
+
+  def "MS_TRIAGE matches the expected dotted-string format"() {
+    expect:
+    Privilege.MS_TRIAGE == "MapSet.triage"
+  }
+
+  private static Method findMethod(Class<?> cls, String name) {
+    cls.declaredMethods.find { it.name == name } ?:
+        { throw new AssertionError("Method ${name} not found on ${cls.simpleName}") }()
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetDownloadAuthAnnotationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetDownloadAuthAnnotationTest.groovy
@@ -1,0 +1,36 @@
+package org.termx.terminology.terminology.valueset
+
+import org.termx.core.auth.Authorized
+import org.termx.terminology.Privilege
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+/**
+ * Verifies that the three ValueSet expansion-export endpoints are gated by VS_TRIAGE
+ * (per Phase A.2 of the GitHub-style permissions migration).
+ *
+ * Annotation-level test: the auth runtime is exercised by AuthorizationFilterTest;
+ * here we just confirm the wire-up.
+ */
+class ValueSetDownloadAuthAnnotationTest extends Specification {
+
+  def "#methodName is gated by VS_TRIAGE"() {
+    expect:
+    findMethod(ValueSetController, methodName).getAnnotation(Authorized).value().toList() ==
+        [Privilege.VS_TRIAGE]
+
+    where:
+    methodName << ["exportConcepts", "getConceptExportCSV", "getConceptExportXLSX"]
+  }
+
+  def "VS_TRIAGE matches the expected dotted-string format"() {
+    expect:
+    Privilege.VS_TRIAGE == "ValueSet.triage"
+  }
+
+  private static Method findMethod(Class<?> cls, String name) {
+    cls.declaredMethods.find { it.name == name } ?:
+        { throw new AssertionError("Method ${name} not found on ${cls.simpleName}") }()
+  }
+}

--- a/termx-api/src/main/java/org/termx/auth/PrivilegeResource.java
+++ b/termx-api/src/main/java/org/termx/auth/PrivilegeResource.java
@@ -21,6 +21,7 @@ public class PrivilegeResource {
   @Accessors(chain = true)
   public static class PrivilegeResourceActions {
     private boolean view;
+    private boolean triage;
     private boolean edit;
     private boolean publish;
   }

--- a/termx-app/build.gradle.kts
+++ b/termx-app/build.gradle.kts
@@ -130,4 +130,10 @@ tasks.named<JavaExec>("run") {
     if (project.hasProperty("dev")) {
         jvmArgs = (jvmArgs ?: listOf()) + listOf("-Dauth.dev.allowed=true", "-Dmicronaut.environments=dev,local")
     }
+    // QA / migration testing: override the yupi default session's privilege set.
+    // Example: ./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view'
+    // See YupiSessionProvider Javadoc for common preset values.
+    if (project.hasProperty("yupiPrivileges")) {
+        jvmArgs = (jvmArgs ?: listOf()) + listOf("-Dauth.dev.yupi.privileges=${project.property("yupiPrivileges")}")
+    }
 }

--- a/termx-app/src/main/java/org/termx/auth/SessionFilter.java
+++ b/termx-app/src/main/java/org/termx/auth/SessionFilter.java
@@ -57,14 +57,16 @@ public class SessionFilter implements HttpServerFilter {
     return false;
   }
 
-  private void deriveTaskPrivileges(SessionInfo session) {
+  void deriveTaskPrivileges(SessionInfo session) {
     if (session.getPrivileges() == null) {
       return;
     }
     java.util.Set<String> derived = new java.util.HashSet<>(session.getPrivileges());
-    
-    // Keep admin unchanged
-    if (session.hasPrivilege("*.*.*")) {
+
+    // Keep admin unchanged. Use a literal string contains (not hasPrivilege) because
+    // hasPrivilege("*.*.*") matches any 3-part privilege via wildcards, which would
+    // short-circuit derivation for every authenticated user.
+    if (session.getPrivileges().contains("*.*.*")) {
       session.setPrivileges(derived);
       return;
     }
@@ -93,7 +95,9 @@ public class SessionFilter implements HttpServerFilter {
         continue; // Not a resource type we derive from
       }
       
-      if ("edit".equals(action)) {
+      if ("triage".equals(action)) {
+        derived.add(contextType + "#" + resourceId + ".Task.view");
+      } else if ("edit".equals(action)) {
         derived.add(contextType + "#" + resourceId + ".Task.view");
         derived.add(contextType + "#" + resourceId + ".Task.edit");
       } else if ("publish".equals(action)) {

--- a/termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java
+++ b/termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java
@@ -1,23 +1,70 @@
 package org.termx.auth;
 
 import com.kodality.commons.util.JsonUtil;
-import org.termx.core.auth.SessionInfo;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
-import java.util.Set;
 import jakarta.inject.Singleton;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.termx.core.auth.SessionInfo;
 
+/**
+ * Local-dev session provider, activated by {@code auth.dev.allowed=true}.
+ *
+ * <p>By default the yupi session is granted the full set of action wildcards
+ * ({@code *.*.view}, {@code *.*.triage}, {@code *.*.edit}, {@code *.*.publish}),
+ * which is effectively admin-equivalent for the privilege-matching algorithm.
+ *
+ * <p>For QA / migration testing the privilege set can be overridden via the
+ * {@code auth.dev.yupi.privileges} property. The value is a comma-separated
+ * list of dotted privilege strings. Common testing presets:
+ * <ul>
+ *   <li>{@code *.*.*} -- true Admin (short-circuits Task derivation)</li>
+ *   <li>{@code *.*.view} -- view-only across all resources (use to verify
+ *       Phase A Q5: download / comment sections must be hidden)</li>
+ *   <li>{@code *.*.view,*.*.triage} -- view + triage (downloads + comments
+ *       visible, no edit)</li>
+ *   <li>{@code icd-10.CodeSystem.view} -- scoped view-only on a single
+ *       resource</li>
+ * </ul>
+ *
+ * <p>Example: {@code ./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view'}
+ *
+ * <p>Per-request overrides via the {@code Authorization: Bearer yupi<json>}
+ * header still work and take precedence over the configured default.
+ */
 @Requires(property = "auth.dev.allowed", value = StringUtils.TRUE)
 @Slf4j
 @Singleton
 public class YupiSessionProvider extends SessionProvider {
   private static final String BEARER_YUPI = "Bearer yupi";
+  static final Set<String> DEFAULT_PRIVILEGES =
+      Set.of("*.*.view", "*.*.triage", "*.*.edit", "*.*.publish");
+
+  private final Set<String> configuredPrivileges;
+
+  public YupiSessionProvider(
+      @Property(name = "auth.dev.yupi.privileges") @Nullable String configuredPrivileges) {
+    this.configuredPrivileges = parsePrivileges(configuredPrivileges);
+    if (!this.configuredPrivileges.equals(DEFAULT_PRIVILEGES)) {
+      log.info("yupi default session overridden via auth.dev.yupi.privileges: {}",
+          this.configuredPrivileges);
+    }
+  }
 
   @Override
   public int getOrder() {
-    return 10;
+    // Must run before MockSessionProvider (order = 5), which would otherwise
+    // intercept the `Bearer yupi` token, fail to find a matching mock user,
+    // and fall back to its `default-user` (typically `admin` with `*.*.*`).
+    // Yupi is selective (only matches `Bearer yupi*`), so taking priority is safe.
+    return 3;
   }
 
   @Override
@@ -36,7 +83,18 @@ public class YupiSessionProvider extends SessionProvider {
     SessionInfo s = new SessionInfo();
     s.setUsername("yupi");
     s.setLang("en");
-    s.setPrivileges(Set.of("*.*.edit", "*.*.view", "*.*.publish"));
+    s.setPrivileges(configuredPrivileges);
     return s;
+  }
+
+  static Set<String> parsePrivileges(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return DEFAULT_PRIVILEGES;
+    }
+    Set<String> parsed = Arrays.stream(raw.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .collect(Collectors.toCollection(LinkedHashSet::new));
+    return parsed.isEmpty() ? DEFAULT_PRIVILEGES : Set.copyOf(parsed);
   }
 }

--- a/termx-app/src/main/resources/db/changelog/uam/01-privilege-defaults.sql
+++ b/termx-app/src/main/resources/db/changelog/uam/01-privilege-defaults.sql
@@ -42,3 +42,15 @@ select 1;
 --precondition-sql-check expectedResult:'dev' select core.get_setting('core.env');
 insert into uam.privilege_resource(privilege_id, resource_type) select id, 'Admin' from uam.privilege p where p.code = 'guest'
 --
+
+--changeset termx:add_triage_to_editor_publisher
+-- Phase A migration: grant the new `triage` action (downloads + comment access)
+-- to the seeded `editor` and `publisher` privileges. `viewer` is intentionally
+-- left without `triage` to preserve the documented Q5 test target (legacy
+-- view-only users lose downloads / comments).
+update uam.privilege_resource
+set actions = actions || '{"triage": true}'::jsonb
+where privilege_id in (select id from uam.privilege where code in ('editor', 'publisher'))
+  and (actions->>'triage') is distinct from 'true';
+--rollback update uam.privilege_resource set actions = actions - 'triage' where privilege_id in (select id from uam.privilege where code in ('editor', 'publisher'));
+--

--- a/termx-app/src/main/resources/mock/users-demo.json
+++ b/termx-app/src/main/resources/mock/users-demo.json
@@ -7,6 +7,7 @@
     "username": "demo-tm",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.publish",
       "*.CodeSystem.publish",
       "*.ValueSet.publish",
@@ -17,6 +18,7 @@
     "username": "demo-publisher",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.publish",
       "icd-10.CodeSystem.publish",
       "icd-11.CodeSystem.publish",
@@ -28,6 +30,7 @@
     "username": "demo-editor",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.edit",
       "icd-10.CodeSystem.edit",
       "icd-11.CodeSystem.edit",
@@ -39,6 +42,7 @@
     "username": "demo-reviewer",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.edit",
       "icd-10.CodeSystem.edit"
     ]

--- a/termx-app/src/main/resources/mock/users.json
+++ b/termx-app/src/main/resources/mock/users.json
@@ -7,6 +7,7 @@
     "username": "publisher1",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.publish",
       "*.CodeSystem.publish",
       "*.ValueSet.publish",
@@ -17,6 +18,7 @@
     "username": "editor1",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.edit",
       "*.CodeSystem.edit",
       "*.ValueSet.edit",
@@ -27,6 +29,7 @@
     "username": "editor2",
     "privileges": [
       "*.*.view",
+      "*.*.triage",
       "*.Task.edit",
       "icd-10.CodeSystem.edit",
       "disorders.ValueSet.edit"

--- a/termx-app/src/test/groovy/org/termx/auth/SessionFilterTaskDerivationTest.groovy
+++ b/termx-app/src/test/groovy/org/termx/auth/SessionFilterTaskDerivationTest.groovy
@@ -1,0 +1,94 @@
+package org.termx.auth
+
+import org.termx.core.auth.SessionInfo
+import spock.lang.Specification
+
+class SessionFilterTaskDerivationTest extends Specification {
+
+  SessionFilter filter = new SessionFilter([])
+
+  def "triage on CodeSystem derives Task.view"() {
+    given:
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.triage"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    session.privileges.contains("code-system#icd-10.Task.view")
+    !session.privileges.contains("code-system#icd-10.Task.edit")
+    !session.privileges.contains("code-system#icd-10.Task.publish")
+  }
+
+  def "edit on CodeSystem still derives Task.view + Task.edit (Phase A vocabulary unchanged)"() {
+    given:
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.edit"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    session.privileges.contains("code-system#icd-10.Task.view")
+    session.privileges.contains("code-system#icd-10.Task.edit")
+    !session.privileges.contains("code-system#icd-10.Task.publish")
+  }
+
+  def "publish on CodeSystem still derives all three Task privileges"() {
+    given:
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.publish"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    session.privileges.contains("code-system#icd-10.Task.view")
+    session.privileges.contains("code-system#icd-10.Task.edit")
+    session.privileges.contains("code-system#icd-10.Task.publish")
+  }
+
+  def "triage on ValueSet derives value-set Task.view"() {
+    given:
+    def session = new SessionInfo(privileges: ["my-vs.ValueSet.triage"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    session.privileges.contains("value-set#my-vs.Task.view")
+  }
+
+  def "view alone (no triage) does NOT derive Task privileges"() {
+    given:
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.view"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    !session.privileges.any { it.startsWith("code-system#") }
+  }
+
+  def "Admin (*.*.*) short-circuits derivation"() {
+    given:
+    def session = new SessionInfo(privileges: ["*.*.*"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    session.privileges == ["*.*.*"] as Set
+    !session.privileges.any { it.contains("Task.") }
+  }
+
+  def "Admin combined with another privilege still short-circuits derivation"() {
+    given:
+    def session = new SessionInfo(privileges: ["*.*.*", "icd-10.CodeSystem.edit"] as Set)
+
+    when:
+    filter.deriveTaskPrivileges(session)
+
+    then:
+    session.privileges == ["*.*.*", "icd-10.CodeSystem.edit"] as Set
+    !session.privileges.any { it.contains("Task.") }
+  }
+}

--- a/termx-app/src/test/groovy/org/termx/auth/YupiSessionProviderTest.groovy
+++ b/termx-app/src/test/groovy/org/termx/auth/YupiSessionProviderTest.groovy
@@ -1,0 +1,109 @@
+package org.termx.auth
+
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class YupiSessionProviderTest extends Specification {
+
+  def "default privileges are returned when override is null"() {
+    given:
+    def provider = new YupiSessionProvider(null)
+
+    expect:
+    provider.authenticate(yupiRequest()).privileges == YupiSessionProvider.DEFAULT_PRIVILEGES
+  }
+
+  def "default privileges are returned when override is blank or whitespace"() {
+    given:
+    def provider = new YupiSessionProvider(input)
+
+    expect:
+    provider.authenticate(yupiRequest()).privileges == YupiSessionProvider.DEFAULT_PRIVILEGES
+
+    where:
+    input << ["", "   ", "\t", ",,,"]
+  }
+
+  @Unroll
+  def "override #raw produces #expected"() {
+    given:
+    def provider = new YupiSessionProvider(raw)
+
+    expect:
+    provider.authenticate(yupiRequest()).privileges == expected as Set
+
+    where:
+    raw                                  | expected
+    "*.*.view"                           | ["*.*.view"]
+    "*.*.view,*.*.triage"                | ["*.*.view", "*.*.triage"]
+    " *.*.view , *.*.triage "            | ["*.*.view", "*.*.triage"]   // trims whitespace
+    "icd-10.CodeSystem.view"             | ["icd-10.CodeSystem.view"]
+    "*.*.*"                              | ["*.*.*"]
+    "*.*.view,,,*.*.edit"                | ["*.*.view", "*.*.edit"]    // skips empty tokens
+  }
+
+  def "view-only override produces a session that fails the triage check"() {
+    given:
+    def provider = new YupiSessionProvider("*.*.view")
+    def session = provider.authenticate(yupiRequest())
+
+    expect:
+    session.privileges == ["*.*.view"] as Set
+    !session.hasPrivilege("administrative-gender.CodeSystem.triage")
+    !session.hasPrivilege("any-space.Wiki.triage")
+    session.hasPrivilege("administrative-gender.CodeSystem.view")
+  }
+
+  def "view+triage override produces a session that passes the triage check"() {
+    given:
+    def provider = new YupiSessionProvider("*.*.view,*.*.triage")
+    def session = provider.authenticate(yupiRequest())
+
+    expect:
+    session.hasPrivilege("administrative-gender.CodeSystem.view")
+    session.hasPrivilege("administrative-gender.CodeSystem.triage")
+    !session.hasPrivilege("administrative-gender.CodeSystem.edit")
+  }
+
+  def "explicit JSON in Bearer header overrides the configured default"() {
+    given:
+    def provider = new YupiSessionProvider("*.*.view")  // configured = view-only
+    def request = Mock(HttpRequest)
+    def headers = Mock(HttpHeaders)
+    headers.getFirst("Authorization") >>
+        Optional.of('Bearer yupi{"username":"adhoc","privileges":["*.*.publish"]}')
+    request.getHeaders() >> headers
+
+    when:
+    def session = provider.authenticate(request)
+
+    then:
+    session.username == "adhoc"
+    session.privileges == ["*.*.publish"] as Set
+  }
+
+  def "non-yupi authorization header returns null"() {
+    given:
+    def provider = new YupiSessionProvider(null)
+    def request = Mock(HttpRequest)
+    def headers = Mock(HttpHeaders)
+    headers.getFirst("Authorization") >> Optional.of("Bearer some-other-token")
+    request.getHeaders() >> headers
+
+    when:
+    def session = provider.authenticate(request)
+
+    then:
+    session == null
+  }
+
+  private HttpRequest<?> yupiRequest() {
+    def request = Mock(HttpRequest)
+    def headers = Mock(HttpHeaders)
+    headers.getFirst("Authorization") >> Optional.of("Bearer yupi")
+    request.getHeaders() >> headers
+    return request
+  }
+}

--- a/termx-core/src/test/groovy/org/termx/AuthorizationFilterTest.groovy
+++ b/termx-core/src/test/groovy/org/termx/AuthorizationFilterTest.groovy
@@ -19,6 +19,14 @@ class AuthorizationFilterTest extends Specification {
     ['*.CodeSystem.view']                  | ['*.CodeSystem.edit']                  | false
     ['ABS.CodeSystem.edit']                | ['SBA.CodeSystem.edit']                | false
     ['*.CodeSystem.*']                     | ['SBA.CodeSystem.edit']                | true
+    // Phase A: triage is a new, independent action
+    ['*.*.triage']                         | ['*.*.*']                              | true
+    ['*.CodeSystem.triage']                | ['icd-10.CodeSystem.triage']           | true
+    ['icd-10.CodeSystem.triage']           | ['*.*.triage']                         | true
+    ['icd-10.CodeSystem.triage']           | ['*.CodeSystem.*']                     | true
+    ['icd-10.CodeSystem.triage']           | ['icd-10.CodeSystem.view']             | false
+    ['icd-10.CodeSystem.view']             | ['icd-10.CodeSystem.triage']           | false
+    ['icd-10.CodeSystem.triage']           | ['icd-10.CodeSystem.edit']             | false
   }
 
 //  def "privilege resource check works"() {

--- a/uam/build.gradle.kts
+++ b/uam/build.gradle.kts
@@ -8,4 +8,7 @@ dependencies {
     implementation("com.kodality.commons:commons-micronaut:${rootProject.extra["commonsMicronautVersion"]}")
     implementation("com.kodality.commons:commons-micronaut-pg:${rootProject.extra["commonsMicronautVersion"]}")
     implementation("com.kodality.commons:commons-cache:${rootProject.extra["commonsVersion"]}")
+
+    testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")
+    testRuntimeOnly("org.objenesis:objenesis:3.3")
 }

--- a/uam/src/main/java/org/termx/uam/privilege/PrivilegeStore.java
+++ b/uam/src/main/java/org/termx/uam/privilege/PrivilegeStore.java
@@ -69,6 +69,9 @@ public class PrivilegeStore implements PrivilegeDataHandler {
     if (actions.isView()) {
       privileges.add(dottedPrivilege(id, type, "view"));
     }
+    if (actions.isTriage()) {
+      privileges.add(dottedPrivilege(id, type, "triage"));
+    }
     if (actions.isEdit()) {
       privileges.add(dottedPrivilege(id, type, "edit"));
     }

--- a/uam/src/test/groovy/org/termx/uam/privilege/PrivilegeStoreTriageTest.groovy
+++ b/uam/src/test/groovy/org/termx/uam/privilege/PrivilegeStoreTriageTest.groovy
@@ -1,0 +1,100 @@
+package org.termx.uam.privilege
+
+import com.kodality.commons.model.QueryResult
+import jakarta.inject.Provider
+import org.termx.auth.Privilege
+import org.termx.auth.PrivilegeQueryParams
+import org.termx.auth.PrivilegeResource
+import org.termx.auth.PrivilegeResource.PrivilegeResourceActions
+import spock.lang.Specification
+
+class PrivilegeStoreTriageTest extends Specification {
+
+  PrivilegeService privilegeService = Mock(PrivilegeService)
+  Provider<PrivilegeService> provider = { privilegeService } as Provider
+  PrivilegeStore store = new PrivilegeStore(provider)
+
+  private static Privilege priv(String code, PrivilegeResource... resources) {
+    new Privilege(code: code, resources: resources.toList())
+  }
+
+  private static PrivilegeResource res(String type, String id, PrivilegeResourceActions actions) {
+    new PrivilegeResource(resourceType: type, resourceId: id, actions: actions)
+  }
+
+  def "calculate emits *.X.triage when actions.triage is true"() {
+    given:
+    def actions = new PrivilegeResourceActions(view: true, triage: true, edit: false, publish: false)
+    def privilege = priv("triage-role-1", res("CodeSystem", "icd-10", actions))
+
+    when:
+    Set<String> result = store.getPrivileges("triage-role-1")
+
+    then:
+    1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
+    result == ["icd-10.CodeSystem.view", "icd-10.CodeSystem.triage"] as Set
+  }
+
+  def "calculate does not emit triage when actions.triage is false (legacy row)"() {
+    given:
+    def actions = new PrivilegeResourceActions(view: true, triage: false, edit: false, publish: false)
+    def privilege = priv("legacy-view-only", res("CodeSystem", "icd-10", actions))
+
+    when:
+    Set<String> result = store.getPrivileges("legacy-view-only")
+
+    then:
+    1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
+    result == ["icd-10.CodeSystem.view"] as Set
+    !result.any { it.endsWith(".triage") }
+  }
+
+  def "calculate emits all four actions when all flags are true"() {
+    given:
+    def actions = new PrivilegeResourceActions(view: true, triage: true, edit: true, publish: true)
+    def privilege = priv("full-role", res("CodeSystem", "icd-10", actions))
+
+    when:
+    Set<String> result = store.getPrivileges("full-role")
+
+    then:
+    1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
+    result == [
+      "icd-10.CodeSystem.view",
+      "icd-10.CodeSystem.triage",
+      "icd-10.CodeSystem.edit",
+      "icd-10.CodeSystem.publish"
+    ] as Set
+  }
+
+  def "Admin resource type expands to *.*.* regardless of triage flag (#description)"() {
+    given:
+    def privilege = priv("admin-role-${description}", res("Admin", null, actions))
+
+    when:
+    Set<String> result = store.getPrivileges("admin-role-${description}")
+
+    then:
+    1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
+    result == ["*.*.*"] as Set
+
+    where:
+    description       | actions
+    "triage-false"    | new PrivilegeResourceActions(triage: false)
+    "triage-true"     | new PrivilegeResourceActions(triage: true)
+    "all-flags-true"  | new PrivilegeResourceActions(view: true, triage: true, edit: true, publish: true)
+  }
+
+  def "Any resource type emits triage as *.<Type>.triage"() {
+    given:
+    def actions = new PrivilegeResourceActions(triage: true)
+    def privilege = priv("any-triage", res("Any", null, actions))
+
+    when:
+    Set<String> result = store.getPrivileges("any-triage")
+
+    then:
+    1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
+    result == ["*.*.triage"] as Set
+  }
+}

--- a/wiki/src/main/java/org/termx/wiki/Privilege.java
+++ b/wiki/src/main/java/org/termx/wiki/Privilege.java
@@ -2,5 +2,6 @@ package org.termx.wiki;
 
 public interface Privilege {
   String W_VIEW = "Wiki.view";
+  String W_TRIAGE = "Wiki.triage";
   String W_EDIT = "Wiki.edit";
 }

--- a/wiki/src/main/java/org/termx/wiki/pagecomment/PageCommentController.java
+++ b/wiki/src/main/java/org/termx/wiki/pagecomment/PageCommentController.java
@@ -26,14 +26,14 @@ public class PageCommentController {
   private final PageContentService pageContentService;
   private final PageCommentService commentService;
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_TRIAGE)
   @Get("{?params*}")
   public QueryResult<PageComment> query(PageCommentQueryParams params) {
-    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_VIEW, Long::valueOf));
+    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_TRIAGE, Long::valueOf));
     return commentService.query(params);
   }
 
-  @Authorized(Privilege.W_EDIT)
+  @Authorized(Privilege.W_TRIAGE)
   @Post
   public HttpResponse<?> create(@Body @Valid PageComment comment) {
     comment.setId(null);
@@ -43,7 +43,7 @@ public class PageCommentController {
   @Authorized(privilege = Privilege.W_EDIT)
   @Put("/{id}")
   public HttpResponse<?> update(@PathVariable Long id, @Body @Valid PageComment comment) {
-    SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_VIEW);
+    SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_TRIAGE);
     comment.setId(id);
     return HttpResponse.ok(commentService.update(comment));
   }

--- a/wiki/src/test/groovy/org/termx/wiki/pagecomment/PageCommentAuthAnnotationTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/pagecomment/PageCommentAuthAnnotationTest.groovy
@@ -1,0 +1,55 @@
+package org.termx.wiki.pagecomment
+
+import org.termx.core.auth.Authorized
+import org.termx.wiki.Privilege
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+/**
+ * Verifies the comment endpoints are gated correctly per Phase A.2:
+ *  - query (GET) and create (POST) require W_TRIAGE  (positional @Authorized(value=...))
+ *  - update / delete / resolve still require W_EDIT  (named @Authorized(privilege=...))
+ *
+ * Per Q4 of the migration spec, comment read is gated by triage (not view).
+ *
+ * The two annotation styles are tested explicitly:
+ *  - positional: value() populated, privilege() empty
+ *  - named:      value() empty,     privilege() populated
+ */
+class PageCommentAuthAnnotationTest extends Specification {
+
+  def "#methodName uses positional @Authorized(W_TRIAGE)"() {
+    given:
+    def annotation = findMethod(PageCommentController, methodName).getAnnotation(Authorized)
+
+    expect:
+    annotation.value().toList() == [Privilege.W_TRIAGE]
+    annotation.privilege() == ""
+
+    where:
+    methodName << ["query", "create"]
+  }
+
+  def "#methodName uses named @Authorized(privilege=W_EDIT)"() {
+    given:
+    def annotation = findMethod(PageCommentController, methodName).getAnnotation(Authorized)
+
+    expect:
+    annotation.privilege() == Privilege.W_EDIT
+    annotation.value().toList() == []
+
+    where:
+    methodName << ["update", "delete", "resolve"]
+  }
+
+  def "W_TRIAGE matches the expected dotted-string format"() {
+    expect:
+    Privilege.W_TRIAGE == "Wiki.triage"
+  }
+
+  private static Method findMethod(Class<?> cls, String name) {
+    cls.declaredMethods.find { it.name == name } ?:
+        { throw new AssertionError("Method ${name} not found on ${cls.simpleName}") }()
+  }
+}


### PR DESCRIPTION
## Summary

Adds the new `triage` action to the existing `view` / `edit` / `publish` privilege model as an additive, **backward-compatible** Phase A change. `triage` gates:

- Download exports (CodeSystem / ValueSet / MapSet CSV+XLSX)
- Wiki comment read / write / reply
- Per-resource Tasks widget visibility

A future Phase B release will rename `view` → `read` and `publish` → `maintain`. Existing privilege rows in storage continue to work unchanged.

## Locked design decisions (from spec)

| Q | Decision |
|---|---|
| Q1 | Only explicit `export-csv` / `export-xlsx` endpoints get triage gating. FHIR `\$expand` / `\$lookup` stay on `view`. |
| Q2 | UI cascade is one-directional (ticking `triage` auto-ticks `view`); server-side flags are **independent** for flexibility. |
| Q4 | Comment read & author require `triage`; edit / delete / resolve require `edit`. |
| Q5 | `view`-only users explicitly **lose** download + comment access (intended regression). |

## Server changes

### Privilege model
- `PrivilegeResource.PrivilegeResourceActions` — new `triage` boolean field (independent flag)
- `PrivilegeStore.calculate` — emits `*.X.triage` when set
- New per-module constants: `CS_TRIAGE`, `VS_TRIAGE`, `MS_TRIAGE`, `W_TRIAGE`

### Endpoint gating
- `CodeSystemController` lines 325, 331, 340 — 3 export endpoints flipped from `CS_VIEW` → `CS_TRIAGE`
- `ValueSetController` lines 244, 250, 259 — same with `VS_TRIAGE`
- `MapSetController` lines 297, 303, 312 — same with `MS_TRIAGE`
- `PageCommentController` — `query` and `create` flipped to `W_TRIAGE`; inner `checkPermitted(W_VIEW)` on `update` also flipped to `W_TRIAGE`. `update`/`delete`/`resolve` outer guard stays on `W_EDIT`.

### Auth infrastructure
- `SessionFilter.deriveTaskPrivileges` — new `triage → Task.view` derivation rule. **Drive-by bug fix**: the existing `session.hasPrivilege("*.*.*")` short-circuit matched any 3-part privilege via wildcards (silently disabling Task derivation for every authenticated user); now uses literal `getPrivileges().contains("*.*.*")`.
- `YupiSessionProvider` — refactored to inject `auth.dev.yupi.privileges` for QA testing (see README). Order lowered from 10 → 3 to take priority over `MockSessionProvider` (order 5), which would otherwise intercept the `Bearer yupi` token and fall back to admin.

### Database
- New Liquibase changeset `termx:add_triage_to_editor_publisher` updates seeded `editor` and `publisher` privileges to include `triage`. `viewer` remains intentionally without `triage` as the Q5 test target.

## Test coverage

49+ test cases across 7 new/extended classes:

| Test | Cases | What it locks |
|---|---|---|
| `AuthorizationFilterTest` (extended) | 6 new rows | view ↛ triage, triage ↛ view server-side; admin matches via `*.*.*` |
| `PrivilegeStoreTriageTest` (new) | 7 | emit/no-emit/full-row/Admin/Any |
| `SessionFilterTaskDerivationTest` (new) | 7 | triage→Task.view, Admin short-circuit, mixed privs |
| `CodeSystem/ValueSet/MapSetDownloadAuthAnnotationTest` (new) | 12 | `@Authorized(*_TRIAGE)` on all 9 export endpoints |
| `PageCommentAuthAnnotationTest` (new) | 6 | data-driven across positional vs named annotation forms |
| `YupiSessionProviderTest` (new) | 15 | parsing, defaults, view-only fails triage, header overrides |

## Mock + dev infrastructure

- `mock/users.json` + `mock/users-demo.json` — added `*.*.triage` to `editor` / `publisher` / `editor2` / `terminology-manager` / `reviewer`. Viewer + guest left as-is (test targets).
- `README.md` — new "Yupi privilege override" section with troubleshooting checklist
- `uam/build.gradle.kts` — added `byte-buddy` + `objenesis` test deps for Spock to mock concrete classes

## Coordination with frontend

The web side (frontend gates, locales, privilege editor with Triage column, viewMode swaps) ships in the parallel **termx-web** PR. **Both PRs must land in the same release** for wire-format coherence — the dotted privilege strings cross the `/auth/userinfo` boundary and a non-atomic deploy produces silent 403s.

## Test plan

- [x] `./gradlew :termx-core:test :uam:test :termx-app:test :terminology:test :wiki:test` — all 49+ targeted cases pass
- [x] Liquibase changeset applies cleanly on a fresh local DB (`./gradlew :termx-app:processResources` succeeds)
- [x] Manual smoke test with `-PyupiPrivileges='*.*.view'` — confirms downloads + comments + Task widgets are hidden for view-only users
- [x] Manual smoke test with `-PyupiPrivileges='*.*.view,*.*.triage'` — confirms everything reappears
- [ ] Reviewer to verify CI passes