### PR TITLE
feat(privileges): rename view/edit/publish to read/write/maintain (Phase B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,17 @@ In the development mode you can use application without authentication. The appl
 
 ### Yupi privilege override (QA / migration testing)
 
-By default the `yupi` session is granted the full set of action wildcards (`*.*.view`, `*.*.triage`, `*.*.edit`, `*.*.publish`). To test the application as a user with a restricted privilege set -- for example, to verify that a `View`-only user no longer sees CodeSystem download links or wiki comments after the Phase A migration -- override the yupi privilege set with the `-PyupiPrivileges` Gradle flag (or directly with `-Dauth.dev.yupi.privileges=...`).
+By default the `yupi` session is granted the full set of action wildcards (`*.*.read`, `*.*.triage`, `*.*.write`, `*.*.maintain`). To test the application as a user with a restricted privilege set -- for example, to verify that a `View`-only user no longer sees CodeSystem download links or wiki comments after the Phase A migration -- override the yupi privilege set with the `-PyupiPrivileges` Gradle flag (or directly with `-Dauth.dev.yupi.privileges=...`).
 
 ```bash
 # View-only: page renders but downloads + comments are hidden.
-./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view'
+./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.read'
 
 # View + Triage: downloads visible, comment thread visible, no edit.
-./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view,*.*.triage'
+./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.read,*.*.triage'
 
 # Resource-scoped view: only the icd-10 CodeSystem is viewable.
-./gradlew :termx-app:run -Pdev -PyupiPrivileges='icd-10.CodeSystem.view'
+./gradlew :termx-app:run -Pdev -PyupiPrivileges='icd-10.CodeSystem.read'
 ```
 
 The value is a comma-separated list of dotted privilege strings (`{resource}.{type}.{action}`); whitespace and empty tokens are ignored. Common preset values and their expected UI effect are documented in [docs/specification/terminology-server/privileges-migration-guide.md](../docs/specification/terminology-server/privileges-migration-guide.md#qa-testing-with-the-yupi-privilege-override) and inline in [`YupiSessionProvider`](termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java).
@@ -107,7 +107,7 @@ The value is a comma-separated list of dotted privilege strings (`{resource}.{ty
 For ad-hoc per-request overrides without restarting the server, send a JSON-encoded `SessionInfo` directly in the header:
 
 ```
-Authorization: Bearer yupi{"username":"qa","privileges":["*.CodeSystem.view"]}
+Authorization: Bearer yupi{"username":"qa","privileges":["*.CodeSystem.read"]}
 ```
 
 **Frontend note.** The web UI (termx-web) fetches privileges from the backend's `/auth/userinfo` endpoint, so any `auth.dev.yupi.privileges` override is reflected in the UI automatically. After changing the override and restarting the server, **hard-refresh the browser** (Cmd/Ctrl-Shift-R) to drop the cached session. If you still see admin (`*.*.*`) after the refresh, check that:

--- a/docs/features/ecosystem-management.md
+++ b/docs/features/ecosystem-management.md
@@ -12,7 +12,7 @@ Key capabilities:
 
 ## Configuration
 
-No server-side configuration required. Ecosystems are managed through the UI and REST API. Uses Space privileges (`Space.view`, `Space.edit`).
+No server-side configuration required. Ecosystems are managed through the UI and REST API. Uses Space privileges (`Space.read`, `Space.write`).
 
 ## Use-Cases
 
@@ -42,10 +42,10 @@ No server-side configuration required. Ecosystems are managed through the UI and
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| POST | `/ecosystems` | Space.edit | Create ecosystem |
-| PUT | `/ecosystems/{id}` | Space.edit | Update ecosystem |
-| GET | `/ecosystems/{id}` | Space.view | Load ecosystem |
-| GET | `/ecosystems` | Space.view | Search ecosystems (textContains) |
+| POST | `/ecosystems` | Space.write | Create ecosystem |
+| PUT | `/ecosystems/{id}` | Space.write | Update ecosystem |
+| GET | `/ecosystems/{id}` | Space.read | Load ecosystem |
+| GET | `/ecosystems` | Space.read | Search ecosystems (textContains) |
 
 ### Public API (unsecured, under /public prefix)
 

--- a/docs/features/mapset-excel-export.md
+++ b/docs/features/mapset-excel-export.md
@@ -107,9 +107,9 @@ All endpoints are under `/api/ts/map-sets`.
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/{mapSet}/versions/{version}/associations-export{?params*}` | `MapSet.view` | Initiate async export, returns process ID |
-| GET | `/associations-export-csv/result/{lorqueProcessId}` | `MapSet.view` | Download CSV result |
-| GET | `/associations-export-xlsx/result/{lorqueProcessId}` | `MapSet.view` | Download Excel result |
+| GET | `/{mapSet}/versions/{version}/associations-export{?params*}` | `MapSet.read` | Initiate async export, returns process ID |
+| GET | `/associations-export-csv/result/{lorqueProcessId}` | `MapSet.read` | Download CSV result |
+| GET | `/associations-export-xlsx/result/{lorqueProcessId}` | `MapSet.read` | Download Excel result |
 
 ### Initiate Export
 

--- a/docs/features/mock-auth.md
+++ b/docs/features/mock-auth.md
@@ -63,9 +63,9 @@ auth:
 | Profile key | Username     | Privileges                                                                                    |
 |-------------|--------------|-----------------------------------------------------------------------------------------------|
 | `admin`     | `admin`      | `*.*.*` (full access)                                                                         |
-| `publisher` | `publisher1` | `*.*.view`, `*.Task.publish`, `icd-10.CodeSystem.publish`, `disorders.ValueSet.publish`, `icd-snomed.MapSet.publish` |
-| `editor`    | `editor1`    | `*.*.view`, `*.Task.edit`, `icd-10.CodeSystem.edit`, `disorders.ValueSet.edit`                 |
-| `viewer`    | `viewer1`    | `*.*.view`                                                                                    |
+| `publisher` | `publisher1` | `*.*.read`, `*.Task.maintain`, `icd-10.CodeSystem.maintain`, `disorders.ValueSet.maintain`, `icd-snomed.MapSet.maintain` |
+| `editor`    | `editor1`    | `*.*.read`, `*.Task.write`, `icd-10.CodeSystem.write`, `disorders.ValueSet.write`                 |
+| `viewer`    | `viewer1`    | `*.*.read`                                                                                    |
 
 #### mock/users-demo.json (demo/showcase)
 
@@ -106,9 +106,9 @@ Privileges follow the TermX convention: `<resourceId>.<ResourceType>.<action>`.
 
 Examples:
 - `*.*.*` -- full admin access
-- `*.*.view` -- view all resources
-- `*.Task.edit` -- edit tasks across all resources
-- `icd-10.CodeSystem.publish` -- publish access to a specific code system
+- `*.*.read` -- view all resources
+- `*.Task.write` -- edit tasks across all resources
+- `icd-10.CodeSystem.maintain` -- publish access to a specific code system
 
 ## Use-Cases
 
@@ -253,10 +253,10 @@ curl -H "Authorization: Bearer editor" http://localhost:8200/api/tm/tasks
   "editor": {
     "username": "editor1",
     "privileges": [
-      "*.*.view",
-      "*.Task.edit",
-      "icd-10.CodeSystem.edit",
-      "disorders.ValueSet.edit"
+      "*.*.read",
+      "*.Task.write",
+      "icd-10.CodeSystem.write",
+      "disorders.ValueSet.write"
     ]
   }
 }
@@ -275,10 +275,10 @@ Privileges follow the pattern: `<resourceId>.<ResourceType>.<action>`
 **Privilege examples:**
 
 - `*.*.*` - Full admin access to everything
-- `*.*.view` - View access to all resources and types
-- `*.Task.edit` - Edit tasks across all resources
-- `icd-10.CodeSystem.publish` - Publish access to specific code system
-- `disorders.ValueSet.edit` - Edit access to specific value set
+- `*.*.read` - View access to all resources and types
+- `*.Task.write` - Edit tasks across all resources
+- `icd-10.CodeSystem.maintain` - Publish access to specific code system
+- `disorders.ValueSet.write` - Edit access to specific value set
 
 ### SessionInfo
 
@@ -287,7 +287,7 @@ When a request arrives, MockSessionProvider creates a SessionInfo object that is
 ```java
 SessionInfo {
   username: "editor1",
-  privileges: ["*.*.view", "*.Task.edit", "icd-10.CodeSystem.edit"],
+  privileges: ["*.*.read", "*.Task.write", "icd-10.CodeSystem.write"],
   authenticated: true
 }
 ```

--- a/docs/features/snomed-rf2-dry-run-scan.md
+++ b/docs/features/snomed-rf2-dry-run-scan.md
@@ -40,8 +40,8 @@ Uploaded zips are cached in `sys.snomed_rf2_upload`. A scheduled task (`SnomedRF
 
 | Privilege | Used for |
 |-----------|----------|
-| `snomed-ct.CodeSystem.view` | Trigger dry-run scan, view scan-result page, run concept-usage lookup |
-| `snomed-ct.CodeSystem.edit` | *Proceed with import* on the scan-result page (the scan itself only needs `view`) |
+| `snomed-ct.CodeSystem.read` | Trigger dry-run scan, view scan-result page, run concept-usage lookup |
+| `snomed-ct.CodeSystem.write` | *Proceed with import* on the scan-result page (the scan itself only needs `view`) |
 
 ## Use-Cases
 

--- a/docs/features/task-access-control.md
+++ b/docs/features/task-access-control.md
@@ -29,18 +29,18 @@ Task access control is automatically enabled and requires no configuration. It i
 Task access is controlled through **virtual privilege derivation**. When a user logs in, their resource privileges are automatically translated into Task privileges:
 
 **Privilege derivation at login:**
-- Any `*.*.edit` privilege (e.g., `icd-10.CodeSystem.edit`) → automatically derives `code-system#icd-10.Task.view` and `code-system#icd-10.Task.edit`
-- Any `*.*.publish` privilege (e.g., `*.ValueSet.publish`) → automatically derives `value-set#*.Task.view`, `value-set#*.Task.edit`, and `value-set#*.Task.publish`
-- View-only privileges (e.g., `*.CodeSystem.view`) → no Task privileges, task list is hidden
+- Any `*.*.write` privilege (e.g., `icd-10.CodeSystem.write`) → automatically derives `code-system#icd-10.Task.read` and `code-system#icd-10.Task.write`
+- Any `*.*.maintain` privilege (e.g., `*.ValueSet.maintain`) → automatically derives `value-set#*.Task.read`, `value-set#*.Task.write`, and `value-set#*.Task.maintain`
+- View-only privileges (e.g., `*.CodeSystem.read`) → no Task privileges, task list is hidden
 
 **Task visibility rules:**
 
 | User Privilege | Task List Accessible? | Derived Task Privileges | Tasks Visible |
 |----------------|----------------------|------------------------|---------------|
-| `*.CodeSystem.view` only | ❌ No | None | None (no Task privileges derived) |
-| `icd-10.CodeSystem.edit` | ✅ Yes | `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit` | Tasks created by OR assigned to user |
-| `icd-10.CodeSystem.publish` | ✅ Yes | `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit`, `code-system#icd-10.Task.publish` | Tasks created by OR assigned to user, PLUS all tasks with context `code-system\|icd-10` |
-| `*.CodeSystem.publish` | ✅ Yes | `code-system#*.Task.view`, `code-system#*.Task.edit`, `code-system#*.Task.publish` | Tasks created by OR assigned to user, PLUS all CodeSystem tasks |
+| `*.CodeSystem.read` only | ❌ No | None | None (no Task privileges derived) |
+| `icd-10.CodeSystem.write` | ✅ Yes | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write` | Tasks created by OR assigned to user |
+| `icd-10.CodeSystem.maintain` | ✅ Yes | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain` | Tasks created by OR assigned to user, PLUS all tasks with context `code-system\|icd-10` |
+| `*.CodeSystem.maintain` | ✅ Yes | `code-system#*.Task.read`, `code-system#*.Task.write`, `code-system#*.Task.maintain` | Tasks created by OR assigned to user, PLUS all CodeSystem tasks |
 | `*.*.*` (admin) | ✅ Yes | (no derivation) | All tasks (no filter) |
 
 ### Default Role Configuration
@@ -48,9 +48,9 @@ Task access is controlled through **virtual privilege derivation**. When a user 
 Default roles in TermX:
 
 - **admin**: `*.*.*` (all privileges)
-- **publisher**: `*.*.publish` (publish on all resources)
-- **editor**: `*.*.edit` (edit on all resources)
-- **viewer**: `*.*.view` (view-only on all resources)
+- **publisher**: `*.*.maintain` (publish on all resources)
+- **editor**: `*.*.write` (edit on all resources)
+- **viewer**: `*.*.read` (view-only on all resources)
 
 See [Mock Authentication](mock-auth.md) for testing with mock user profiles.
 
@@ -62,7 +62,7 @@ Tasks are linked to resources via context items (e.g., CodeSystem, ValueSet, Map
 2. **Specific resource ID** from task context
 3. **Task ownership** (created by or assigned to user)
 
-Example: A user with privilege `icd-10.CodeSystem.edit` can see tasks with context `{type: "code-system", id: "icd-10"}` that they created or are assigned to.
+Example: A user with privilege `icd-10.CodeSystem.write` can see tasks with context `{type: "code-system", id: "icd-10"}` that they created or are assigned to.
 
 ## Use-Cases
 
@@ -71,9 +71,9 @@ Example: A user with privilege `icd-10.CodeSystem.edit` can see tasks with conte
 **Context:** Junior editor needs to create a review task for ICD-10 concepts they're working on.
 
 **Steps:**
-1. Editor logs in with `icd-10.CodeSystem.edit` privilege
-2. System automatically derives `code-system#icd-10.Task.view` and `code-system#icd-10.Task.edit` privileges at login
-3. Task list becomes visible (gate check passes with Task.view privilege)
+1. Editor logs in with `icd-10.CodeSystem.write` privilege
+2. System automatically derives `code-system#icd-10.Task.read` and `code-system#icd-10.Task.write` privileges at login
+3. Task list becomes visible (gate check passes with Task.read privilege)
 4. Creates task: "Review new diabetes concepts" with context `{type: "code-system", id: "icd-10"}`
 5. Task is assigned to themselves
 6. Query task list - sees the newly created task (creator match)
@@ -86,10 +86,10 @@ Example: A user with privilege `icd-10.CodeSystem.edit` can see tasks with conte
 **Context:** Senior publisher needs to see all review tasks for ICD-10 and ICD-11 code systems.
 
 **Steps:**
-1. Publisher logs in with `icd-10.CodeSystem.publish` and `icd-11.CodeSystem.publish` privileges
+1. Publisher logs in with `icd-10.CodeSystem.maintain` and `icd-11.CodeSystem.maintain` privileges
 2. System automatically derives:
-   - `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit`, `code-system#icd-10.Task.publish`
-   - `code-system#icd-11.Task.view`, `code-system#icd-11.Task.edit`, `code-system#icd-11.Task.publish`
+   - `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain`
+   - `code-system#icd-11.Task.read`, `code-system#icd-11.Task.write`, `code-system#icd-11.Task.maintain`
 3. Query task list - sees:
    - ALL tasks with context `code-system|icd-10` (from all users)
    - ALL tasks with context `code-system|icd-11` (from all users)
@@ -116,9 +116,9 @@ Example: A user with privilege `icd-10.CodeSystem.edit` can see tasks with conte
 **Context:** Read-only user (reports/auditing role) should not see task management interface.
 
 **Steps:**
-1. Viewer logs in with only `*.*.view` privileges (no edit or publish on any resource)
+1. Viewer logs in with only `*.*.read` privileges (no edit or publish on any resource)
 2. System does NOT derive any Task privileges (no resource-specific Task privileges)
-3. Query task list - receives 403 Forbidden (gate check fails - no Task.view privilege)
+3. Query task list - receives 403 Forbidden (gate check fails - no Task.read privilege)
 4. Task menu items hidden in UI (no Task privileges)
 
 **Outcome:** Viewer cannot access task system, maintaining separation of concerns. The resource-specific privilege derivation ensures task access is automatically tied to edit/publish privileges on actual resources.
@@ -128,16 +128,16 @@ Example: A user with privilege `icd-10.CodeSystem.edit` can see tasks with conte
 **Context:** Mixed publisher/editor privileges on different resources.
 
 **Steps:**
-1. User has privileges: `icd-10.CodeSystem.publish`, `disorders.ValueSet.edit`
+1. User has privileges: `icd-10.CodeSystem.maintain`, `disorders.ValueSet.write`
 2. System derives:
-   - `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit`, `code-system#icd-10.Task.publish`
-   - `value-set#disorders.Task.view`, `value-set#disorders.Task.edit`
+   - `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain`
+   - `value-set#disorders.Task.read`, `value-set#disorders.Task.write`
 3. Query task list - sees tasks where:
    - **(Rule A)** Created by user OR assigned to user (any resource)
    - **OR (Rule B)** Context matches `code-system#icd-10` (publisher access, sees all ICD-10 CodeSystem tasks)
 4. Specifically:
    - ✅ Own tasks for disorders ValueSet (creator/assignee match)
-   - ✅ All ICD-10 CodeSystem tasks (publisher context match: `code-system#icd-10.Task.publish`)
+   - ✅ All ICD-10 CodeSystem tasks (publisher context match: `code-system#icd-10.Task.maintain`)
    - ❌ Other users' disorders tasks (no publish access on disorders, not own task)
    - ❌ Other resources' tasks (no access, not own task)
 
@@ -166,7 +166,7 @@ The `visibilityFilter` is automatically applied for non-admin users - it cannot 
 
 - **Admin**: All tasks (no filter)
 - **Publisher/Editor**: Tasks matching visibility filter (own tasks OR publisher context match)
-- **Viewer**: 403 Forbidden (no Task.view privilege)
+- **Viewer**: 403 Forbidden (no Task.read privilege)
 
 ## Testing
 
@@ -214,7 +214,7 @@ curl -H "Authorization: Bearer editor" http://localhost:8200/api/tm/tasks
 # Expected: Task appears in results
 
 # Different editor (no access to icd-10) should NOT see it
-# (if they don't have icd-10.CodeSystem.edit privilege)
+# (if they don't have icd-10.CodeSystem.write privilege)
 
 # Publisher with icd-10 publish access should see it
 curl -H "Authorization: Bearer publisher" http://localhost:8200/api/tm/tasks
@@ -298,20 +298,20 @@ Resource privileges are automatically translated to resource-specific Task privi
 
 | Resource Privilege | Derived Task Privileges | Effect |
 |--------------------|------------------------|--------|
-| `icd-10.CodeSystem.edit` | `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit` | Can access task list, see own ICD-10 tasks |
-| `icd-10.CodeSystem.publish` | `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit`, `code-system#icd-10.Task.publish` | Can access task list, see own tasks + all ICD-10 CodeSystem tasks |
-| `*.CodeSystem.edit` | `code-system#*.Task.view`, `code-system#*.Task.edit` | Can access task list, see own tasks for any CodeSystem |
-| `*.CodeSystem.publish` | `code-system#*.Task.view`, `code-system#*.Task.edit`, `code-system#*.Task.publish` | Can access task list, see own tasks + all CodeSystem tasks |
-| `*.*.view` only | None | Cannot access task list |
+| `icd-10.CodeSystem.write` | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write` | Can access task list, see own ICD-10 tasks |
+| `icd-10.CodeSystem.maintain` | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain` | Can access task list, see own tasks + all ICD-10 CodeSystem tasks |
+| `*.CodeSystem.write` | `code-system#*.Task.read`, `code-system#*.Task.write` | Can access task list, see own tasks for any CodeSystem |
+| `*.CodeSystem.maintain` | `code-system#*.Task.read`, `code-system#*.Task.write`, `code-system#*.Task.maintain` | Can access task list, see own tasks + all CodeSystem tasks |
+| `*.*.read` only | None | Cannot access task list |
 | `*.*.*` (admin) | (no derivation) | Sees all tasks |
 
 **Privilege format:** `contextType#resourceId.Task.action`
 
 Examples:
-- `code-system#icd-10.Task.edit` - ICD-10 CodeSystem task editing
-- `value-set#disorders.Task.publish` - Disorders ValueSet task publishing
-- `map-set#icd10-to-snomed.Task.view` - MapSet task viewing
-- `code-system#*.Task.edit` - All CodeSystem task editing (wildcard)
+- `code-system#icd-10.Task.write` - ICD-10 CodeSystem task editing
+- `value-set#disorders.Task.maintain` - Disorders ValueSet task publishing
+- `map-set#icd10-to-snomed.Task.read` - MapSet task viewing
+- `code-system#*.Task.write` - All CodeSystem task editing (wildcard)
 
 ### TaskSearchParams (Backend)
 
@@ -336,12 +336,12 @@ These parameters are mapped from `TaskQueryParams` by the controller after apply
 flowchart TD
     Login[User Login] --> SessionProvider[SessionProvider]
     SessionProvider --> DerivePrivs[deriveTaskPrivileges]
-    DerivePrivs -->|*.*.edit or *.*.publish| AddTaskPrivs[Add *.Task.view/edit/publish]
+    DerivePrivs -->|*.*.write or *.*.maintain| AddTaskPrivs[Add *.Task.read/edit/publish]
     AddTaskPrivs --> SessionInfo[SessionInfo with derived privileges]
     
-    Request[API Request] --> Auth[@Authorized Task.view]
-    Auth -->|No Task.view| Forbidden[403 Forbidden]
-    Auth -->|Has Task.view| Controller[TaskController]
+    Request[API Request] --> Auth[@Authorized Task.read]
+    Auth -->|No Task.read| Forbidden[403 Forbidden]
+    Auth -->|Has Task.read| Controller[TaskController]
     
     Controller --> CheckAdmin{Is Admin?}
     CheckAdmin -->|Yes| AllTasks[Query All Tasks]
@@ -364,7 +364,7 @@ flowchart TD
 **Privilege resolution flow:**
 
 1. **Login**: SessionFilter calls `deriveTaskPrivileges()` - resource privileges derive resource-specific Task privileges
-2. **Request arrives**: `@Authorized(privilege = Privilege.T_VIEW)` checks for any Task.view privilege (gate check)
+2. **Request arrives**: `@Authorized(privilege = Privilege.T_VIEW)` checks for any Task.read privilege (gate check)
 3. **Controller logic**:
    - If admin (`*.*.*`): no filter
    - Otherwise: build `TaskVisibilityFilter` with username + publisher contexts extracted from hash-format privileges
@@ -380,7 +380,7 @@ SELECT * FROM taskforge.task t
 WHERE (
   -- Rule A: Own tasks
   (t.created_by = ? OR t.assignee = ?)
-  -- Rule B: Publisher context match (from code-system#icd-10.Task.publish privileges)
+  -- Rule B: Publisher context match (from code-system#icd-10.Task.maintain privileges)
   OR EXISTS (
     SELECT 1 FROM jsonb_array_elements(t.context) ctx
     WHERE (ctx->>'type', ctx->>'id') IN (
@@ -430,12 +430,12 @@ private void deriveTaskPrivileges(SessionInfo session) {
         if (contextType == null) continue;
         
         if ("edit".equals(action)) {
-            derived.add(contextType + "#" + resourceId + ".Task.view");
-            derived.add(contextType + "#" + resourceId + ".Task.edit");
+            derived.add(contextType + "#" + resourceId + ".Task.read");
+            derived.add(contextType + "#" + resourceId + ".Task.write");
         } else if ("publish".equals(action)) {
-            derived.add(contextType + "#" + resourceId + ".Task.view");
-            derived.add(contextType + "#" + resourceId + ".Task.edit");
-            derived.add(contextType + "#" + resourceId + ".Task.publish");
+            derived.add(contextType + "#" + resourceId + ".Task.read");
+            derived.add(contextType + "#" + resourceId + ".Task.write");
+            derived.add(contextType + "#" + resourceId + ".Task.maintain");
         }
     }
     
@@ -474,11 +474,11 @@ private List<String> getPermittedContexts(SessionInfo session, String action) {
 }
 
 private List<String> getPermittedResourceIds(SessionInfo session, String contextType, String action) {
-    // Check for wildcard: code-system#*.Task.publish
+    // Check for wildcard: code-system#*.Task.maintain
     if (session.hasPrivilege(contextType + "#*.Task." + action)) {
         return null; // all resources
     }
-    // Extract IDs from privileges like code-system#icd-10.Task.publish
+    // Extract IDs from privileges like code-system#icd-10.Task.maintain
     String prefix = contextType + "#";
     String suffix = ".Task." + action;
     return session.getPrivileges().stream()
@@ -510,10 +510,10 @@ Task context items link tasks to resources:
 
 | Context Type | Resource | Privilege Pattern |
 |--------------|----------|-------------------|
-| `code-system` | CodeSystem | `<resourceId>.CodeSystem.edit/publish` |
-| `value-set` | ValueSet | `<resourceId>.ValueSet.edit/publish` |
-| `map-set` | MapSet | `<resourceId>.MapSet.edit/publish` |
-| `wiki` | Wiki space | `<resourceId>.Wiki.edit/publish` |
+| `code-system` | CodeSystem | `<resourceId>.CodeSystem.write/publish` |
+| `value-set` | ValueSet | `<resourceId>.ValueSet.write/publish` |
+| `map-set` | MapSet | `<resourceId>.MapSet.write/publish` |
+| `wiki` | Wiki space | `<resourceId>.Wiki.write/publish` |
 
 The system extracts resource IDs from task context and checks user privileges against those specific resources.
 

--- a/docs/features/task-management.md
+++ b/docs/features/task-management.md
@@ -104,14 +104,14 @@ No environment variables are required. TaskForge uses the main application datab
 **Context:** Organization has editors who should only see their own tasks, not all tasks in the system.
 
 **Steps:**
-1. Configure user with `*.CodeSystem.edit` privilege (not publish)
-2. User logs in - system automatically derives `code-system#*.Task.view` and `code-system#*.Task.edit` privileges (resource-specific)
-3. User navigates to task list (now accessible with derived Task.view privilege)
+1. Configure user with `*.CodeSystem.write` privilege (not publish)
+2. User logs in - system automatically derives `code-system#*.Task.read` and `code-system#*.Task.write` privileges (resource-specific)
+3. User navigates to task list (now accessible with derived Task.read privilege)
 4. System automatically filters to show only tasks:
    - Created by the user OR assigned to the user
-5. User with `icd-10.CodeSystem.publish` sees:
+5. User with `icd-10.CodeSystem.maintain` sees:
    - Tasks created by OR assigned to them (any resource)
-   - PLUS all ICD-10 CodeSystem tasks (publisher oversight via `code-system#icd-10.Task.publish`)
+   - PLUS all ICD-10 CodeSystem tasks (publisher oversight via `code-system#icd-10.Task.maintain`)
 
 **Outcome:** Users see only relevant tasks via automatic resource-specific privilege derivation and OR-based filtering, reducing clutter and protecting sensitive information.
 
@@ -123,22 +123,22 @@ All endpoints are under `/api/tm`.
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/tasks{?params*}` | Task.view | Query tasks (privilege-filtered) |
-| GET | `/tasks/{number}` | Task.view | Load single task by number |
-| POST | `/tasks` | Task.edit | Create task |
-| PUT | `/tasks/{number}` | Task.edit | Update task |
-| PATCH | `/tasks/{number}` | Task.edit | Patch individual fields |
-| POST | `/tasks/{number}/opened` | Task.view | Log task opened (read log) |
-| POST | `/tasks/{number}/activities` | Task.edit | Create activity (comment) |
-| PUT | `/tasks/{number}/activities/{id}` | Task.edit | Update activity |
-| DELETE | `/tasks/{number}/activities/{id}` | Task.edit | Cancel activity |
+| GET | `/tasks{?params*}` | Task.read | Query tasks (privilege-filtered) |
+| GET | `/tasks/{number}` | Task.read | Load single task by number |
+| POST | `/tasks` | Task.write | Create task |
+| PUT | `/tasks/{number}` | Task.write | Update task |
+| PATCH | `/tasks/{number}` | Task.write | Patch individual fields |
+| POST | `/tasks/{number}/opened` | Task.read | Log task opened (read log) |
+| POST | `/tasks/{number}/activities` | Task.write | Create activity (comment) |
+| PUT | `/tasks/{number}/activities/{id}` | Task.write | Update activity |
+| DELETE | `/tasks/{number}/activities/{id}` | Task.write | Cancel activity |
 
 ### Projects & Workflows
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/projects` | Task.view | List all projects |
-| GET | `/projects/{code}/workflows` | Task.view | List workflows for a project |
+| GET | `/projects` | Task.read | List all projects |
+| GET | `/projects/{code}/workflows` | Task.read | List workflows for a project |
 
 ### Query Parameters
 
@@ -158,18 +158,18 @@ Common query parameters for `/tasks{?params*}`:
 ### Privilege-Based Filtering
 
 **Resource-specific privilege derivation at login:**
-- Any resource edit privilege (e.g., `icd-10.CodeSystem.edit`) → derives `code-system#icd-10.Task.view` and `code-system#icd-10.Task.edit`
-- Any resource publish privilege (e.g., `*.ValueSet.publish`) → derives `value-set#*.Task.view`, `value-set#*.Task.edit`, and `value-set#*.Task.publish`
+- Any resource edit privilege (e.g., `icd-10.CodeSystem.write`) → derives `code-system#icd-10.Task.read` and `code-system#icd-10.Task.write`
+- Any resource publish privilege (e.g., `*.ValueSet.maintain`) → derives `value-set#*.Task.read`, `value-set#*.Task.write`, and `value-set#*.Task.maintain`
 - View-only privileges → no Task privileges (task list hidden)
 
 **Task visibility rules (OR logic):**
 
 | User Privilege | Task List Accessible? | Derived Privileges | Tasks Visible |
 |----------------|----------------------|-------------------|---------------|
-| `*.CodeSystem.view` only | ❌ No | None | None (no Task privileges) |
-| `icd-10.CodeSystem.edit` | ✅ Yes | `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit` | Tasks created by OR assigned to user |
-| `icd-10.CodeSystem.publish` | ✅ Yes | `code-system#icd-10.Task.view`, `code-system#icd-10.Task.edit`, `code-system#icd-10.Task.publish` | (Created by OR assigned to user) OR (context = code-system\|icd-10) |
-| `*.CodeSystem.publish` | ✅ Yes | `code-system#*.Task.view`, `code-system#*.Task.edit`, `code-system#*.Task.publish` | (Created by OR assigned to user) OR (all CodeSystem contexts) |
+| `*.CodeSystem.read` only | ❌ No | None | None (no Task privileges) |
+| `icd-10.CodeSystem.write` | ✅ Yes | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write` | Tasks created by OR assigned to user |
+| `icd-10.CodeSystem.maintain` | ✅ Yes | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain` | (Created by OR assigned to user) OR (context = code-system\|icd-10) |
+| `*.CodeSystem.maintain` | ✅ Yes | `code-system#*.Task.read`, `code-system#*.Task.write`, `code-system#*.Task.maintain` | (Created by OR assigned to user) OR (all CodeSystem contexts) |
 | `*.*.*` (admin) | ✅ Yes | (no derivation) | All tasks (no filter) |
 
 ## Testing
@@ -365,11 +365,11 @@ flowchart TD
 ```mermaid
 flowchart TD
     Login[User Login] --> DerivePrivs[Derive Task Privileges]
-    DerivePrivs -->|*.*.edit or *.*.publish| TaskPrivs[*.Task.view/edit/publish]
+    DerivePrivs -->|*.*.write or *.*.maintain| TaskPrivs[*.Task.read/edit/publish]
     
-    Request[API Request] --> Auth[@Authorized Task.view]
-    Auth -->|No Task.view| Forbidden[403 Forbidden]
-    Auth -->|Has Task.view| Controller[TaskController]
+    Request[API Request] --> Auth[@Authorized Task.read]
+    Auth -->|No Task.read| Forbidden[403 Forbidden]
+    Auth -->|Has Task.read| Controller[TaskController]
     
     Controller --> CheckAdmin{Is Admin?}
     CheckAdmin -->|Yes| AllTasks[No Filter]
@@ -392,25 +392,25 @@ Task privileges are automatically derived from resource privileges at login usin
 | Resource Privilege | Derived Task Privileges | Tasks Visible |
 |--------------------|------------------------|---------------|
 | `*.*.*` | (no derivation) | All tasks |
-| `icd-10.CodeSystem.publish` | `code-system#icd-10.Task.view/edit/publish` | Own tasks + ICD-10 CodeSystem tasks |
-| `*.CodeSystem.publish` | `code-system#*.Task.view/edit/publish` | Own tasks + all CodeSystem tasks |
-| `icd-10.CodeSystem.edit` | `code-system#icd-10.Task.view/edit` | Own tasks only |
-| `*.*.view` only | None | No task access (403) |
+| `icd-10.CodeSystem.maintain` | `code-system#icd-10.Task.read/edit/publish` | Own tasks + ICD-10 CodeSystem tasks |
+| `*.CodeSystem.maintain` | `code-system#*.Task.read/edit/publish` | Own tasks + all CodeSystem tasks |
+| `icd-10.CodeSystem.write` | `code-system#icd-10.Task.read/edit` | Own tasks only |
+| `*.*.read` only | None | No task access (403) |
 
 **Privilege format:** `contextType#resourceId.Task.action`
 
 Examples:
-- `code-system#icd-10.Task.edit`
-- `value-set#disorders.Task.publish`
-- `code-system#*.Task.edit` (wildcard)
+- `code-system#icd-10.Task.write`
+- `value-set#disorders.Task.maintain`
+- `code-system#*.Task.write` (wildcard)
 
 **How filtering works:**
 
 1. **Login** -- `SessionFilter.deriveTaskPrivileges()` adds resource-specific Task privileges
-2. **Gate check** -- `@Authorized(privilege = Privilege.T_VIEW)` verifies any Task.view privilege exists
+2. **Gate check** -- `@Authorized(privilege = Privilege.T_VIEW)` verifies any Task.read privilege exists
 3. **Visibility filter** -- Controller builds `TaskVisibilityFilter` with:
    - `username` for creator/assignee matching
-   - `publisherContexts` extracted from hash-format privileges (e.g., `code-system#icd-10.Task.publish` → `code-system|icd-10`)
+   - `publisherContexts` extracted from hash-format privileges (e.g., `code-system#icd-10.Task.maintain` → `code-system|icd-10`)
 4. **SQL filtering** -- Repository applies OR logic: `(own tasks) OR (publisher context match)`
 
 Single task load applies the same logic: admins see all, others see tasks matching own OR publisher criteria.

--- a/docs/features/terminology-server-ecosystem-export.md
+++ b/docs/features/terminology-server-ecosystem-export.md
@@ -17,7 +17,7 @@ This feature allows you to export your TermX terminology servers in the **FHIR T
 
 **GET** `/api/terminology-servers/export/ecosystem`
 
-**Authorization:** `TerminologyServer.view` privilege required
+**Authorization:** `TerminologyServer.read` privilege required
 
 **Query Parameters:**
 - `download` (optional, boolean) - If `true`, returns response as downloadable file
@@ -234,7 +234,7 @@ Support multiple FHIR versions per server:
 - Only `access_info` text is included (no credentials)
 
 **Access Control:**
-- Requires `TerminologyServer.view` privilege
+- Requires `TerminologyServer.read` privilege
 - Admin users have access by default
 - Configure additional users in `mock/users.json`
 
@@ -255,7 +255,7 @@ curl http://localhost:8200/api/terminology-servers
 ```yaml
 auth:
   mock:
-    default-user: admin  # Required for TerminologyServer.view
+    default-user: admin  # Required for TerminologyServer.read
 ```
 
 ---

--- a/docs/features/valueset-excel-export-optimize.md
+++ b/docs/features/valueset-excel-export-optimize.md
@@ -120,17 +120,17 @@ Export endpoints are unchanged. Optimizations are transparent to API consumers.
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/value-sets/{id}/versions/{version}/expansion-export{?params*}` | `ValueSet.view` | Initiate export, returns process ID |
-| GET | `/expansion-export-csv/result/{processId}` | `ValueSet.view` | Download CSV |
-| GET | `/expansion-export-xlsx/result/{processId}` | `ValueSet.view` | Download Excel |
+| GET | `/value-sets/{id}/versions/{version}/expansion-export{?params*}` | `ValueSet.read` | Initiate export, returns process ID |
+| GET | `/expansion-export-csv/result/{processId}` | `ValueSet.read` | Download CSV |
+| GET | `/expansion-export-xlsx/result/{processId}` | `ValueSet.read` | Download Excel |
 
 ### CodeSystem Export
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/code-systems/{id}/versions/{version}/concepts-export{?params*}` | `CodeSystem.view` | Initiate export |
-| GET | `/concepts-export-csv/result/{processId}` | `CodeSystem.view` | Download CSV |
-| GET | `/concepts-export-xlsx/result/{processId}` | `CodeSystem.view` | Download Excel |
+| GET | `/code-systems/{id}/versions/{version}/concepts-export{?params*}` | `CodeSystem.read` | Initiate export |
+| GET | `/concepts-export-csv/result/{processId}` | `CodeSystem.read` | Download CSV |
+| GET | `/concepts-export-xlsx/result/{processId}` | `CodeSystem.read` | Download Excel |
 
 ## Testing
 

--- a/docs/release-notes/ecosystem-management.md
+++ b/docs/release-notes/ecosystem-management.md
@@ -62,5 +62,5 @@ Added Ecosystem Management for defining FHIR TX Ecosystem configurations through
 - Existing Terminology Server data is preserved; all new columns are nullable with sensible defaults
 - The 5 authoritative resource lists are stored as `jsonb` arrays on `sys.terminology_server`
 - Backend API path changed from `/terminology-servers` to `/servers`
-- Frontend privilege strings remain `*.TerminologyServer.edit/view` (backend unchanged)
+- Frontend privilege strings remain `*.TerminologyServer.write/view` (backend unchanged)
 - HTX Router: optionally add `"ecosystem_url": "https://termx.example.org/public/ecosystems/{code}"` to ecosystem.json

--- a/edition-est/src/main/java/org/termx/editionest/Privilege.java
+++ b/edition-est/src/main/java/org/termx/editionest/Privilege.java
@@ -1,5 +1,5 @@
 package org.termx.editionest;
 
 public interface Privilege {
-  String CS_EDIT = "*.CodeSystem.edit";
+  String CS_WRITE = "*.CodeSystem.write";
 }

--- a/edition-est/src/main/java/org/termx/editionest/atcest/AtcEstController.java
+++ b/edition-est/src/main/java/org/termx/editionest/atcest/AtcEstController.java
@@ -28,7 +28,7 @@ public class AtcEstController {
 
   private static final String JOB_TYPE = "ATC-est";
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post("/import")
   public JobLogResponse importAtcEst(@NonNull @QueryValue String url, @Body @Valid @NonNull CodeSystemImportConfiguration configuration) {
     JobLogResponse jobLogResponse = importLogger.createJob(configuration.getPublisher(), JOB_TYPE);

--- a/edition-est/src/main/java/org/termx/editionest/icd10est/Icd10EstController.java
+++ b/edition-est/src/main/java/org/termx/editionest/icd10est/Icd10EstController.java
@@ -28,7 +28,7 @@ public class Icd10EstController {
 
   private static final String JOB_TYPE = "RHK-10";
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post("/import")
   public JobLogResponse importIcd10Est(@NonNull @QueryValue String url, @Body @Valid @NonNull CodeSystemImportConfiguration configuration) {
     JobLogResponse jobLogResponse = importLogger.createJob(configuration.getPublisher(), JOB_TYPE);

--- a/edition-int/src/main/java/org/termx/editionint/Privilege.java
+++ b/edition-int/src/main/java/org/termx/editionint/Privilege.java
@@ -1,5 +1,5 @@
 package org.termx.editionint;
 
 public interface Privilege {
-  String CS_EDIT = "*.CodeSystem.edit";
+  String CS_WRITE = "*.CodeSystem.write";
 }

--- a/edition-int/src/main/java/org/termx/editionint/atc/AtcController.java
+++ b/edition-int/src/main/java/org/termx/editionint/atc/AtcController.java
@@ -28,7 +28,7 @@ public class AtcController {
 
   private static final String JOB_TYPE = "ATC";
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post("/import")
   public JobLogResponse importAtc(@Body @Valid @NonNull CodeSystemImportConfiguration configuration) {
     JobLogResponse jobLogResponse = importLogger.createJob(configuration.getPublisher(), JOB_TYPE);

--- a/edition-int/src/main/java/org/termx/editionint/icd10/Icd10Controller.java
+++ b/edition-int/src/main/java/org/termx/editionint/icd10/Icd10Controller.java
@@ -28,7 +28,7 @@ public class Icd10Controller {
 
   private static final String JOB_TYPE = "ICD-10";
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post("/import")
   public JobLogResponse importIcd10(@NonNull @QueryValue String url, @Body @Valid @NonNull CodeSystemImportConfiguration configuration) {
     JobLogResponse jobLogResponse = importLogger.createJob(configuration.getPublisher(), JOB_TYPE);

--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java
@@ -30,7 +30,7 @@ public class LoincController {
   private final LoincService loincService;
   private final ImportLogger importLogger;
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA)
   public JobLogResponse process(
       @Nullable Publisher<CompletedFileUpload> partsFile,

--- a/edition-int/src/main/java/org/termx/editionint/orphanet/OrphanetController.java
+++ b/edition-int/src/main/java/org/termx/editionint/orphanet/OrphanetController.java
@@ -35,7 +35,7 @@ public class OrphanetController {
 
   private static final String JOB_TYPE = "Orphanet";
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA)
   public JobLogResponse importIcd10(@Nullable Publisher<CompletedFileUpload> file, @Part("request") String request) {
     CodeSystemImportConfiguration configuration = JsonUtil.fromJson(request, CodeSystemImportConfiguration.class);

--- a/edition-uzb/src/main/java/org/termx/editionuzb/Privilege.java
+++ b/edition-uzb/src/main/java/org/termx/editionuzb/Privilege.java
@@ -1,5 +1,5 @@
 package org.termx.editionuzb;
 
 public interface Privilege {
-  String CS_EDIT = "*.CodeSystem.edit";
+  String CS_WRITE = "*.CodeSystem.write";
 }

--- a/edition-uzb/src/main/java/org/termx/editionuzb/ichiuz/IchiUzController.java
+++ b/edition-uzb/src/main/java/org/termx/editionuzb/ichiuz/IchiUzController.java
@@ -29,7 +29,7 @@ public class IchiUzController {
 
   private static final String JOB_TYPE = "ICHI";
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post("/import")
   public JobLogResponse importIchiUz(@NonNull @QueryValue String url, @Body @Valid @NonNull CodeSystemImportConfiguration configuration) {
     JobLogResponse jobLogResponse = importLogger.createJob(configuration.getPublisher(), JOB_TYPE);

--- a/implementation-guide/src/main/java/org/termx/implementationguide/Privilege.java
+++ b/implementation-guide/src/main/java/org/termx/implementationguide/Privilege.java
@@ -1,7 +1,7 @@
 package org.termx.implementationguide;
 
 public interface Privilege {
-  String IG_VIEW = "ImplementationGuide.view";
-  String IG_EDIT = "ImplementationGuide.edit";
-  String IG_PUBLISH = "ImplementationGuide.publish";
+  String IG_READ = "ImplementationGuide.read";
+  String IG_WRITE = "ImplementationGuide.write";
+  String IG_MAINTAIN = "ImplementationGuide.maintain";
 }

--- a/implementation-guide/src/main/java/org/termx/implementationguide/github/ImplementationGuideGithubController.java
+++ b/implementation-guide/src/main/java/org/termx/implementationguide/github/ImplementationGuideGithubController.java
@@ -20,45 +20,45 @@ import lombok.RequiredArgsConstructor;
 public class ImplementationGuideGithubController {
   private final ImplementationGuideGithubService service;
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Post("/authenticate")
   public SpaceGithubAuthResult authenticate(@PathVariable String ig, @PathVariable String version, @Body IgGithubAuthRequest r) {
     return service.authenticate(ig, version, r.returnUrl);
   }
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get("/status")
   public IgGithubStatus prepareFiles(@PathVariable String ig, @PathVariable String version) {
     return service.status(ig, version);
   }
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get("/branches")
   public List<String> listBranches(@PathVariable String ig, @PathVariable String version) {
     return service.listBranches(ig, version);
   }
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get("/diff")
   public GithubDiff diff(@PathVariable String ig, @PathVariable String version, @QueryValue String file) {
     return service.diff(ig, version, file);
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/push")
   public HttpResponse<?> push(@PathVariable String ig, @PathVariable String version, @Body IgGithubCommitRequest req) {
     service.push(ig, version, req.message);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/ig-initialize")
   public HttpResponse<?> initIg(@PathVariable String ig, @PathVariable String version) {
     service.initIg(ig, version);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/create-branch")
   public HttpResponse<?> createBranch(@PathVariable String ig, @PathVariable String version, @Body IgGithubCreateBranchRequest req) {
     service.createBranch(ig, version, req.baseBranch);

--- a/implementation-guide/src/main/java/org/termx/implementationguide/ig/ImplementationGuideController.java
+++ b/implementation-guide/src/main/java/org/termx/implementationguide/ig/ImplementationGuideController.java
@@ -38,28 +38,28 @@ public class ImplementationGuideController {
   private final ImplementationGuideVersionService igVersionService;
   private final ImplementationGuideProvenanceService provenanceService;
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get(uri = "{?params*}")
   public QueryResult<ImplementationGuide> query(ImplementationGuideQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.IG_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.IG_READ));
     return igService.query(params);
   }
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get(uri = "/{ig}")
   public ImplementationGuide load(@PathVariable String ig) {
     return igService.load(ig).orElseThrow(() -> new NotFoundException("ImplementationGuide not found: " + ig));
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/transaction")
   public HttpResponse<?> save(@Body @Valid ImplementationGuideTransactionRequest request) {
-    SessionStore.require().checkPermitted(request.getImplementationGuide().getId(), Privilege.IG_EDIT);
+    SessionStore.require().checkPermitted(request.getImplementationGuide().getId(), Privilege.IG_WRITE);
     provenanceService.provenanceImplementationGuideTransactionRequest("save", request, () -> igService.save(request));
     return HttpResponse.created(request.getImplementationGuide());
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post(uri = "/{ig}/change-id")
   public HttpResponse<?> changeId(@PathVariable String ig, @Valid @Body Map<String, String> body) {
     String newId = body.get("id");
@@ -68,7 +68,7 @@ public class ImplementationGuideController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.IG_PUBLISH)
+  @Authorized(Privilege.IG_MAINTAIN)
   @Delete(uri = "/{ig}")
   public HttpResponse<?> delete(@PathVariable String ig) {
     igService.cancel(ig);
@@ -79,21 +79,21 @@ public class ImplementationGuideController {
 
   //----------------ImplementationGuide Version----------------
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get(uri = "/{ig}/versions{?params*}")
   public QueryResult<ImplementationGuideVersion> queryVersions(@PathVariable String ig, ImplementationGuideVersionQueryParams params) {
-    params.setPermittedImplementationGuideIds(SessionStore.require().getPermittedResourceIds(Privilege.IG_VIEW));
+    params.setPermittedImplementationGuideIds(SessionStore.require().getPermittedResourceIds(Privilege.IG_READ));
     params.setImplementationGuideIds(ig);
     return igVersionService.query(params);
   }
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get(uri = "/{ig}/versions/{version}")
   public ImplementationGuideVersion getVersion(@PathVariable String ig, @PathVariable String version) {
     return igVersionService.load(ig, version).orElseThrow(() -> new NotFoundException("ImplementationGuide version not found: " + ig + "|" + version));
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post(uri = "/{ig}/versions")
   public HttpResponse<?> createVersion(@PathVariable String ig, @Body @Valid ImplementationGuideVersion igVersion) {
     igVersion.setId(null);
@@ -102,7 +102,7 @@ public class ImplementationGuideController {
     return HttpResponse.created(igVersion);
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Put(uri = "/{ig}/versions/{version}")
   public HttpResponse<?> updateVersion(@PathVariable String ig, @PathVariable String version,
                                                  @Body @Valid ImplementationGuideVersion igVersion) {
@@ -112,54 +112,54 @@ public class ImplementationGuideController {
     return HttpResponse.created(igVersion);
   }
 
-  @Authorized(Privilege.IG_PUBLISH)
+  @Authorized(Privilege.IG_MAINTAIN)
   @Post(uri = "/{ig}/versions/{version}/activate")
   public HttpResponse<?> activateVersion(@PathVariable String ig, @PathVariable String version) {
     provenanceService.provenanceImplementationGuideVersion("activate", ig, version, () -> igVersionService.changeStatus(ig, version, PublicationStatus.active));
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.IG_PUBLISH)
+  @Authorized(Privilege.IG_MAINTAIN)
   @Post(uri = "/{ig}/versions/{version}/retire")
   public HttpResponse<?> retireVersion(@PathVariable String ig, @PathVariable String version) {
     provenanceService.provenanceImplementationGuideVersion("retire", ig, version, () -> igVersionService.changeStatus(ig, version, PublicationStatus.retired));
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.IG_PUBLISH)
+  @Authorized(Privilege.IG_MAINTAIN)
   @Post(uri = "/{ig}/versions/{version}/draft")
   public HttpResponse<?> saveAsDraftVersion(@PathVariable String ig, @PathVariable String version) {
     provenanceService.provenanceImplementationGuideVersion("save", ig, version, () -> igVersionService.changeStatus(ig, version, PublicationStatus.draft));
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/{ig}/versions/{version}/groups")
   public HttpResponse<?> saveVersionGroups(@PathVariable String ig, @PathVariable String version, @Body List<ImplementationGuideGroup> groups) {
     provenanceService.provenanceImplementationGuideVersion("save-groups", ig, version, () -> igVersionService.saveGroups(ig, version, groups));
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Get("/{ig}/versions/{version}/resources")
   public List<ImplementationGuideResource> loadVersionResources(@PathVariable String ig, @PathVariable String version) {
     return igVersionService.loadResources(ig, version);
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/{ig}/versions/{version}/resources")
   public HttpResponse<?> saveVersionResources(@PathVariable String ig, @PathVariable String version, @Body List<ImplementationGuideResource> resources) {
     provenanceService.provenanceImplementationGuideVersion("save-resources", ig, version, () -> igVersionService.saveResources(ig, version, resources));
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Get("/{ig}/versions/{version}/pages")
   public List<ImplementationGuidePage> loadVersionPages(@PathVariable String ig, @PathVariable String version) {
     return igVersionService.loadPages(ig, version);
   }
 
-  @Authorized(Privilege.IG_EDIT)
+  @Authorized(Privilege.IG_WRITE)
   @Post("/{ig}/versions/{version}/pages")
   public HttpResponse<?> saveVersionPages(@PathVariable String ig, @PathVariable String version, @Body List<ImplementationGuidePage> pages) {
     provenanceService.provenanceImplementationGuideVersion("save-resources", ig, version, () -> igVersionService.savePages(ig, version, pages));
@@ -169,7 +169,7 @@ public class ImplementationGuideController {
 
   //----------------Provenances----------------
 
-  @Authorized(Privilege.IG_VIEW)
+  @Authorized(Privilege.IG_READ)
   @Get(uri = "/{ig}/provenances")
   public List<Provenance> queryProvenances(@PathVariable String ig, @Nullable @QueryValue String version) {
     return provenanceService.find(ig, version);

--- a/modeler/src/main/java/org/termx/modeler/Privilege.java
+++ b/modeler/src/main/java/org/termx/modeler/Privilege.java
@@ -1,9 +1,9 @@
 package org.termx.modeler;
 
 public interface Privilege {
-  String SD_VIEW = "StructureDefinition.view";
-  String SD_EDIT = "StructureDefinition.edit";
+  String SD_READ = "StructureDefinition.read";
+  String SD_WRITE = "StructureDefinition.write";
 
-  String TD_VIEW = "TransformationDefinition.view";
-  String TD_EDIT = "TransformationDefinition.edit";
+  String TD_READ = "TransformationDefinition.read";
+  String TD_WRITE = "TransformationDefinition.write";
 }

--- a/modeler/src/main/java/org/termx/modeler/fhir/StructureDefinitionResourceStorage.java
+++ b/modeler/src/main/java/org/termx/modeler/fhir/StructureDefinitionResourceStorage.java
@@ -95,7 +95,7 @@ public class StructureDefinitionResourceStorage extends BaseFhirResourceHandler 
           default -> throw new ApiClientException("Search by '" + k + "' not supported");
         }
       });
-      List<String> ids = SessionStore.require().getPermittedResourceIds(Privilege.SD_VIEW);
+      List<String> ids = SessionStore.require().getPermittedResourceIds(Privilege.SD_READ);
       if (ids != null) {
         params.setPermittedIds(ids.stream().map(Long::valueOf).toList());
       }

--- a/modeler/src/main/java/org/termx/modeler/fhir/StructureMapResourceStorage.java
+++ b/modeler/src/main/java/org/termx/modeler/fhir/StructureMapResourceStorage.java
@@ -225,7 +225,7 @@ public class StructureMapResourceStorage extends BaseFhirResourceHandler {
         }
       });
 
-      List<String> ids = SessionStore.require().getPermittedResourceIds(Privilege.TD_VIEW);
+      List<String> ids = SessionStore.require().getPermittedResourceIds(Privilege.TD_READ);
       if (ids != null) {
         params.setPermittedIds(ids.stream().map(Long::valueOf).toList());
       }

--- a/modeler/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionController.java
+++ b/modeler/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionController.java
@@ -29,25 +29,25 @@ public class StructureDefinitionController {
   private final StructureDefinitionFhirImportService importService;
   private final StructureDefinitionContentReferenceService contentReferenceService;
 
-  @Authorized(Privilege.SD_VIEW)
+  @Authorized(Privilege.SD_READ)
   @Get(uri = "/{id}{?version}")
   public StructureDefinition getStructureDefinition(@PathVariable Long id, @Nullable @QueryValue String version) {
     return service.load(id, version).orElseThrow(() -> new NotFoundException("Structure definition not found: " + id));
   }
 
-  @Authorized(Privilege.SD_VIEW)
+  @Authorized(Privilege.SD_READ)
   @Get(uri = "/{id}/versions")
   public java.util.List<StructureDefinitionVersion> listVersions(@PathVariable Long id) {
     return service.listVersions(id);
   }
 
-  @Authorized(Privilege.SD_VIEW)
+  @Authorized(Privilege.SD_READ)
   @Get(uri = "/{id}/versions/{version}")
   public StructureDefinitionVersion getStructureDefinitionVersion(@PathVariable Long id, @PathVariable String version) {
     return service.loadVersion(id, version).orElseThrow(() -> new NotFoundException("Structure definition version not found: " + id + "/" + version));
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Post(uri = "/{id}/versions")
   public HttpResponse<?> createVersion(@PathVariable Long id, @Body StructureDefinitionVersion version) {
     version.setId(null);
@@ -56,7 +56,7 @@ public class StructureDefinitionController {
     return HttpResponse.created(version);
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Put(uri = "/{id}/versions/{versionCode}")
   public HttpResponse<?> updateVersion(@PathVariable Long id, @PathVariable String versionCode, @Body StructureDefinitionVersion version) {
     version.setStructureDefinitionId(id);
@@ -64,7 +64,7 @@ public class StructureDefinitionController {
     return HttpResponse.ok(version);
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Post(uri = "/{id}/versions/{versionCode}/duplicate")
   public HttpResponse<?> duplicateVersion(@PathVariable Long id, @PathVariable String versionCode, @Body java.util.Map<String, String> request) {
     String targetVersion = request.get("version");
@@ -72,42 +72,42 @@ public class StructureDefinitionController {
     return HttpResponse.created(ver);
   }
 
-  @Authorized(Privilege.SD_VIEW)
+  @Authorized(Privilege.SD_READ)
   @Get(uri = "{?params*}")
   public QueryResult<StructureDefinition> queryStructureDefinitions(StructureDefinitionQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.SD_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.SD_READ, Long::valueOf));
     return service.query(params);
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Post
   public HttpResponse<?> saveStructureDefinition(@Body StructureDefinition structureDefinition) {
     structureDefinition.setId(null);
     return HttpResponse.created(service.save(structureDefinition));
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Put(uri = "/{id}")
   public HttpResponse<?> updateStructureDefinition(@PathVariable Long id, @Body StructureDefinition structureDefinition) {
     structureDefinition.setId(id);
     return HttpResponse.created(service.save(structureDefinition));
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Delete(uri = "/{id}")
   public HttpResponse<?> deleteStructureDefinition(@PathVariable Long id) {
     service.cancel(id);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Post(uri = "/{id}/recalculate-references")
   public HttpResponse<?> recalculateReferences(@PathVariable Long id) {
     contentReferenceService.recalculate(id);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SD_EDIT)
+  @Authorized(Privilege.SD_WRITE)
   @Post(uri = "/import")
   public HttpResponse<StructureDefinition> importStructureDefinition(@Body StructureDefinitionImportRequest request) {
     if (request.getUrl() != null && !request.getUrl().isBlank()) {

--- a/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformationDefinitionController.java
+++ b/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformationDefinitionController.java
@@ -36,20 +36,20 @@ public class TransformationDefinitionController {
   private final TransformerService transformerService;
   private final ProvenanceService provenanceService;
 
-  @Authorized(Privilege.TD_VIEW)
+  @Authorized(Privilege.TD_READ)
   @Get(uri = "/{id}")
   public TransformationDefinition load(@PathVariable Long id) {
     return service.load(id);
   }
 
-  @Authorized(Privilege.TD_VIEW)
+  @Authorized(Privilege.TD_READ)
   @Get(uri = "{?params*}")
   public QueryResult<TransformationDefinition> search(TransformationDefinitionQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.TD_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.TD_READ, Long::valueOf));
     return service.search(params);
   }
 
-  @Authorized(Privilege.TD_EDIT)
+  @Authorized(Privilege.TD_WRITE)
   @Post
   public TransformationDefinition create(@Valid @Body TransformationDefinition def) {
     def.setId(null);
@@ -58,7 +58,7 @@ public class TransformationDefinitionController {
     return def;
   }
 
-  @Authorized(Privilege.TD_EDIT)
+  @Authorized(Privilege.TD_WRITE)
   @Put(uri = "/{id}")
   public TransformationDefinition update(@PathVariable Long id, @Valid @Body TransformationDefinition def) {
     def.setId(id);
@@ -67,7 +67,7 @@ public class TransformationDefinitionController {
     return def;
   }
 
-  @Authorized(Privilege.TD_EDIT)
+  @Authorized(Privilege.TD_WRITE)
   @Delete(uri = "/{id}")
   public HttpResponse<?> delete(@PathVariable Long id) {
     service.delete(id);
@@ -75,13 +75,13 @@ public class TransformationDefinitionController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.TD_EDIT)
+  @Authorized(Privilege.TD_WRITE)
   @Post(uri = "/{id}/duplicate")
   public TransformationDefinition duplicate(@PathVariable Long id) {
     return service.duplicate(id);
   }
 
-  @Authorized(Privilege.TD_VIEW)
+  @Authorized(Privilege.TD_READ)
   @Post("{id}/transform")
   public TransformationResult transformInstance(@PathVariable Long id, @Body InstanceTransformationRequest req) {
     return transformerService.transform(req.source, load(id));
@@ -141,13 +141,13 @@ public class TransformationDefinitionController {
     }
   }
 
-  @Authorized(privilege = Privilege.TD_VIEW)
+  @Authorized(privilege = Privilege.TD_READ)
   @Post("/generate-input")
   public GenerateInputResponse generateInput(@Body GenerateInputRequest req) {
     return new GenerateInputResponse(transformerService.generateObject(req.resource));
   }
 
-  @Authorized(privilege = Privilege.TD_VIEW)
+  @Authorized(privilege = Privilege.TD_READ)
   @Get(uri = "/base-resources")
   public String loadBaseResources() {
     try {

--- a/observation-definition/src/main/java/org/termx/observationdefinition/Privilege.java
+++ b/observation-definition/src/main/java/org/termx/observationdefinition/Privilege.java
@@ -1,6 +1,6 @@
 package org.termx.observationdefinition;
 
 public interface Privilege {
-  String OBS_DEF_VIEW = "ObservationDefinition.view";
-  String OBS_DEF_EDIT = "ObservationDefinition.edit";
+  String OBS_DEF_READ = "ObservationDefinition.read";
+  String OBS_DEF_WRITE = "ObservationDefinition.write";
 }

--- a/observation-definition/src/main/java/org/termx/observationdefinition/observationdefinition/ObservationDefinitionController.java
+++ b/observation-definition/src/main/java/org/termx/observationdefinition/observationdefinition/ObservationDefinitionController.java
@@ -33,7 +33,7 @@ public class ObservationDefinitionController {
 
   private final ImportLogger importLogger;
 
-  @Authorized(Privilege.OBS_DEF_EDIT)
+  @Authorized(Privilege.OBS_DEF_WRITE)
   @Post()
   public ObservationDefinition create(@Body @Valid ObservationDefinition def) {
     def.setId(null);
@@ -41,7 +41,7 @@ public class ObservationDefinitionController {
     return load(def.getId());
   }
 
-  @Authorized(Privilege.OBS_DEF_EDIT)
+  @Authorized(Privilege.OBS_DEF_WRITE)
   @Put("/{id}")
   public ObservationDefinition update(@PathVariable Long id, @Body @Valid ObservationDefinition def) {
     def.setId(id);
@@ -49,7 +49,7 @@ public class ObservationDefinitionController {
     return load(def.getId());
   }
 
-  @Authorized(Privilege.OBS_DEF_VIEW)
+  @Authorized(Privilege.OBS_DEF_READ)
   @Get("/{id}")
   public ObservationDefinition load(@PathVariable Long id) {
     ObservationDefinition def = observationDefinitionService.load(id);
@@ -59,14 +59,14 @@ public class ObservationDefinitionController {
     return def;
   }
 
-  @Authorized(Privilege.OBS_DEF_VIEW)
+  @Authorized(Privilege.OBS_DEF_READ)
   @Get("/{?params*}")
   public QueryResult<ObservationDefinition> search(ObservationDefinitionSearchParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.OBS_DEF_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.OBS_DEF_READ, Long::valueOf));
     return observationDefinitionService.search(params);
   }
 
-  @Authorized(privilege = Privilege.OBS_DEF_EDIT)
+  @Authorized(privilege = Privilege.OBS_DEF_WRITE)
   @Post("/import")
   public JobLogResponse importDefinitions(@Body @Valid ObservationDefinitionImportRequest request) {
     JobLogResponse jobLogResponse = importLogger.createJob("OBS-DEF-IMPORT");

--- a/snomed/src/main/java/org/termx/snomed/Privilege.java
+++ b/snomed/src/main/java/org/termx/snomed/Privilege.java
@@ -1,6 +1,6 @@
 package org.termx.snomed;
 
 public interface Privilege {
-  String SNOMED_VIEW = "snomed-ct.CodeSystem.view";
-  String SNOMED_EDIT = "snomed-ct.CodeSystem.edit";
+  String SNOMED_READ = "snomed-ct.CodeSystem.read";
+  String SNOMED_WRITE = "snomed-ct.CodeSystem.write";
 }

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -90,40 +90,40 @@ public class SnomedController {
 
   //----------------CodeSystems----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/codesystems")
   public List<SnomedCodeSystem> loadCodeSystems() {
     return snomedService.loadCodeSystems();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Get("/codesystems/{shortName}")
   public SnomedCodeSystem loadCodeSystem(@PathVariable String shortName) {
     return snomedService.loadCodeSystem(shortName);
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/codesystems")
   public HttpResponse<?> createCodeSystem(@Body SnomedCodeSystem codeSystem) {
     snowstormClient.createCodeSystem(codeSystem).join();
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/codesystems/{shortName}/upgrade")
   public HttpResponse<?> upgradeCodeSystem(@PathVariable String shortName, @Body SnomedCodeSystemUpgradeRequest request) {
     snowstormClient.upgradeCodeSystem(shortName, request).join();
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Put("/codesystems/{shortName}")
   public HttpResponse<?> createCodeSystem(@PathVariable String shortName, @Body SnomedCodeSystem codeSystem) {
     snowstormClient.updateCodeSystem(shortName, codeSystem).join();
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Delete("/codesystems/{shortName}")
   public HttpResponse<?> deleteCodeSystem(@PathVariable String shortName) {
     snowstormClient.deleteCodeSystem(shortName).join();
@@ -131,7 +131,7 @@ public class SnomedController {
   }
 
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/codesystems/{shortName}/versions")
   public HttpResponse<?> createCodeSystemVersion(@PathVariable String shortName, @Body SnomedCodeSystemVersion version) {
     snowstormClient.createCodeSystemVersion(shortName, version).join();
@@ -140,84 +140,84 @@ public class SnomedController {
 
   //----------------Branches----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/branches")
   public List<SnomedBranch> loadBranches() {
     return snowstormClient.loadBranches().join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/branches/{path}")
   public SnomedBranch loadBranch(@PathVariable String path) {
     return snowstormClient.loadBranch(parsePath(path)).join();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/branches")
   public SnomedBranch createBranch(@Body SnomedBranchRequest request) {
     snomedService.validateBranchName(request.getName());
     return snowstormClient.createBranch(request).join();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Put("/branches/{path}")
   public SnomedBranch updateBranch(@PathVariable String path, @Body SnomedBranchRequest request) {
     snomedService.validateBranchName(request.getName());
     return snowstormClient.updateBranch(parsePath(path), request).join();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Delete("/branches/{path}")
   public HttpResponse<?> deleteBranch(@PathVariable String path) {
     snowstormClient.deleteBranch(parsePath(path)).join();
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/branches/{path}/lock")
   public HttpResponse<?> lockBranch(@PathVariable String path, @QueryValue String lockMessage) {
     snowstormClient.lockBranch(parsePath(path), Map.of("lockMessage", lockMessage)).join();
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/branches/{path}/unlock")
   public HttpResponse<?> unlockBranch(@PathVariable String path) {
     snowstormClient.unlockBranch(parsePath(path)).join();
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/branches/{path}/integrity-check")
   public Object branchIntegrityCheck(@PathVariable String path) {
     return snowstormClient.branchIntegrityCheck(parsePath(path)).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/{path}/authoring-stats/changed-fully-specified-names")
   public List<SnomedAuthoringStatsResponse> getChangedFsn(@PathVariable String path) {
     return snowstormClient.getChangedFsn(parsePath(path)).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/{path}/authoring-stats/new-descriptions")
   public List<SnomedAuthoringStatsResponse> getNewDescriptions(@PathVariable String path) {
     return snowstormClient.getNewDescriptions(parsePath(path)).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/{path}/authoring-stats/new-synonyms-on-existing-concepts")
   public List<SnomedAuthoringStatsResponse> getNewSynonyms(@PathVariable String path) {
     return snowstormClient.getNewSynonyms(parsePath(path)).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/{path}/authoring-stats/inactivated-synonyms")
   public List<SnomedAuthoringStatsResponse> getInactivatedSynonyms(@PathVariable String path) {
     return snowstormClient.getInactivatedSynonyms(parsePath(path)).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/{path}/authoring-stats/reactivated-synonyms")
   public List<SnomedAuthoringStatsResponse> getReactivatedSynonyms(@PathVariable String path) {
     return snowstormClient.getReactivatedSynonyms(parsePath(path)).join();
@@ -226,21 +226,21 @@ public class SnomedController {
 
   //----------------RF2----------------
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/exports")
   public Map<String, String> createExportJob(@Body SnomedExportRequest request) {
     return Map.of("jobId", snowstormClient.createExportJob(request).join());
   }
 
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get(value = "/exports/{jobId}/archive")
   public HttpResponse<?> getRF2File(@PathVariable String jobId) {
     LorqueProcess lorqueProcess = snomedRF2Service.getRF2File(jobId);
     return HttpResponse.accepted().body(lorqueProcess);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get(value = "/exports/archive/result/{lorqueProcessId}", produces = "application/zip")
   public HttpResponse<?> getRF2File(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());
@@ -248,7 +248,7 @@ public class SnomedController {
         .contentType(MediaType.of("application/zip"));
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post(value = "/imports", consumes = MediaType.MULTIPART_FORM_DATA)
   public Map<String, String> createImportJob(Publisher<CompletedFileUpload> file, @Part("request") String request) {
     SnomedImportRequest req = JsonUtil.fromJson(request, SnomedImportRequest.class);
@@ -256,7 +256,7 @@ public class SnomedController {
     return snomedService.importRF2File(req, importFile);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Post(value = "/imports/scan", consumes = MediaType.MULTIPART_FORM_DATA)
   public LorqueProcess scanImport(Publisher<CompletedFileUpload> file, @Part("request") String request) {
     SnomedImportRequest req = JsonUtil.fromJson(request, SnomedImportRequest.class);
@@ -266,7 +266,7 @@ public class SnomedController {
     return snomedRF2ScanService.scanRF2(req, importFile, filename);
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/imports/scan/{cacheId}/proceed")
   public Map<String, String> proceedScanImport(@PathVariable Long cacheId) {
     SnomedRF2Upload cached = snomedRF2UploadCacheService.load(cacheId);
@@ -282,13 +282,13 @@ public class SnomedController {
     return result;
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/imports/{jobId}")
   public SnomedImportJob loadImportJob(@PathVariable String jobId) {
     return snowstormClient.loadImportJob(jobId).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/imports/scan/result/{lorqueProcessId}")
   public SnomedRF2ScanEnvelope loadScanResult(@PathVariable Long lorqueProcessId) {
     LorqueProcess process = lorqueProcessService.load(lorqueProcessId);
@@ -299,7 +299,7 @@ public class SnomedController {
     return JsonUtil.fromJson(json, SnomedRF2ScanEnvelope.class);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Post("/concept-usage")
   public List<SnomedConceptUsage> findConceptUsage(@Body SnomedConceptUsageRequest request) {
     return snomedConceptUsageService.findUsage(request == null ? null : request.getCodes());
@@ -307,7 +307,7 @@ public class SnomedController {
 
   //----------------Concepts----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/concepts/{conceptId}")
   public SnomedConcept loadConcept(@PathVariable String conceptId, @QueryValue @Nullable String branch) {
     if (StringUtils.isNotEmpty(branch)) {
@@ -316,7 +316,7 @@ public class SnomedController {
     return snowstormClient.loadConcept(conceptId).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/concepts/{conceptId}/children")
   public List<SnomedConcept> findConceptChildren(@PathVariable String conceptId, @QueryValue @Nullable String branch) {
     if (StringUtils.isNotEmpty(branch)) {
@@ -333,7 +333,7 @@ public class SnomedController {
     return concepts;
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/concepts{?params*}")
   public SnomedSearchResult<SnomedConcept> findConcepts(SnomedConceptSearchParams params) {
     SnomedSearchResult<SnomedConcept> concepts = snowstormClient.queryConcepts(params).join();
@@ -344,14 +344,14 @@ public class SnomedController {
     return concepts;
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Post(value = "/concepts/export-csv")
   public HttpResponse<?> startConceptCsvExport(@Body SnomedConceptSearchParams params) {
     LorqueProcess lorqueProcess = snomedConceptCsvService.startCsvExport(params);
     return HttpResponse.accepted().body(lorqueProcess);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get(value = "/concepts/export-csv/result/{lorqueProcessId}", produces = "application/csv")
   public HttpResponse<?> getConceptCsv(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());
@@ -362,7 +362,7 @@ public class SnomedController {
 
   //----------------Descriptions----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/descriptions{?params*}")
   public SnomedDescriptionItemResponse findConceptDescriptions(SnomedDescriptionItemSearchParams params) {
     params.setActive(true);
@@ -379,7 +379,7 @@ public class SnomedController {
     return response;
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/branches/{path}/descriptions/{descriptionId}/deactivate")
   public HttpResponse<?> deactivateDescription(@PathVariable String path, @PathVariable String descriptionId) {
     path += "/";
@@ -387,7 +387,7 @@ public class SnomedController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Post("/branches/{path}/descriptions/{descriptionId}/reactivate")
   public HttpResponse<?> reactivateDescription(@PathVariable String path, @PathVariable String descriptionId) {
     path += "/";
@@ -395,7 +395,7 @@ public class SnomedController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_EDIT)
+  @Authorized(Privilege.SNOMED_WRITE)
   @Delete("/branches/{path}/descriptions/{descriptionId}")
   public HttpResponse<?> deleteDescription(@PathVariable String path, @PathVariable String descriptionId) {
     path += "/";
@@ -405,13 +405,13 @@ public class SnomedController {
 
   //----------------RefSets----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/refsets{?params*}")
   public SnomedRefsetResponse findRefsets(SnomedRefsetSearchParams params) {
     return snowstormClient.findRefsets(params).join();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/refset-members{?params*}")
   public SnomedRefsetMemberResponse findRefsetMembers(SnomedRefsetSearchParams params) {
     return snowstormClient.findRefsetMembers(params).join();
@@ -420,7 +420,7 @@ public class SnomedController {
 
 //----------------Translations----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/translations")
   public List<SnomedTranslation> queryTranslations(@QueryValue @Nullable Boolean active,
                                                    @QueryValue @Nullable Boolean unlinked,
@@ -428,40 +428,40 @@ public class SnomedController {
     return translationService.loadAll(active, unlinked, branch);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/translations/{id}")
   public SnomedTranslation loadTranslation(@PathVariable Long id) {
     return translationService.load(id);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Post("/translations/{id}/add-to-branch")
   public HttpResponse<?> addTranslationToBranch(@PathVariable Long id) {
     translationActionService.addToBranch(id);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get("/concepts/{conceptId}/translations")
   public List<SnomedTranslation> loadTranslations(@PathVariable String conceptId) {
     return translationService.load(conceptId);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Post("/concepts/{conceptId}/translations")
   public HttpResponse<?> saveTranslations(@PathVariable String conceptId, @Body List<SnomedTranslation> translations) {
     provenanceService.provenanceTranslations("snomed-translations-save", conceptId, () -> translationService.save(conceptId, translations));
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Post(value = "/translations/export-rf2")
   public HttpResponse<?> startRF2Export() {
     LorqueProcess lorqueProcess = snomedRF2Service.startRF2Export();
     return HttpResponse.accepted().body(lorqueProcess);
   }
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get(value = "/translations/export-rf2/result/{lorqueProcessId}", produces = "application/zip")
   public HttpResponse<?> getRF2(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());
@@ -472,7 +472,7 @@ public class SnomedController {
 
   //----------------Provenances----------------
 
-  @Authorized(Privilege.SNOMED_VIEW)
+  @Authorized(Privilege.SNOMED_READ)
   @Get(uri = "/concepts/{conceptId}/provenances")
   public List<Provenance> queryProvenances(@PathVariable String conceptId) {
     return provenanceService.find(conceptId);

--- a/task/src/main/java/org/termx/task/Privilege.java
+++ b/task/src/main/java/org/termx/task/Privilege.java
@@ -2,23 +2,23 @@ package org.termx.task;
 
 /**
  * Task privilege constants.
- * 
+ *
  * Note: Actual Task privileges are resource-specific and derived at login from resource privileges.
  * Format: contextType#resourceId.Task.action
- * 
+ *
  * Examples:
- * - code-system#icd-10.Task.view
- * - value-set#disorders.Task.edit
- * - map-set#icd10-to-snomed.Task.publish
- * - code-system#*.Task.edit (wildcard - all CodeSystems)
- * 
+ * - code-system#icd-10.Task.read
+ * - value-set#disorders.Task.write
+ * - map-set#icd10-to-snomed.Task.maintain
+ * - code-system#*.Task.write (wildcard - all CodeSystems)
+ *
  * Derivation:
- * - icd-10.CodeSystem.edit → code-system#icd-10.Task.view + code-system#icd-10.Task.edit
- * - icd-10.CodeSystem.publish → code-system#icd-10.Task.view + code-system#icd-10.Task.edit + code-system#icd-10.Task.publish
+ * - icd-10.CodeSystem.write    → code-system#icd-10.Task.read + code-system#icd-10.Task.write
+ * - icd-10.CodeSystem.maintain → code-system#icd-10.Task.read + code-system#icd-10.Task.write + code-system#icd-10.Task.maintain
  */
 public interface Privilege {
   // These constants are used in @Authorized annotations and will be checked against derived privileges
-  String T_VIEW = "Task.view";
-  String T_EDIT = "Task.edit";
-  String T_PUBLISH = "Task.publish";
+  String T_READ = "Task.read";
+  String T_WRITE = "Task.write";
+  String T_MAINTAIN = "Task.maintain";
 }

--- a/task/src/main/java/org/termx/task/TaskController.java
+++ b/task/src/main/java/org/termx/task/TaskController.java
@@ -32,7 +32,7 @@ public class TaskController {
 
   // ----------- Tasks -----------
 
-  @Authorized(privilege = Privilege.T_VIEW)
+  @Authorized(privilege = Privilege.T_READ)
   @Get(uri = "/tasks{?params*}")
   public QueryResult<Task> queryTasks(TaskQueryParams params) {
     SessionInfo session = SessionStore.require();
@@ -50,7 +50,7 @@ public class TaskController {
     return taskService.queryTasks(params);
   }
 
-  @Authorized(privilege = Privilege.T_VIEW)
+  @Authorized(privilege = Privilege.T_READ)
   @Get(uri = "/tasks/{number}")
   public Task loadTask(@PathVariable String number) {
     SessionInfo session = SessionStore.require();
@@ -88,10 +88,10 @@ public class TaskController {
     boolean allPermitted = true;
     
     for (String contextType : CONTEXT_TYPES) {
-      // Check for privileges like code-system#icd-10.Task.publish
+      // Check for privileges like code-system#icd-10.Task.maintain
       List<String> ids = getPermittedResourceIds(session, contextType, action);
       if (ids == null) {
-        continue; // null = all resources of this type (code-system#*.Task.publish)
+        continue; // null = all resources of this type (code-system#*.Task.maintain)
       }
       allPermitted = false;
       for (String id : ids) {
@@ -106,13 +106,13 @@ public class TaskController {
       return List.of();
     }
     
-    // Check for wildcard: code-system#*.Task.publish
+    // Check for wildcard: code-system#*.Task.maintain
     String wildcardPrivilege = contextType + "#*.Task." + action;
     if (session.hasPrivilege(wildcardPrivilege)) {
       return null; // null = all resources
     }
     
-    // Extract resource IDs from privileges like code-system#icd-10.Task.publish
+    // Extract resource IDs from privileges like code-system#icd-10.Task.maintain
     String suffix = ".Task." + action;
     String prefix = contextType + "#";
     
@@ -127,13 +127,13 @@ public class TaskController {
       return true;
     }
     return task.getContext().stream().allMatch(ctx -> {
-      // Build privilege string using context type directly: code-system#icd-10.Task.publish
+      // Build privilege string using context type directly: code-system#icd-10.Task.maintain
       String privilege = ctx.getType() + "#" + ctx.getId() + ".Task." + action;
       return session.hasPrivilege(privilege);
     });
   }
 
-  @Authorized(privilege = Privilege.T_VIEW)
+  @Authorized(privilege = Privilege.T_READ)
   @Post("/tasks/{number}/opened")
   public HttpResponse<?> logTaskOpened(@PathVariable String number) {
     SessionInfo session = SessionStore.require();
@@ -141,40 +141,40 @@ public class TaskController {
     return HttpResponse.ok();
   }
 
-  @Authorized(privilege = Privilege.T_EDIT)
+  @Authorized(privilege = Privilege.T_WRITE)
   @Post("/tasks")
   public Task saveTask(@Body Task task) {
     task.setNumber(null);
     return taskService.saveTask(task);
   }
 
-  @Authorized(privilege = Privilege.T_EDIT)
+  @Authorized(privilege = Privilege.T_WRITE)
   @Put("/tasks/{number}")
   public Task updateTask(@PathVariable String number, @Body Task task) {
     task.setNumber(number);
     return taskService.saveTask(task);
   }
 
-  @Authorized(privilege = Privilege.T_EDIT)
+  @Authorized(privilege = Privilege.T_WRITE)
   @Patch("/tasks/{number}")
   public Task patchTask(@PathVariable String number, @Body PatchRequest request) {
     Task currentTask = taskService.loadTask(number);
     return taskService.saveTask(PatchUtil.mergeFields(request, currentTask));
   }
 
-  @Authorized(privilege = Privilege.T_EDIT)
+  @Authorized(privilege = Privilege.T_WRITE)
   @Post("/tasks/{number}/activities")
   public TaskActivity createTaskActivity(@PathVariable String number, @Valid @Body Map<String, String> body) {
     return taskService.createTaskActivity(number, body.get("note"), null);
   }
 
-  @Authorized(privilege = Privilege.T_EDIT)
+  @Authorized(privilege = Privilege.T_WRITE)
   @Put("/tasks/{number}/activities/{id}")
   public TaskActivity createTaskActivity(@PathVariable String number, @PathVariable String id, @Valid @Body Map<String, String> body) {
     return taskService.updateTaskActivity(number, id, body.get("note"));
   }
 
-  @Authorized(privilege = Privilege.T_EDIT)
+  @Authorized(privilege = Privilege.T_WRITE)
   @Delete("/tasks/{number}/activities/{id}")
   public HttpResponse<?> deleteTaskActivity(@PathVariable String number, @PathVariable String id) {
     taskService.cancelTaskActivity(number, id);
@@ -184,13 +184,13 @@ public class TaskController {
 
   // ----------- Projects -----------
 
-  @Authorized(privilege = Privilege.T_VIEW)
+  @Authorized(privilege = Privilege.T_READ)
   @Get(uri = "/projects")
   public List<CodeName> loadProjects() {
     return taskService.loadProjects();
   }
 
-  @Authorized(privilege = Privilege.T_VIEW)
+  @Authorized(privilege = Privilege.T_READ)
   @Get(uri = "/projects/{code}/workflows")
   public List<Workflow> loadProjectWorkflows(@PathVariable String code) {
     return taskService.loadProjectWorkFlows(code);

--- a/terminology/src/main/java/org/termx/terminology/Privilege.java
+++ b/terminology/src/main/java/org/termx/terminology/Privilege.java
@@ -1,29 +1,29 @@
 package org.termx.terminology;
 
 public interface Privilege {
-  String CS_VIEW = "CodeSystem.view";
+  String CS_READ = "CodeSystem.read";
   String CS_TRIAGE = "CodeSystem.triage";
-  String CS_EDIT = "CodeSystem.edit";
-  String CS_PUBLISH = "CodeSystem.publish";
+  String CS_WRITE = "CodeSystem.write";
+  String CS_MAINTAIN = "CodeSystem.maintain";
 
-  String DEF_PROP_VIEW = "DefinedProperty.view";
-  String DEF_PROP_EDIT = "DefinedProperty.edit";
+  String DEF_PROP_READ = "DefinedProperty.read";
+  String DEF_PROP_WRITE = "DefinedProperty.write";
 
-  String VS_VIEW = "ValueSet.view";
+  String VS_READ = "ValueSet.read";
   String VS_TRIAGE = "ValueSet.triage";
-  String VS_EDIT = "ValueSet.edit";
-  String VS_PUBLISH = "ValueSet.publish";
+  String VS_WRITE = "ValueSet.write";
+  String VS_MAINTAIN = "ValueSet.maintain";
 
-  String MS_VIEW = "MapSet.view";
+  String MS_READ = "MapSet.read";
   String MS_TRIAGE = "MapSet.triage";
-  String MS_EDIT = "MapSet.edit";
-  String MS_PUBLISH = "MapSet.publish";
+  String MS_WRITE = "MapSet.write";
+  String MS_MAINTAIN = "MapSet.maintain";
 
-  String AT_VIEW = "AssociationType.view";
-  String AT_EDIT = "AssociationType.edit";
-  String AT_PUBLISH= "AssociationType.publish";
+  String AT_READ = "AssociationType.read";
+  String AT_WRITE = "AssociationType.write";
+  String AT_MAINTAIN = "AssociationType.maintain";
 
-  String NS_VIEW = "NamingSystem.view";
-  String NS_EDIT = "NamingSystem.edit";
-  String NS_PUBLISH = "NamingSystem.publish";
+  String NS_READ = "NamingSystem.read";
+  String NS_WRITE = "NamingSystem.write";
+  String NS_MAINTAIN = "NamingSystem.maintain";
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -806,7 +806,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     });
     params.setVersionsDecorated(true);
     params.setPropertiesDecorated(true);
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     return params;
   }
 
@@ -858,7 +858,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
         default -> throw new ApiClientException("Search by '" + k + "' not supported");
       }
     });
-    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     return params;
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemFindMatchesOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemFindMatchesOperation.java
@@ -59,7 +59,7 @@ public class CodeSystemFindMatchesOperation implements InstanceOperationDefiniti
     ConceptQueryParams conceptParams = new ConceptQueryParams();
     conceptParams.setCodeSystem(csId);
     conceptParams.setCodeSystemVersion(versionNumber);
-    conceptParams.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    conceptParams.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     if (exact) {
       conceptParams.setPropertyValues(String.join(";", properties));
     } else {
@@ -89,7 +89,7 @@ public class CodeSystemFindMatchesOperation implements InstanceOperationDefiniti
     ConceptQueryParams conceptParams = new ConceptQueryParams();
     conceptParams.setCodeSystemUri(system);
     conceptParams.setCodeSystemVersion(version);
-    conceptParams.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    conceptParams.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     if (exact) {
       conceptParams.setPropertyValues(String.join(";", properties));
     } else {

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemSubsumesOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemSubsumesOperation.java
@@ -100,7 +100,7 @@ public class CodeSystemSubsumesOperation implements InstanceOperationDefinition,
     conceptParams.setCode(code);
     conceptParams.setCodeSystemVersionId(codeSystemVersion.getId());
     conceptParams.setLimit(1);
-    conceptParams.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    conceptParams.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     return conceptService.query(conceptParams).findFirst()
         .orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "Concept '" + code + "' not found in " + codeSystemVersion.getCodeSystem()));
   }

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemSyncOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemSyncOperation.java
@@ -47,7 +47,7 @@ public class CodeSystemSyncOperation implements TypeOperationDefinition {
     }
     resources.forEach(res -> {
       String id = res.findPart("id").map(ParametersParameter::getValueString).orElseThrow();
-      SessionStore.require().checkPermitted(id, Privilege.CS_EDIT);
+      SessionStore.require().checkPermitted(id, Privilege.CS_WRITE);
     });
 
     JobLogResponse jobLogResponse = importLogger.createJob("FHIR-CS");

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -122,7 +122,7 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     cp.setIncludeSupplement(true);
     cp.setDisplayLanguage(displayLanguage);
     cp.setUseSupplement(extractUseSupplement(req));
-    cp.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    cp.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
 
     Concept concept = conceptService.query(cp).findFirst().orElse(null);
     if (concept == null) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
@@ -523,7 +523,7 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
       }
     });
     params.setVersionsDecorated(true);
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.MS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.MS_READ));
     return params;
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapSyncOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapSyncOperation.java
@@ -52,7 +52,7 @@ public class ConceptMapSyncOperation implements TypeOperationDefinition {
     }
     resources.forEach(res -> {
       String id = res.findPart("id").map(ParametersParameter::getValueString).orElseThrow();
-      SessionStore.require().checkPermitted(id, Privilege.MS_EDIT);
+      SessionStore.require().checkPermitted(id, Privilege.MS_WRITE);
     });
 
     JobLogResponse jobLogResponse = importLogger.createJob("FHIR-MS");

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapTranslateOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapTranslateOperation.java
@@ -133,7 +133,7 @@ public class ConceptMapTranslateOperation implements InstanceOperationDefinition
         .setUri(cmUrl)
         .setVersionVersion(cmVersion)
         .setVersionsDecorated(cmVersion != null)
-        .setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.MS_VIEW))
+        .setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.MS_READ))
         .limit(1);
     MapSet mapSet = mapSetService.query(msParams).findFirst().orElse(null);
     if (mapSet == null) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -495,7 +495,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       }
     });
     params.setDecorated(true);
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
     return params;
   }
 
@@ -546,7 +546,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
         default -> throw new ApiClientException("Search by '" + k + "' not supported");
       }
     });
-    params.setPermittedValueSets(SessionStore.require().getPermittedResourceIds(Privilege.VS_VIEW));
+    params.setPermittedValueSets(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
     return params;
   }
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -51,7 +51,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     ValueSetQueryParams vsParams = new ValueSetQueryParams();
     vsParams.setId(vsId);
     vsParams.setLimit(1);
-    vsParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_VIEW));
+    vsParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
     ValueSet valueSet = valueSetService.query(vsParams).findFirst()
         .orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "value set not found: " + id.getResourceId()));
 
@@ -83,7 +83,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     ValueSetQueryParams vsParams = new ValueSetQueryParams();
     vsParams.setUri(url);
     vsParams.setLimit(1);
-    vsParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_VIEW));
+    vsParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
     ValueSet valueSet = valueSetService.query(vsParams).findFirst()
         .orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "value set not found: " + url));
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetSyncOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetSyncOperation.java
@@ -49,7 +49,7 @@ public class ValueSetSyncOperation implements TypeOperationDefinition {
     }
     resources.forEach(res -> {
       String id = res.findPart("id").map(ParametersParameter::getValueString).orElseThrow();
-      SessionStore.require().checkPermitted(id, Privilege.VS_EDIT);
+      SessionStore.require().checkPermitted(id, Privilege.VS_WRITE);
     });
 
     JobLogResponse jobLogResponse = importLogger.createJob(JOB_TYPE);

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -79,7 +79,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   }
 
   public Parameters run(ValueSetVersion vsVersion, Parameters req) {
-    SessionStore.require().checkPermitted(vsVersion.getValueSet(), Privilege.VS_VIEW);
+    SessionStore.require().checkPermitted(vsVersion.getValueSet(), Privilege.VS_READ);
     String code = req.findParameter("code").map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).orElse(null);
     String system = findSystem(req);
     String version = req.findParameter("systemVersion").map(ParametersParameter::getValueString).orElse(null);

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/analyze/FileAnalysisController.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/analyze/FileAnalysisController.java
@@ -22,7 +22,7 @@ import org.reactivestreams.Publisher;
 public class FileAnalysisController {
   private final FileAnalysisService fileAnalysisService;
 
-  @Authorized(privilege = Privilege.CS_EDIT)
+  @Authorized(privilege = Privilege.CS_WRITE)
   @Post(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA)
   public FileAnalysisResponse analyze(@Nullable Publisher<CompletedFileUpload> file, @Part("request") String request) {
     FileAnalysisRequest req = JsonUtil.fromJson(request, FileAnalysisRequest.class);

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/association/AssociationFileImportController.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/association/AssociationFileImportController.java
@@ -36,7 +36,7 @@ public class AssociationFileImportController {
   private final AssociationFileImportService fileImporterService;
   private final ImportLogger importLogger;
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(value = "/process", consumes = MediaType.MULTIPART_FORM_DATA)
   public JobLogResponse process(Publisher<CompletedFileUpload> file, @Part("request") String request) {
     AssociationFileImportRequest req = JsonUtil.fromJson(request, AssociationFileImportRequest.class);
@@ -65,7 +65,7 @@ public class AssociationFileImportController {
     return jobLogResponse;
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Get(value = "/csv-template", produces = "application/csv")
   public HttpResponse<?> getTemplate() {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(fileImporterService.getTemplate());

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportController.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportController.java
@@ -39,7 +39,7 @@ public class CodeSystemFileImportController {
   private final CodeSystemFileImportService fileImporterService;
   private final ImportLogger importLogger;
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(value = "/process", consumes = MediaType.MULTIPART_FORM_DATA)
   public JobLogResponse process(@Nullable Publisher<CompletedFileUpload> file, @Part("request") String request) {
     String val = URLDecoder.decode(request, StandardCharsets.UTF_8);

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/mapset/MapSetFileImportController.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/mapset/MapSetFileImportController.java
@@ -31,7 +31,7 @@ public class MapSetFileImportController {
   private final ImportLogger importLogger;
   private final MapSetFileImportService importService;
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Post(value = "/process", consumes = MediaType.MULTIPART_FORM_DATA)
   public JobLogResponse process(Publisher<CompletedFileUpload> file, @Part("request") String request) {
     MapSetFileImportRequest req = JsonUtil.fromJson(request, MapSetFileImportRequest.class);
@@ -39,7 +39,7 @@ public class MapSetFileImportController {
     return importLogger.runJob(JOB_TYPE, Map.of("request", req, "file", importFile), importService::process);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Get(value = "/csv-template", produces = "application/csv")
   public HttpResponse<?> getTemplate() {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(importService.getTemplate());

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/valueset/ValueSetFileImportController.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/valueset/ValueSetFileImportController.java
@@ -37,7 +37,7 @@ public class ValueSetFileImportController {
   private final ValueSetFileImportService fileImporterService;
   private final ImportLogger importLogger;
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(value = "/process", consumes = MediaType.MULTIPART_FORM_DATA)
   public JobLogResponse process(@Nullable Publisher<CompletedFileUpload> file, @Part("request") String request) {
     String val = URLDecoder.decode(request, StandardCharsets.UTF_8);

--- a/terminology/src/main/java/org/termx/terminology/terminology/association/AssociationTypeController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/association/AssociationTypeController.java
@@ -24,28 +24,28 @@ public class AssociationTypeController {
   private final AssociationTypeService associationTypeService;
   private final AssociationTypeDeleteService associationTypeDeleteService;
 
-  @Authorized(Privilege.AT_VIEW)
+  @Authorized(Privilege.AT_READ)
   @Get(uri = "{?params*}")
   public QueryResult<AssociationType> queryAssociationTypes(AssociationTypeQueryParams params) {
-    params.setPermittedCodes(SessionStore.require().getPermittedResourceIds(Privilege.AT_VIEW));
+    params.setPermittedCodes(SessionStore.require().getPermittedResourceIds(Privilege.AT_READ));
     return associationTypeService.query(params);
   }
 
-  @Authorized(Privilege.AT_VIEW)
+  @Authorized(Privilege.AT_READ)
   @Get(uri = "/{code}")
   public AssociationType getAssociationType(@PathVariable String code) {
     return associationTypeService.load(code).orElseThrow(() -> new NotFoundException("Association type not found: " + code));
   }
 
-  @Authorized(Privilege.AT_EDIT)
+  @Authorized(Privilege.AT_WRITE)
   @Post
   public HttpResponse<?> createAssociationType(@Body @Valid AssociationType associationType) {
-    SessionStore.require().checkPermitted(associationType.getCode(), Privilege.AT_EDIT);
+    SessionStore.require().checkPermitted(associationType.getCode(), Privilege.AT_WRITE);
     associationTypeService.save(associationType);
     return HttpResponse.created(associationType);
   }
 
-  @Authorized(Privilege.AT_EDIT)
+  @Authorized(Privilege.AT_WRITE)
   @Put("/{code}")
   public HttpResponse<?> updateAssociationType(@PathVariable String code, @Body @Valid AssociationType associationType) {
     associationType.setCode(code);
@@ -53,7 +53,7 @@ public class AssociationTypeController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.AT_PUBLISH)
+  @Authorized(Privilege.AT_MAINTAIN)
   @Delete(uri = "/{code}")
   public HttpResponse<?> deleteAssociationType(@PathVariable String code) {
     associationTypeDeleteService.delete(code);

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java
@@ -76,34 +76,34 @@ public class CodeSystemController {
 
   //----------------CodeSystem----------------
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "{?params*}")
   public QueryResult<CodeSystem> queryCodeSystems(CodeSystemQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     return codeSystemService.query(params);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}{?decorate}")
   public CodeSystem getCodeSystem(@PathVariable String codeSystem, Optional<Boolean> decorate) {
     return codeSystemService.load(codeSystem, decorate.orElse(false)).orElseThrow(() -> new NotFoundException("CodeSystem not found: " + codeSystem));
   }
 
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post("/transaction")
   public HttpResponse<?> saveCodeSystemTransaction(@Body @Valid CodeSystemTransactionRequest request) {
-    SessionStore.require().checkPermitted(request.getCodeSystem().getId(), Privilege.CS_EDIT);
+    SessionStore.require().checkPermitted(request.getCodeSystem().getId(), Privilege.CS_WRITE);
     provenanceService.provenanceCodeSystemTransactionRequest("save", request, () -> {
       codeSystemService.save(request);
     });
     return HttpResponse.created(request.getCodeSystem());
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/duplicate")
   public HttpResponse<?> duplicateCodeSystem(@PathVariable String codeSystem, @Body @Valid CodeSystemDuplicateRequest request) {
-    SessionStore.require().checkPermitted(request.getCodeSystem(), Privilege.CS_EDIT);
+    SessionStore.require().checkPermitted(request.getCodeSystem(), Privilege.CS_WRITE);
     provenanceService.provenanceCodeSystem("duplicate", request.getCodeSystem(), () -> {
       CodeSystem targetCodeSystem = new CodeSystem().setId(request.getCodeSystem()).setUri(request.getCodeSystemUri());
       codeSystemDuplicateService.duplicateCodeSystem(targetCodeSystem, codeSystem);
@@ -111,7 +111,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/supplement")
   public HttpResponse<?> supplementCodeSystem(@PathVariable String codeSystem, @Body @Valid CodeSystemSupplementRequest request) {
     provenanceService.provenanceCodeSystem("supplement", request.getCodeSystem(), () -> {
@@ -120,7 +120,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/change-id")
   public HttpResponse<?> changeCodeSystemId(@PathVariable String codeSystem, @Valid @Body UniqueResource<?> body) {
     String newId = body.getId();
@@ -129,7 +129,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Delete(uri = "/{codeSystem}")
   public HttpResponse<?> deleteCodeSystem(@PathVariable String codeSystem) {
     codeSystemService.cancel(parseCode(codeSystem));
@@ -139,28 +139,28 @@ public class CodeSystemController {
 
   //----------------CodeSystem Version----------------
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/versions{?params*}")
   public QueryResult<CodeSystemVersion> queryCodeSystemVersions(@PathVariable String codeSystem, CodeSystemVersionQueryParams params) {
-    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     params.setCodeSystem(codeSystem);
     return codeSystemVersionService.query(params);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/versions/{version}")
   public CodeSystemVersion getCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version) {
     return codeSystemVersionService.load(codeSystem, version).orElseThrow(() -> new NotFoundException("CodeSystemVersion not found: " + codeSystem));
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/value-set-impacts")
   public List<CodeSystemArtifactImpact> getValueSetImpacts(@PathVariable String codeSystem) {
-    SessionStore.require().checkPermitted(codeSystem, Privilege.CS_VIEW);
+    SessionStore.require().checkPermitted(codeSystem, Privilege.CS_READ);
     return valueSetCodeSystemImpactService.findValueSetImpacts(codeSystem);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions")
   public HttpResponse<?> createCodeSystemVersion(@PathVariable String codeSystem, @Body @Valid CodeSystemVersion codeSystemVersion) {
     codeSystemVersion.setId(null);
@@ -171,7 +171,7 @@ public class CodeSystemController {
     return HttpResponse.created(codeSystemVersion);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Put(uri = "/{codeSystem}/versions/{version}")
   public HttpResponse<?> updateCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version,
                                                  @Body @Valid CodeSystemVersion codeSystemVersion) {
@@ -183,7 +183,7 @@ public class CodeSystemController {
     return HttpResponse.created(codeSystemVersion);
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{codeSystem}/versions/{version}/activate")
   public HttpResponse<?> activateCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version) {
     provenanceService.provenanceCodeSystemVersion("activate", codeSystem, version, () -> {
@@ -192,7 +192,7 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{codeSystem}/versions/{version}/retire")
   public HttpResponse<?> retireCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version) {
     provenanceService.provenanceCodeSystemVersion("retire", codeSystem, version, () -> {
@@ -201,7 +201,7 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{codeSystem}/versions/{version}/draft")
   public HttpResponse<?> saveAsDraftCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version) {
     provenanceService.provenanceCodeSystemVersion("save", codeSystem, version, () -> {
@@ -210,18 +210,18 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions/{version}/duplicate")
   public HttpResponse<?> duplicateCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version,
                                                     @Body @Valid CodeSystemVersionDuplicateRequest request) {
-    SessionStore.require().checkPermitted(request.getCodeSystem(), Privilege.CS_EDIT);
+    SessionStore.require().checkPermitted(request.getCodeSystem(), Privilege.CS_WRITE);
     provenanceService.provenanceCodeSystemVersion("duplicate", codeSystem, request.getVersion(), () -> {
       codeSystemDuplicateService.duplicateCodeSystemVersion(request.getVersion(), request.getCodeSystem(), version, codeSystem);
     });
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Delete(uri = "/{codeSystem}/versions/{version}")
   public HttpResponse<?> deleteCodeSystemVersion(@PathVariable String codeSystem, @PathVariable String version) {
     CodeSystemVersion csv = codeSystemVersionService.load(codeSystem, version).orElseThrow();
@@ -233,14 +233,14 @@ public class CodeSystemController {
 
   //----------------CodeSystem Concept----------------
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/concepts{?params*}")
   public QueryResult<Concept> queryConcepts(@PathVariable String codeSystem, ConceptQueryParams params) {
     params.setCodeSystem(codeSystem);
     return conceptService.query(params);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/concepts/tree-search{?params*}")
   public ConceptTreeSearchResult queryConceptTree(@PathVariable String codeSystem, ConceptQueryParams params) {
     params.setCodeSystem(codeSystem);
@@ -251,7 +251,7 @@ public class CodeSystemController {
     return conceptService.queryTree(params);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/concepts/{code}{?params*}")
   public Concept getConcept(@PathVariable String codeSystem, @PathVariable String code, ConceptQueryParams params) {
     return conceptService.load(codeSystem, parseCode(code))
@@ -259,7 +259,7 @@ public class CodeSystemController {
         .orElseThrow(() -> new NotFoundException("Concept not found: " + parseCode(code)));
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/concepts/{code}/propagate-properties")
   public HttpResponse<?> propagateProperties(@PathVariable String codeSystem, @PathVariable String code,
                                              @Body @Valid CodeSystemConceptPropertyPropagationRequest request) {
@@ -267,7 +267,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/concepts/transaction")
   public HttpResponse<?> saveConceptTransaction(@PathVariable String codeSystem, @Body @Valid ConceptTransactionRequest request) {
     request.setCodeSystem(codeSystem);
@@ -276,7 +276,7 @@ public class CodeSystemController {
     return HttpResponse.created(concept);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Delete(uri = "/{codeSystem}/concepts/{code}")
   public HttpResponse<?> deleteConcept(@PathVariable String codeSystem, @PathVariable String code) {
     Concept concept = conceptService.load(codeSystem, code).orElseThrow();
@@ -285,14 +285,14 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/versions/{version}/concepts/{code}")
   public Concept getConcept(@PathVariable String codeSystem, @PathVariable String version, @PathVariable String code) {
     return conceptService.load(codeSystem, version, parseCode(code))
         .orElseThrow(() -> new NotFoundException("Concept not found: " + parseCode(code)));
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions/{version}/concepts/transaction")
   public HttpResponse<?> saveConceptTransaction(@PathVariable String codeSystem, @PathVariable String version,
                                                 @Body @Valid ConceptTransactionRequest request) {
@@ -302,7 +302,7 @@ public class CodeSystemController {
     return HttpResponse.created(concept);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions/{version}/concepts/link")
   public HttpResponse<?> linkEntityVersion(@PathVariable String codeSystem, @PathVariable String version,
                                            @Body CodeSystemEntityVersionLinkRequest request) {
@@ -312,7 +312,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions/{version}/concepts/unlink")
   public HttpResponse<?> unlinkEntityVersion(@PathVariable String codeSystem, @PathVariable String version,
                                              @Body CodeSystemEntityVersionLinkRequest request) {
@@ -350,14 +350,14 @@ public class CodeSystemController {
 
   //----------------CodeSystem EntityVersion----------------
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/entity-versions{?params*}")
   public QueryResult<CodeSystemEntityVersion> queryEntityVersions(@PathVariable String codeSystem, CodeSystemEntityVersionQueryParams params) {
     params.setCodeSystem(codeSystem);
     return codeSystemEntityVersionService.query(params);
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{codeSystem}/entity-versions/{id}/activate")
   public HttpResponse<?> activateEntityVersion(@PathVariable String codeSystem, @PathVariable Long id) {
     codeSystemEntityVersionService.validate(codeSystem, id);
@@ -368,7 +368,7 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{codeSystem}/entity-versions/{id}/retire")
   public HttpResponse<?> retireEntityVersion(@PathVariable String codeSystem, @PathVariable Long id) {
     codeSystemEntityVersionService.validate(codeSystem, id);
@@ -379,7 +379,7 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{codeSystem}/entity-versions/{id}/draft")
   public HttpResponse<?> saveAsDraftEntityVersion(@PathVariable String codeSystem, @PathVariable Long id) {
     codeSystemEntityVersionService.validate(codeSystem, id);
@@ -390,7 +390,7 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Delete(uri = "/{codeSystem}/entity-versions/{id}")
   public HttpResponse<?> deleteEntityVersion(@PathVariable String codeSystem, @PathVariable Long id) {
     CodeSystemEntityVersion version = codeSystemEntityVersionService.load(id);
@@ -399,7 +399,7 @@ public class CodeSystemController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/entity-versions/{id}/duplicate")
   public HttpResponse<?> duplicateEntityVersion(@PathVariable String codeSystem, @PathVariable Long id) {
     CodeSystemEntityVersion newVersion = codeSystemEntityVersionService.duplicate(codeSystem, id);
@@ -407,7 +407,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/entity-versions/supplement")
   public HttpResponse<?> supplementEntityVersion(@PathVariable String codeSystem, @Body CodeSystemSupplementRequest request) {
     List<CodeSystemEntityVersion> versions = codeSystemSupplementService.supplement(codeSystem, null, request);
@@ -415,7 +415,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions/{version}/entity-versions/supplement")
   public HttpResponse<?> supplementEntityVersion(@PathVariable String codeSystem, @PathVariable String version, @Body CodeSystemSupplementRequest request) {
     List<CodeSystemEntityVersion> versions = codeSystemSupplementService.supplement(codeSystem, version, request);
@@ -423,13 +423,13 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/entity-versions/{id}/references")
   public List<CodeSystemAssociation> getReferences(@PathVariable String codeSystem, @PathVariable Long id) {
     return codeSystemAssociationService.loadReferences(codeSystem, id);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/versions/{version}/entity-versions/activate")
   public HttpResponse<?> activateEntityVersions(@PathVariable String codeSystem, @PathVariable String version) {
     codeSystemEntityVersionService.activate(codeSystem, version);
@@ -439,21 +439,21 @@ public class CodeSystemController {
 
   //----------------CodeSystem Property----------------
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/entity-properties{?params*}")
   public QueryResult<EntityProperty> queryEntityProperties(@PathVariable String codeSystem, EntityPropertyQueryParams params) {
     params.setCodeSystem(codeSystem);
     return entityPropertyService.query(params);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/entity-properties/{id}")
   public EntityProperty getEntityProperty(@PathVariable String codeSystem, @PathVariable Long id) {
     return entityPropertyService.load(id)
         .orElseThrow(() -> new NotFoundException("EntityProperty not found: " + id));
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/entity-properties")
   public HttpResponse<?> createEntityProperty(@PathVariable String codeSystem, @Body @Valid EntityProperty property) {
     property.setId(null);
@@ -463,7 +463,7 @@ public class CodeSystemController {
     return HttpResponse.created(property);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Put(uri = "/{codeSystem}/entity-properties/{id}")
   public HttpResponse<?> updateEntityProperty(@PathVariable String codeSystem, @PathVariable Long id, @Body @Valid EntityProperty property) {
     property.setId(id);
@@ -473,7 +473,7 @@ public class CodeSystemController {
     return HttpResponse.created(property);
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Delete(uri = "/{codeSystem}/entity-properties/{id}")
   public HttpResponse<?> deleteEntityProperty(@PathVariable String codeSystem, @PathVariable Long id) {
     provenanceService.provenanceCodeSystem("delete", codeSystem, () -> {
@@ -482,7 +482,7 @@ public class CodeSystemController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.CS_EDIT)
+  @Authorized(Privilege.CS_WRITE)
   @Post(uri = "/{codeSystem}/entity-properties/{propertyId}/delete-usages")
   public HttpResponse<?> deleteEntityPropertyUsages(@PathVariable String codeSystem, @PathVariable Long propertyId) {
     provenanceService.provenanceCodeSystem("delete-usages", codeSystem, () -> {
@@ -493,7 +493,7 @@ public class CodeSystemController {
 
   //----------------Provenances----------------
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "/{codeSystem}/provenances")
   public List<Provenance> queryProvenances(@PathVariable String codeSystem, @Nullable @QueryValue String version) {
     return provenanceService.find(codeSystem, version);

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
@@ -88,7 +88,7 @@ public class CodeSystemImportService {
 
   @Transactional
   public CodeSystem importCodeSystem(CodeSystem codeSystem, List<AssociationType> associationTypes, CodeSystemImportAction action) {
-    SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_EDIT);
+    SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_WRITE);
 
     long start = System.currentTimeMillis();
     log.info("IMPORT STARTED : code system - {}", codeSystem.getId());
@@ -103,11 +103,11 @@ public class CodeSystemImportService {
     saveConcepts(prepareConcepts(codeSystem.getConcepts(), codeSystem.getBaseCodeSystem()), codeSystemVersion, entityProperties, action.isCleanConceptRun());
 
     if (action.isActivate()) {
-      SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_PUBLISH);
+      SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_MAINTAIN);
       codeSystemVersionService.activate(codeSystem.getId(), codeSystemVersion.getVersion());
     }
     if (action.isRetire()) {
-      SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_PUBLISH);
+      SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_MAINTAIN);
       codeSystemVersionService.retire(codeSystem.getId(), codeSystemVersion.getVersion());
     }
     if (StringUtils.isNotEmpty(action.getSpaceToAdd())) {
@@ -194,7 +194,7 @@ public class CodeSystemImportService {
   }
 
   public List<EntityProperty> saveProperties(List<EntityProperty> properties, String codeSystem) {
-    SessionStore.require().checkPermitted(codeSystem, Privilege.CS_EDIT);
+    SessionStore.require().checkPermitted(codeSystem, Privilege.CS_WRITE);
 
     List<EntityProperty> existingProperties = entityPropertyService.query(new EntityPropertyQueryParams().setCodeSystem(codeSystem)).getData();
     List<EntityProperty> entityProperties = new ArrayList<>(existingProperties);
@@ -203,7 +203,7 @@ public class CodeSystemImportService {
   }
 
   public void saveConcepts(List<Concept> concepts, CodeSystemVersion version, List<EntityProperty> entityProperties, boolean cleanRun) {
-    SessionStore.require().checkPermitted(version.getCodeSystem(), Privilege.CS_EDIT);
+    SessionStore.require().checkPermitted(version.getCodeSystem(), Privilege.CS_WRITE);
 
     log.info("Creating '{}' concepts", concepts.size());
     long start = System.currentTimeMillis();

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/compare/CodeSystemCompareController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/compare/CodeSystemCompareController.java
@@ -16,11 +16,11 @@ public class CodeSystemCompareController {
   private final CodeSystemCompareService service;
   private final CodeSystemVersionService codeSystemVersionService;
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Get()
   public CodeSystemCompareResult compare(@QueryValue Long source, @QueryValue Long target) {
-    SessionStore.require().checkPermitted(codeSystemVersionService.load(source).getCodeSystem(), Privilege.CS_VIEW);
-    SessionStore.require().checkPermitted(codeSystemVersionService.load(target).getCodeSystem(), Privilege.CS_VIEW);
+    SessionStore.require().checkPermitted(codeSystemVersionService.load(source).getCodeSystem(), Privilege.CS_READ);
+    SessionStore.require().checkPermitted(codeSystemVersionService.load(target).getCodeSystem(), Privilege.CS_READ);
     return service.compare(source, target);
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptController.java
@@ -18,19 +18,19 @@ public class ConceptController {
 
   private final ConceptService conceptService;
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Get(uri = "/{id}{?params*}")
   public Concept getConcept(@PathVariable Long id, ConceptQueryParams params) {
     Concept c = conceptService.load(id).map(concept -> conceptService.decorate(concept, concept.getCodeSystem(), params))
         .orElseThrow(() -> new NotFoundException("Concept not found: " + id));
-    SessionStore.require().checkPermitted(c.getCodeSystem(), Privilege.CS_VIEW);
+    SessionStore.require().checkPermitted(c.getCodeSystem(), Privilege.CS_READ);
     return c;
   }
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Get(uri = "{?params*}")
   public QueryResult<Concept> queryConcepts(ConceptQueryParams params) {
-    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     return conceptService.query(params);
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/designation/DesignationController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/designation/DesignationController.java
@@ -15,10 +15,10 @@ import lombok.RequiredArgsConstructor;
 public class DesignationController {
   private final DesignationService designationService;
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get(uri = "{?params*}")
   public QueryResult<Designation> queryDesignations(DesignationQueryParams params) {
-    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_VIEW));
+    params.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
     return designationService.query(params);
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionController.java
@@ -14,12 +14,12 @@ import lombok.RequiredArgsConstructor;
 public class CodeSystemEntityVersionController {
   private final CodeSystemEntityVersionService codeSystemEntityVersionService;
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Get(uri = "/{id}")
   public CodeSystemEntityVersion getEntityVersion(@PathVariable Long id) {
     CodeSystemEntityVersion csev = codeSystemEntityVersionService.load(id);
     if (csev != null) {
-      SessionStore.require().checkPermitted(csev.getCodeSystem(), Privilege.CS_VIEW);
+      SessionStore.require().checkPermitted(csev.getCodeSystem(), Privilege.CS_READ);
     }
     return csev;
   }

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertysummary/CodeSystemEntityPropertySummaryController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertysummary/CodeSystemEntityPropertySummaryController.java
@@ -14,25 +14,25 @@ import lombok.RequiredArgsConstructor;
 public class CodeSystemEntityPropertySummaryController {
   private final CodeSystemEntityPropertySummaryService service;
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get("/{codeSystem}/entity-property-summary")
   public CodeSystemEntityPropertySummary getSummary(@PathVariable String codeSystem, @Nullable @QueryValue String entityPropertyValues) {
     return service.getSummary(codeSystem, null, entityPropertyValues);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get("/{codeSystem}/versions/{version}/entity-property-summary")
   public CodeSystemEntityPropertySummary getSummary(@PathVariable String codeSystem, @PathVariable String version, @Nullable @QueryValue String entityPropertyValues) {
     return service.getSummary(codeSystem, version, entityPropertyValues);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get("/{codeSystem}/entity-property-concept-summary")
   public CodeSystemEntityPropertyConceptSummary getConceptSummary(@PathVariable String codeSystem, @QueryValue Long entityPropertyId, @Nullable @QueryValue String entityPropertyValues) {
     return service.getConceptSummary(codeSystem, null, entityPropertyId, entityPropertyValues);
   }
 
-  @Authorized(Privilege.CS_VIEW)
+  @Authorized(Privilege.CS_READ)
   @Get("/{codeSystem}/versions/{version}/entity-property-concept-summary")
   public CodeSystemEntityPropertyConceptSummary getConceptSummary(@PathVariable String codeSystem, @PathVariable String version, @QueryValue Long entityPropertyId, @Nullable @QueryValue String entityPropertyValues) {
     return service.getConceptSummary(codeSystem, version, entityPropertyId, entityPropertyValues);

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/validator/CodeSystemValidatorController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/validator/CodeSystemValidatorController.java
@@ -18,14 +18,14 @@ public class CodeSystemValidatorController {
   private final CodeSystemUniquenessValidatorService uniquenessValidatorService;
   private final CodeSystemCircularDependenciesDetectorService circularDependenciesDetectorService;
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Post("/validate-uniqueness")
   public HttpResponse<?> validateUniqueness(@Body @Valid CodeSystemUniquenessValidatorRequest request) {
     LorqueProcess lorqueProcess = uniquenessValidatorService.validate(request);
     return HttpResponse.accepted().body(lorqueProcess);
   }
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Get("/detect-circular-dependencies")
   public CodeSystemCircularDependenciesDetectorResult detectCircularDependencies(@QueryValue Long versionId) {
     return circularDependenciesDetectorService.detect(versionId);

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionController.java
@@ -14,11 +14,11 @@ import lombok.RequiredArgsConstructor;
 public class CodeSystemVersionController {
   private final CodeSystemVersionService codeSystemVersionService;
 
-  @Authorized(privilege = Privilege.CS_VIEW)
+  @Authorized(privilege = Privilege.CS_READ)
   @Get(uri = "/{id}")
   public CodeSystemVersion getVersion(@PathVariable Long id) {
     CodeSystemVersion version = codeSystemVersionService.load(id);
-    SessionStore.require().checkPermitted(version.getCodeSystem(), Privilege.CS_VIEW);
+    SessionStore.require().checkPermitted(version.getCodeSystem(), Privilege.CS_READ);
     return version;
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/definedproperty/DefinedPropertyController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/definedproperty/DefinedPropertyController.java
@@ -21,19 +21,19 @@ import lombok.RequiredArgsConstructor;
 public class DefinedPropertyController {
   private final DefinedPropertyService service;
 
-  @Authorized(Privilege.DEF_PROP_VIEW)
+  @Authorized(Privilege.DEF_PROP_READ)
   @Get(uri = "{?params*}")
   public QueryResult<DefinedProperty> query(DefinedPropertyQueryParams params) {
     return service.query(params);
   }
 
-  @Authorized(Privilege.DEF_PROP_VIEW)
+  @Authorized(Privilege.DEF_PROP_READ)
   @Get(uri = "/{id}")
   public DefinedProperty load(@PathVariable Long id) {
     return service.load(id).orElseThrow(() -> new NotFoundException("Defined entity property not found: " + id));
   }
 
-  @Authorized(Privilege.DEF_PROP_EDIT)
+  @Authorized(Privilege.DEF_PROP_WRITE)
   @Post
   public HttpResponse<?> create(@Body @Valid DefinedProperty entityProperty) {
     entityProperty.setId(null);
@@ -41,7 +41,7 @@ public class DefinedPropertyController {
     return HttpResponse.created(entityProperty);
   }
 
-  @Authorized(Privilege.DEF_PROP_EDIT)
+  @Authorized(Privilege.DEF_PROP_WRITE)
   @Put("/{id}")
   public HttpResponse<?> update(@PathVariable Long id, @Body @Valid DefinedProperty entityProperty) {
     entityProperty.setId(id);
@@ -49,7 +49,7 @@ public class DefinedPropertyController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.DEF_PROP_EDIT)
+  @Authorized(Privilege.DEF_PROP_WRITE)
   @Post("/{id}/update-related")
   public HttpResponse<?> updateRelated(@PathVariable Long id) {
     service.updateRelated(id);

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetController.java
@@ -73,31 +73,31 @@ public class MapSetController {
 
   //----------------MapSet----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "{?params*}")
   public QueryResult<MapSet> queryMapSets(MapSetQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.MS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.MS_READ));
     return mapSetService.query(params);
   }
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "/{mapSet}{?decorate}")
   public MapSet getMapSet(@PathVariable String mapSet, Optional<Boolean> decorate) {
     return mapSetService.load(mapSet, decorate.orElse(false))
         .orElseThrow(() -> new NotFoundException("MapSet not found: " + mapSet));
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post("/transaction")
   public HttpResponse<?> saveMapSetTransaction(@Body @Valid MapSetTransactionRequest request) {
-    SessionStore.require().checkPermitted(request.getMapSet().getId(), Privilege.VS_EDIT);
+    SessionStore.require().checkPermitted(request.getMapSet().getId(), Privilege.VS_WRITE);
     provenanceService.provenanceMapSetTransaction("save", request, () -> {
       mapSetService.save(request);
     });
     return HttpResponse.created(request.getMapSet());
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/change-id")
   public HttpResponse<?> changeMapSetId(@PathVariable String mapSet, @Valid @Body UniqueResource<?> body) {
     String newId = body.getId();
@@ -107,7 +107,7 @@ public class MapSetController {
   }
 
 
-  @Authorized(Privilege.MS_PUBLISH)
+  @Authorized(Privilege.MS_MAINTAIN)
   @Delete(uri = "/{mapSet}")
   public HttpResponse<?> deleteMapSet(@PathVariable String mapSet) {
     mapSetService.cancel(mapSet);
@@ -117,21 +117,21 @@ public class MapSetController {
 
   //----------------MapSet Version----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "/{mapSet}/versions{?params*}")
   public QueryResult<MapSetVersion> queryMapSetVersions(@PathVariable String mapSet, MapSetVersionQueryParams params) {
     params.setMapSet(mapSet);
     return mapSetVersionService.query(params);
   }
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "/{mapSet}/versions/{version}")
   public MapSetVersion getMapSetVersion(@PathVariable String mapSet, @PathVariable String version) {
     return mapSetVersionService.load(mapSet, version)
         .orElseThrow(() -> new NotFoundException("Map set version not found: " + version));
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions")
   public HttpResponse<?> createVersion(@PathVariable String mapSet, @Body @Valid MapSetVersion mapSetVersion) {
     mapSetVersion.setId(null);
@@ -142,7 +142,7 @@ public class MapSetController {
     return HttpResponse.created(mapSetVersion);
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Put(uri = "/{mapSet}/versions/{version}")
   public HttpResponse<?> updateVersion(@PathVariable String mapSet, @PathVariable String version, @Body @Valid MapSetVersion mapSetVersion) {
     mapSetVersion.setVersion(version);
@@ -153,7 +153,7 @@ public class MapSetController {
     return HttpResponse.created(mapSetVersion);
   }
 
-  @Authorized(Privilege.MS_PUBLISH)
+  @Authorized(Privilege.MS_MAINTAIN)
   @Post(uri = "/{mapSet}/versions/{version}/activate")
   public HttpResponse<?> activateVersion(@PathVariable String mapSet, @PathVariable String version) {
     provenanceService.provenanceMapSetVersion("activate", mapSet, version, () -> {
@@ -162,7 +162,7 @@ public class MapSetController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.MS_PUBLISH)
+  @Authorized(Privilege.MS_MAINTAIN)
   @Post(uri = "/{mapSet}/versions/{version}/retire")
   public HttpResponse<?> retireVersion(@PathVariable String mapSet, @PathVariable String version) {
     provenanceService.provenanceMapSetVersion("retire", mapSet, version, () -> {
@@ -171,7 +171,7 @@ public class MapSetController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Post(uri = "/{mapSet}/versions/{version}/draft")
   public HttpResponse<?> saveAsDraftMapSetVersion(@PathVariable String mapSet, @PathVariable String version) {
     provenanceService.provenanceMapSetVersion("save", mapSet, version, () -> {
@@ -180,7 +180,7 @@ public class MapSetController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.CS_PUBLISH)
+  @Authorized(Privilege.CS_MAINTAIN)
   @Delete(uri = "/{mapSet}/versions/{version}")
   public HttpResponse<?> deleteMapSetVersion(@PathVariable String mapSet, @PathVariable String version) {
     MapSetVersion msv = mapSetVersionService.load(mapSet, version).orElseThrow();
@@ -190,11 +190,11 @@ public class MapSetController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions/{version}/duplicate")
   public HttpResponse<?> duplicateMapSetVersion(@PathVariable String mapSet, @PathVariable String version,
                                                 @Body @Valid MapSetVersionDuplicateRequest request) {
-    SessionStore.require().checkPermitted(request.getMapSet(), Privilege.MS_EDIT);
+    SessionStore.require().checkPermitted(request.getMapSet(), Privilege.MS_WRITE);
     provenanceService.provenanceMapSetVersion("duplicate", mapSet, request.getVersion(), () -> {
       mapSetDuplicateService.duplicateMapSetVersion(request.getVersion(), request.getMapSet(), version, mapSet);
     });
@@ -204,7 +204,7 @@ public class MapSetController {
 
   //----------------MapSet Statistics----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Post(uri = "/{mapSet}/versions/{version}/reload-statistics-async")
   public JobLogResponse reloadStatisticsAsync(@PathVariable String mapSet, @PathVariable String version) {
     JobLogResponse jobLogResponse = importLogger.createJob(mapSet, "map-set-statistics-reload");
@@ -229,7 +229,7 @@ public class MapSetController {
 
   //----------------MapSet Concept----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "/{mapSet}/versions/{version}/concepts{?params*}")
   public QueryResult<MapSetConcept> queryMapSetConcepts(@PathVariable String mapSet, @PathVariable String version, MapSetConceptQueryParams params) {
     return mapSetConceptService.query(mapSet, version, params);
@@ -238,14 +238,14 @@ public class MapSetController {
 
   //----------------MapSet Association----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "/{mapSet}/associations{?params*}")
   public QueryResult<MapSetAssociation> queryAssociations(@PathVariable String mapSet, MapSetAssociationQueryParams params) {
     params.setMapSet(mapSet);
     return mapSetAssociationService.query(params);
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions/{version}/associations")
   public HttpResponse<?> createAssociation(@PathVariable String mapSet, @PathVariable String version, @Body @Valid MapSetAssociation association) {
     association.setId(null);
@@ -255,7 +255,7 @@ public class MapSetController {
     return HttpResponse.created(association);
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Put(uri = "/{mapSet}/versions/{version}/associations/{id}")
   public HttpResponse<?> updateAssociation(@PathVariable String mapSet, @PathVariable String version, @PathVariable Long id, @Body @Valid MapSetAssociation association) {
     association.setId(id);
@@ -265,7 +265,7 @@ public class MapSetController {
     return HttpResponse.created(association);
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions/{version}/associations-batch")
   public HttpResponse<?> saveAssociations(@PathVariable String mapSet, @PathVariable String version, @Body @Valid Map<String,List<MapSetAssociation>> associations) {
     provenanceService.provenanceMapSetVersion("save-association-batch", mapSet, version, () -> {
@@ -274,7 +274,7 @@ public class MapSetController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions/{version}/associations/verify")
   public HttpResponse<?> verifyAssociations(@PathVariable String mapSet, @PathVariable String version, @Body @Valid Map<String, List<Long>> request) {
     provenanceService.provenanceMapSetVersion("verify-association-batch", mapSet, version, () -> {
@@ -283,7 +283,7 @@ public class MapSetController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions/{version}/associations/unmap")
   public HttpResponse<?> unmapAssociations(@PathVariable String mapSet, @PathVariable String version, @Body @Valid Map<String, List<Long>> request) {
     provenanceService.provenanceMapSetVersion("unmap-association-batch", mapSet, version, () -> {
@@ -320,13 +320,13 @@ public class MapSetController {
 
   //----------------Provenances----------------
 
-  @Authorized(Privilege.MS_VIEW)
+  @Authorized(Privilege.MS_READ)
   @Get(uri = "/{mapSet}/provenances")
   public List<Provenance> queryProvenances(@PathVariable String mapSet, @Nullable @QueryValue String version) {
     return provenanceService.find(mapSet, version);
   }
 
-  @Authorized(Privilege.MS_EDIT)
+  @Authorized(Privilege.MS_WRITE)
   @Post(uri = "/{mapSet}/versions/{version}/associations/automap")
   public JobLogResponse automapAssociations(@PathVariable String mapSet, @PathVariable String version, @Body @Valid MapSetAutomapRequest request) {
     JobLogResponse jobLogResponse = importLogger.createJob(mapSet, "map-set-automap");

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetImportService.java
@@ -40,7 +40,7 @@ public class MapSetImportService {
 
   @Transactional
   public void importMapSet(MapSet mapSet, List<AssociationType> associationTypes, MapSetImportAction action) {
-    SessionStore.require().checkPermitted(mapSet.getId(), Privilege.MS_EDIT);
+    SessionStore.require().checkPermitted(mapSet.getId(), Privilege.MS_WRITE);
 
     long start = System.currentTimeMillis();
     log.info("IMPORT STARTED : map set - {}", mapSet.getId());

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/version/MapSetVersionController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/version/MapSetVersionController.java
@@ -14,11 +14,11 @@ import lombok.RequiredArgsConstructor;
 public class MapSetVersionController {
   private final MapSetVersionService mapSetVersionService;
 
-  @Authorized(privilege = Privilege.VS_VIEW)
+  @Authorized(privilege = Privilege.VS_READ)
   @Get(uri = "/{id}")
   public MapSetVersion getVersion(@PathVariable Long id) {
     MapSetVersion version = mapSetVersionService.load(id);
-    SessionStore.require().checkPermitted(version.getMapSet(), Privilege.VS_VIEW);
+    SessionStore.require().checkPermitted(version.getMapSet(), Privilege.VS_READ);
     return version;
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/namingsystem/NamingSystemController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/namingsystem/NamingSystemController.java
@@ -22,42 +22,42 @@ import lombok.RequiredArgsConstructor;
 public class NamingSystemController {
   private final NamingSystemService namingSystemService;
 
-  @Authorized(Privilege.NS_VIEW)
+  @Authorized(Privilege.NS_READ)
   @Get(uri = "{?params*}")
   public QueryResult<NamingSystem> queryNamingSystems(NamingSystemQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.NS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.NS_READ));
     return namingSystemService.query(params);
   }
 
-  @Authorized(Privilege.NS_VIEW)
+  @Authorized(Privilege.NS_READ)
   @Get(uri = "/{namingSystem}")
   public NamingSystem getNamingSystem(@PathVariable String namingSystem) {
     return namingSystemService.load(namingSystem).orElseThrow(() -> new NotFoundException("Naming system not found: " + namingSystem));
   }
 
-  @Authorized(Privilege.NS_EDIT)
+  @Authorized(Privilege.NS_WRITE)
   @Post
   public HttpResponse<?> saveNamingSystem(@Body @Valid NamingSystem namingSystem) {
-    SessionStore.require().checkPermitted(namingSystem.getId(), Privilege.NS_EDIT);
+    SessionStore.require().checkPermitted(namingSystem.getId(), Privilege.NS_WRITE);
     namingSystemService.save(namingSystem);
     return HttpResponse.created(namingSystem);
   }
 
-  @Authorized(Privilege.NS_PUBLISH)
+  @Authorized(Privilege.NS_MAINTAIN)
   @Post(uri = "/{namingSystem}/activate")
   public HttpResponse<?> activateNamingSystem(@PathVariable String namingSystem) {
     namingSystemService.activate(namingSystem);
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.NS_PUBLISH)
+  @Authorized(Privilege.NS_MAINTAIN)
   @Post(uri = "/{namingSystem}/retire")
   public HttpResponse<?> retireNamingSystem(@PathVariable String namingSystem) {
     namingSystemService.retire(namingSystem);
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.NS_PUBLISH)
+  @Authorized(Privilege.NS_MAINTAIN)
   @Delete(uri = "/{namingSystem}")
   public HttpResponse<?> deleteNamingSystem(@PathVariable String namingSystem) {
     namingSystemService.cancel(namingSystem);

--- a/terminology/src/main/java/org/termx/terminology/terminology/relatedartifacts/RelatedArtifactController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/relatedartifacts/RelatedArtifactController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class RelatedArtifactController {
   private final List<RelatedArtifactService> services;
 
-  @Authorized("*.*.view")
+  @Authorized("*.*.read")
   @Post()
   public List<RelatedArtifact> findRelatedArtifacts(@Valid @Body RelatedArtifactRequest request) {
     return services.stream().flatMap(s -> s.findRelatedArtifacts(request).stream()).toList();

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetController.java
@@ -74,31 +74,31 @@ public class ValueSetController {
 
   //----------------ValueSet----------------
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Get(uri = "{?params*}")
   public QueryResult<ValueSet> queryValueSets(ValueSetQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_VIEW));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
     return valueSetService.query(params);
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Get(uri = "/{valueSet}{?decorate}")
   public ValueSet getValueSet(@PathVariable String valueSet, Optional<Boolean> decorate) {
     return valueSetService.load(valueSet, decorate.orElse(false))
         .orElseThrow(() -> new NotFoundException("ValueSet not found: " + valueSet));
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Post("/transaction")
   public HttpResponse<?> saveValueSetTransaction(@Body @Valid ValueSetTransactionRequest request) {
-    SessionStore.require().checkPermitted(request.getValueSet().getId(), Privilege.VS_EDIT);
+    SessionStore.require().checkPermitted(request.getValueSet().getId(), Privilege.VS_WRITE);
     provenanceService.provenanceValueSetTransaction("save", request, () -> {
       valueSetService.save(request);
     });
     return HttpResponse.created(request.getValueSet());
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Post(uri = "/{valueSet}/change-id")
   public HttpResponse<?> changeValueSetId(@PathVariable String valueSet, @Valid @Body UniqueResource<?> body) {
     String newId = body.getId();
@@ -108,7 +108,7 @@ public class ValueSetController {
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.VS_PUBLISH)
+  @Authorized(Privilege.VS_MAINTAIN)
   @Delete(uri = "/{valueSet}")
   public HttpResponse<?> deleteValueSet(@PathVariable String valueSet) {
     valueSetService.cancel(valueSet);
@@ -118,21 +118,21 @@ public class ValueSetController {
 
   //----------------ValueSet Version----------------
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Get(uri = "/{valueSet}/versions{?params*}")
   public QueryResult<ValueSetVersion> queryValueSetVersions(@PathVariable String valueSet, ValueSetVersionQueryParams params) {
     params.setValueSet(valueSet);
     return valueSetVersionService.query(params);
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Get(uri = "/{valueSet}/versions/{version}")
   public ValueSetVersion getValueSetVersion(@PathVariable String valueSet, @PathVariable String version) {
     return valueSetVersionService.load(valueSet, version)
         .orElseThrow(() -> new NotFoundException("Value set version not found: " + version));
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Post(uri = "/{valueSet}/versions")
   public HttpResponse<?> createVersion(@PathVariable String valueSet, @Body @Valid ValueSetVersion version) {
     version.setId(null);
@@ -143,7 +143,7 @@ public class ValueSetController {
     return HttpResponse.created(version);
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Put(uri = "/{valueSet}/versions/{version}")
   public HttpResponse<?> updateVersion(@PathVariable String valueSet, @PathVariable String version, @Body @Valid ValueSetVersion valueSetVersion) {
     valueSetVersion.setVersion(version);
@@ -154,7 +154,7 @@ public class ValueSetController {
     return HttpResponse.created(valueSetVersion);
   }
 
-  @Authorized(Privilege.VS_PUBLISH)
+  @Authorized(Privilege.VS_MAINTAIN)
   @Post(uri = "/{valueSet}/versions/{version}/activate")
   public HttpResponse<?> activateVersion(@PathVariable String valueSet, @PathVariable String version) {
     provenanceService.provenanceValueSetVersion("activate", valueSet, version, () -> {
@@ -163,7 +163,7 @@ public class ValueSetController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.VS_PUBLISH)
+  @Authorized(Privilege.VS_MAINTAIN)
   @Post(uri = "/{valueSet}/versions/{version}/retire")
   public HttpResponse<?> retireVersion(@PathVariable String valueSet, @PathVariable String version) {
     provenanceService.provenanceValueSetVersion("retire", valueSet, version, () -> {
@@ -172,7 +172,7 @@ public class ValueSetController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.VS_PUBLISH)
+  @Authorized(Privilege.VS_MAINTAIN)
   @Post(uri = "/{valueSet}/versions/{version}/draft")
   public HttpResponse<?> saveAsDraft(@PathVariable String valueSet, @PathVariable String version) {
     provenanceService.provenanceValueSetVersion("save", valueSet, version, () -> {
@@ -181,18 +181,18 @@ public class ValueSetController {
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Post(uri = "/{valueSet}/versions/{version}/duplicate")
   public HttpResponse<?> duplicateValueSetVersion(@PathVariable String valueSet, @PathVariable String version,
                                                   @Body @Valid ValueSetVersionDuplicateRequest request) {
-    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_EDIT);
+    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_WRITE);
     provenanceService.provenanceValueSetVersion("duplicate", valueSet, request.getVersion(), () -> {
       valueSetDuplicateService.duplicateValueSetVersion(request.getVersion(), request.getValueSet(), version, valueSet);
     });
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.VS_PUBLISH)
+  @Authorized(Privilege.VS_MAINTAIN)
   @Delete(uri = "/{valueset}/versions/{version}")
   public HttpResponse<?> deleteValueSetVersion(@PathVariable String valueset, @PathVariable String version) {
     Long versionId = valueSetVersionService.load(valueset, version).map(ValueSetVersionReference::getId).orElseThrow();
@@ -204,24 +204,24 @@ public class ValueSetController {
 
   //----------------ValueSet Expand----------------
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Post(uri = "/expand")
   public List<ValueSetVersionConcept> expand(@Body @Valid ValueSetExpandRequest request) {
-    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_VIEW);
+    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_READ);
     return valueSetVersionConceptService.expand(request.getValueSet(), request.getValueSetVersion());
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Post(uri = "/expand-rule")
   public List<ValueSetVersionConcept> expandRule(@Body @Valid ValueSetRuleExpandRequest request) {
-    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_VIEW);
+    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_READ);
     return valueSetRuleExpandService.expandRule(request.getValueSet(), request.getValueSetVersion(), request.getRule(), request.isInactiveConcepts());
   }
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Post(uri = "/expand-async")
   public JobLogResponse expandAsync(@Body @Valid ValueSetExpandRequest request) {
-    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_VIEW);
+    SessionStore.require().checkPermitted(request.getValueSet(), Privilege.VS_READ);
     JobLogResponse jobLogResponse = importLogger.createJob(request.getValueSet(), "value-set-expand");
     CompletableFuture.runAsync(SessionStore.wrap(() -> {
       try {
@@ -266,7 +266,7 @@ public class ValueSetController {
   }
 
   //----------------ValueSet Version Rule----------------
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Put(uri = "/{valueSet}/versions/{version}/rule-sets/{id}")
   public HttpResponse<?> updateRuleSet(@PathVariable String valueSet, @PathVariable String version, @PathVariable Long id,
                                     @Body @Valid ValueSetVersionRuleSet ruleSet) {
@@ -277,7 +277,7 @@ public class ValueSetController {
     return HttpResponse.created(ruleSet);
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Post(uri = "/{valueSet}/versions/{version}/rules")
   public HttpResponse<?> createRule(@PathVariable String valueSet, @PathVariable String version, @Body @Valid ValueSetVersionRule rule) {
     rule.setId(null);
@@ -287,7 +287,7 @@ public class ValueSetController {
     return HttpResponse.created(rule);
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Put(uri = "/{valueSet}/versions/{version}/rules/{id}")
   public HttpResponse<?> updateRule(@PathVariable String valueSet, @PathVariable String version, @PathVariable Long id,
                                     @Body @Valid ValueSetVersionRule rule) {
@@ -298,7 +298,7 @@ public class ValueSetController {
     return HttpResponse.created(rule);
   }
 
-  @Authorized(Privilege.VS_EDIT)
+  @Authorized(Privilege.VS_WRITE)
   @Delete(uri = "/{valueSet}/versions/{version}/rules/{id}")
   public HttpResponse<?> deleteRule(@PathVariable String valueSet, @PathVariable String version, @PathVariable Long id) {
     if (valueSetVersionService.load(valueSet, version).isEmpty()) {
@@ -312,7 +312,7 @@ public class ValueSetController {
 
   //----------------Provenances----------------
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Get(uri = "/{valueSet}/provenances")
   public List<Provenance> queryProvenances(@PathVariable String valueSet, @Nullable @QueryValue String version) {
     return provenanceService.find(valueSet, version);

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetImportService.java
@@ -53,7 +53,7 @@ public class ValueSetImportService {
 
   @Transactional
   public ValueSet importValueSet(ValueSet valueSet, ValueSetImportAction action) {
-    SessionStore.require().checkPermitted(valueSet.getId(), Privilege.VS_EDIT);
+    SessionStore.require().checkPermitted(valueSet.getId(), Privilege.VS_WRITE);
 
     long start = System.currentTimeMillis();
     log.info("IMPORT STARTED : value set - {}", valueSet.getId());

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionController.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class ValueSetVersionController {
   private final ValueSetVersionService valueSetVersionService;
 
-  @Authorized(Privilege.VS_VIEW)
+  @Authorized(Privilege.VS_READ)
   @Get(uri = "/{id}")
   public ValueSetVersion getVersion(@PathVariable Long id) {
     return valueSetVersionService.load(id);

--- a/termx-api/src/main/java/org/termx/auth/PrivilegeResource.java
+++ b/termx-api/src/main/java/org/termx/auth/PrivilegeResource.java
@@ -20,9 +20,9 @@ public class PrivilegeResource {
   @Setter
   @Accessors(chain = true)
   public static class PrivilegeResourceActions {
-    private boolean view;
+    private boolean read;
     private boolean triage;
-    private boolean edit;
-    private boolean publish;
+    private boolean write;
+    private boolean maintain;
   }
 }

--- a/termx-app/src/main/java/org/termx/auth/SessionFilter.java
+++ b/termx-app/src/main/java/org/termx/auth/SessionFilter.java
@@ -96,14 +96,14 @@ public class SessionFilter implements HttpServerFilter {
       }
       
       if ("triage".equals(action)) {
-        derived.add(contextType + "#" + resourceId + ".Task.view");
-      } else if ("edit".equals(action)) {
-        derived.add(contextType + "#" + resourceId + ".Task.view");
-        derived.add(contextType + "#" + resourceId + ".Task.edit");
-      } else if ("publish".equals(action)) {
-        derived.add(contextType + "#" + resourceId + ".Task.view");
-        derived.add(contextType + "#" + resourceId + ".Task.edit");
-        derived.add(contextType + "#" + resourceId + ".Task.publish");
+        derived.add(contextType + "#" + resourceId + ".Task.read");
+      } else if ("write".equals(action)) {
+        derived.add(contextType + "#" + resourceId + ".Task.read");
+        derived.add(contextType + "#" + resourceId + ".Task.write");
+      } else if ("maintain".equals(action)) {
+        derived.add(contextType + "#" + resourceId + ".Task.read");
+        derived.add(contextType + "#" + resourceId + ".Task.write");
+        derived.add(contextType + "#" + resourceId + ".Task.maintain");
       }
     }
     

--- a/termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java
+++ b/termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java
@@ -18,7 +18,7 @@ import org.termx.core.auth.SessionInfo;
  * Local-dev session provider, activated by {@code auth.dev.allowed=true}.
  *
  * <p>By default the yupi session is granted the full set of action wildcards
- * ({@code *.*.view}, {@code *.*.triage}, {@code *.*.edit}, {@code *.*.publish}),
+ * ({@code *.*.read}, {@code *.*.triage}, {@code *.*.write}, {@code *.*.maintain}),
  * which is effectively admin-equivalent for the privilege-matching algorithm.
  *
  * <p>For QA / migration testing the privilege set can be overridden via the
@@ -26,15 +26,15 @@ import org.termx.core.auth.SessionInfo;
  * list of dotted privilege strings. Common testing presets:
  * <ul>
  *   <li>{@code *.*.*} -- true Admin (short-circuits Task derivation)</li>
- *   <li>{@code *.*.view} -- view-only across all resources (use to verify
+ *   <li>{@code *.*.read} -- read-only across all resources (use to verify
  *       Phase A Q5: download / comment sections must be hidden)</li>
- *   <li>{@code *.*.view,*.*.triage} -- view + triage (downloads + comments
- *       visible, no edit)</li>
- *   <li>{@code icd-10.CodeSystem.view} -- scoped view-only on a single
+ *   <li>{@code *.*.read,*.*.triage} -- read + triage (downloads + comments
+ *       visible, no write)</li>
+ *   <li>{@code icd-10.CodeSystem.read} -- scoped read-only on a single
  *       resource</li>
  * </ul>
  *
- * <p>Example: {@code ./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view'}
+ * <p>Example: {@code ./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.read'}
  *
  * <p>Per-request overrides via the {@code Authorization: Bearer yupi<json>}
  * header still work and take precedence over the configured default.
@@ -45,7 +45,7 @@ import org.termx.core.auth.SessionInfo;
 public class YupiSessionProvider extends SessionProvider {
   private static final String BEARER_YUPI = "Bearer yupi";
   static final Set<String> DEFAULT_PRIVILEGES =
-      Set.of("*.*.view", "*.*.triage", "*.*.edit", "*.*.publish");
+      Set.of("*.*.read", "*.*.triage", "*.*.write", "*.*.maintain");
 
   private final Set<String> configuredPrivileges;
 

--- a/termx-app/src/main/resources/db/changelog/uam/02-privilege-actions-rename.sql
+++ b/termx-app/src/main/resources/db/changelog/uam/02-privilege-actions-rename.sql
@@ -1,0 +1,29 @@
+--liquibase formatted sql
+
+--changeset termx:rename_actions_view_edit_publish_to_read_write_maintain
+-- Phase B migration: rename action keys in uam.privilege_resource.actions JSONB
+-- from view/edit/publish to read/write/maintain. Idempotent: only rewrites rows
+-- that still carry the legacy keys.
+--
+-- Uses jsonb_exists_any() instead of the `?|` operator to avoid JDBC parsing
+-- the `?` as a positional parameter placeholder.
+update uam.privilege_resource
+set actions =
+  (actions
+    - 'view' - 'edit' - 'publish')
+    || jsonb_strip_nulls(jsonb_build_object(
+         'read',     actions->'view',
+         'write',    actions->'edit',
+         'maintain', actions->'publish'
+       ))
+where jsonb_exists_any(actions, array['view', 'edit', 'publish']);
+--rollback update uam.privilege_resource
+--rollback set actions =
+--rollback   (actions
+--rollback     - 'read' - 'write' - 'maintain')
+--rollback     || jsonb_strip_nulls(jsonb_build_object(
+--rollback          'view',    actions->'read',
+--rollback          'edit',    actions->'write',
+--rollback          'publish', actions->'maintain'
+--rollback        ))
+--rollback where jsonb_exists_any(actions, array['read', 'write', 'maintain']);

--- a/termx-app/src/main/resources/db/changelog/uam/changelog.xml
+++ b/termx-app/src/main/resources/db/changelog/uam/changelog.xml
@@ -4,4 +4,5 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
     <include file="01-privilege-defaults.sql" relativeToChangelogFile="true"/>
+    <include file="02-privilege-actions-rename.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/termx-app/src/main/resources/mock/users-demo.json
+++ b/termx-app/src/main/resources/mock/users-demo.json
@@ -6,53 +6,53 @@
   "terminology-manager": {
     "username": "demo-tm",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.publish",
-      "*.CodeSystem.publish",
-      "*.ValueSet.publish",
-      "*.MapSet.publish"
+      "*.Task.maintain",
+      "*.CodeSystem.maintain",
+      "*.ValueSet.maintain",
+      "*.MapSet.maintain"
     ]
   },
   "publisher": {
     "username": "demo-publisher",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.publish",
-      "icd-10.CodeSystem.publish",
-      "icd-11.CodeSystem.publish",
-      "disorders.ValueSet.publish",
-      "icd-snomed.MapSet.publish"
+      "*.Task.maintain",
+      "icd-10.CodeSystem.maintain",
+      "icd-11.CodeSystem.maintain",
+      "disorders.ValueSet.maintain",
+      "icd-snomed.MapSet.maintain"
     ]
   },
   "editor": {
     "username": "demo-editor",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.edit",
-      "icd-10.CodeSystem.edit",
-      "icd-11.CodeSystem.edit",
-      "disorders.ValueSet.edit",
-      "icd-snomed.MapSet.edit"
+      "*.Task.write",
+      "icd-10.CodeSystem.write",
+      "icd-11.CodeSystem.write",
+      "disorders.ValueSet.write",
+      "icd-snomed.MapSet.write"
     ]
   },
   "reviewer": {
     "username": "demo-reviewer",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.edit",
-      "icd-10.CodeSystem.edit"
+      "*.Task.write",
+      "icd-10.CodeSystem.write"
     ]
   },
   "viewer": {
     "username": "demo-viewer",
-    "privileges": ["*.*.view"]
+    "privileges": ["*.*.read"]
   },
   "guest": {
     "username": "guest",
-    "privileges": ["*.*.view"]
+    "privileges": ["*.*.read"]
   }
 }

--- a/termx-app/src/main/resources/mock/users.json
+++ b/termx-app/src/main/resources/mock/users.json
@@ -6,37 +6,37 @@
   "publisher": {
     "username": "publisher1",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.publish",
-      "*.CodeSystem.publish",
-      "*.ValueSet.publish",
-      "*.MapSet.publish"
+      "*.Task.maintain",
+      "*.CodeSystem.maintain",
+      "*.ValueSet.maintain",
+      "*.MapSet.maintain"
     ]
   },
   "editor": {
     "username": "editor1",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.edit",
-      "*.CodeSystem.edit",
-      "*.ValueSet.edit",
-      "*.MapSet.edit"
+      "*.Task.write",
+      "*.CodeSystem.write",
+      "*.ValueSet.write",
+      "*.MapSet.write"
     ]
   },
   "editor2": {
     "username": "editor2",
     "privileges": [
-      "*.*.view",
+      "*.*.read",
       "*.*.triage",
-      "*.Task.edit",
-      "icd-10.CodeSystem.edit",
-      "disorders.ValueSet.edit"
+      "*.Task.write",
+      "icd-10.CodeSystem.write",
+      "disorders.ValueSet.write"
     ]
   },
   "viewer": {
     "username": "viewer1",
-    "privileges": ["*.*.view"]
+    "privileges": ["*.*.read"]
   }
 }

--- a/termx-app/src/test/groovy/org/termx/auth/SessionFilterTaskDerivationTest.groovy
+++ b/termx-app/src/test/groovy/org/termx/auth/SessionFilterTaskDerivationTest.groovy
@@ -7,7 +7,7 @@ class SessionFilterTaskDerivationTest extends Specification {
 
   SessionFilter filter = new SessionFilter([])
 
-  def "triage on CodeSystem derives Task.view"() {
+  def "triage on CodeSystem derives Task.read"() {
     given:
     def session = new SessionInfo(privileges: ["icd-10.CodeSystem.triage"] as Set)
 
@@ -15,38 +15,38 @@ class SessionFilterTaskDerivationTest extends Specification {
     filter.deriveTaskPrivileges(session)
 
     then:
-    session.privileges.contains("code-system#icd-10.Task.view")
-    !session.privileges.contains("code-system#icd-10.Task.edit")
-    !session.privileges.contains("code-system#icd-10.Task.publish")
+    session.privileges.contains("code-system#icd-10.Task.read")
+    !session.privileges.contains("code-system#icd-10.Task.write")
+    !session.privileges.contains("code-system#icd-10.Task.maintain")
   }
 
-  def "edit on CodeSystem still derives Task.view + Task.edit (Phase A vocabulary unchanged)"() {
+  def "write on CodeSystem derives Task.read + Task.write"() {
     given:
-    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.edit"] as Set)
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.write"] as Set)
 
     when:
     filter.deriveTaskPrivileges(session)
 
     then:
-    session.privileges.contains("code-system#icd-10.Task.view")
-    session.privileges.contains("code-system#icd-10.Task.edit")
-    !session.privileges.contains("code-system#icd-10.Task.publish")
+    session.privileges.contains("code-system#icd-10.Task.read")
+    session.privileges.contains("code-system#icd-10.Task.write")
+    !session.privileges.contains("code-system#icd-10.Task.maintain")
   }
 
-  def "publish on CodeSystem still derives all three Task privileges"() {
+  def "maintain on CodeSystem derives all three Task privileges"() {
     given:
-    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.publish"] as Set)
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.maintain"] as Set)
 
     when:
     filter.deriveTaskPrivileges(session)
 
     then:
-    session.privileges.contains("code-system#icd-10.Task.view")
-    session.privileges.contains("code-system#icd-10.Task.edit")
-    session.privileges.contains("code-system#icd-10.Task.publish")
+    session.privileges.contains("code-system#icd-10.Task.read")
+    session.privileges.contains("code-system#icd-10.Task.write")
+    session.privileges.contains("code-system#icd-10.Task.maintain")
   }
 
-  def "triage on ValueSet derives value-set Task.view"() {
+  def "triage on ValueSet derives value-set Task.read"() {
     given:
     def session = new SessionInfo(privileges: ["my-vs.ValueSet.triage"] as Set)
 
@@ -54,12 +54,12 @@ class SessionFilterTaskDerivationTest extends Specification {
     filter.deriveTaskPrivileges(session)
 
     then:
-    session.privileges.contains("value-set#my-vs.Task.view")
+    session.privileges.contains("value-set#my-vs.Task.read")
   }
 
-  def "view alone (no triage) does NOT derive Task privileges"() {
+  def "read alone (no triage) does NOT derive Task privileges"() {
     given:
-    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.view"] as Set)
+    def session = new SessionInfo(privileges: ["icd-10.CodeSystem.read"] as Set)
 
     when:
     filter.deriveTaskPrivileges(session)
@@ -82,13 +82,13 @@ class SessionFilterTaskDerivationTest extends Specification {
 
   def "Admin combined with another privilege still short-circuits derivation"() {
     given:
-    def session = new SessionInfo(privileges: ["*.*.*", "icd-10.CodeSystem.edit"] as Set)
+    def session = new SessionInfo(privileges: ["*.*.*", "icd-10.CodeSystem.write"] as Set)
 
     when:
     filter.deriveTaskPrivileges(session)
 
     then:
-    session.privileges == ["*.*.*", "icd-10.CodeSystem.edit"] as Set
+    session.privileges == ["*.*.*", "icd-10.CodeSystem.write"] as Set
     !session.privileges.any { it.contains("Task.") }
   }
 }

--- a/termx-app/src/test/groovy/org/termx/auth/YupiSessionProviderTest.groovy
+++ b/termx-app/src/test/groovy/org/termx/auth/YupiSessionProviderTest.groovy
@@ -36,44 +36,44 @@ class YupiSessionProviderTest extends Specification {
 
     where:
     raw                                  | expected
-    "*.*.view"                           | ["*.*.view"]
-    "*.*.view,*.*.triage"                | ["*.*.view", "*.*.triage"]
-    " *.*.view , *.*.triage "            | ["*.*.view", "*.*.triage"]   // trims whitespace
-    "icd-10.CodeSystem.view"             | ["icd-10.CodeSystem.view"]
+    "*.*.read"                           | ["*.*.read"]
+    "*.*.read,*.*.triage"                | ["*.*.read", "*.*.triage"]
+    " *.*.read , *.*.triage "            | ["*.*.read", "*.*.triage"]   // trims whitespace
+    "icd-10.CodeSystem.read"             | ["icd-10.CodeSystem.read"]
     "*.*.*"                              | ["*.*.*"]
-    "*.*.view,,,*.*.edit"                | ["*.*.view", "*.*.edit"]    // skips empty tokens
+    "*.*.read,,,*.*.write"               | ["*.*.read", "*.*.write"]    // skips empty tokens
   }
 
-  def "view-only override produces a session that fails the triage check"() {
+  def "read-only override produces a session that fails the triage check"() {
     given:
-    def provider = new YupiSessionProvider("*.*.view")
+    def provider = new YupiSessionProvider("*.*.read")
     def session = provider.authenticate(yupiRequest())
 
     expect:
-    session.privileges == ["*.*.view"] as Set
+    session.privileges == ["*.*.read"] as Set
     !session.hasPrivilege("administrative-gender.CodeSystem.triage")
     !session.hasPrivilege("any-space.Wiki.triage")
-    session.hasPrivilege("administrative-gender.CodeSystem.view")
+    session.hasPrivilege("administrative-gender.CodeSystem.read")
   }
 
-  def "view+triage override produces a session that passes the triage check"() {
+  def "read+triage override produces a session that passes the triage check"() {
     given:
-    def provider = new YupiSessionProvider("*.*.view,*.*.triage")
+    def provider = new YupiSessionProvider("*.*.read,*.*.triage")
     def session = provider.authenticate(yupiRequest())
 
     expect:
-    session.hasPrivilege("administrative-gender.CodeSystem.view")
+    session.hasPrivilege("administrative-gender.CodeSystem.read")
     session.hasPrivilege("administrative-gender.CodeSystem.triage")
-    !session.hasPrivilege("administrative-gender.CodeSystem.edit")
+    !session.hasPrivilege("administrative-gender.CodeSystem.write")
   }
 
   def "explicit JSON in Bearer header overrides the configured default"() {
     given:
-    def provider = new YupiSessionProvider("*.*.view")  // configured = view-only
+    def provider = new YupiSessionProvider("*.*.read")  // configured = read-only
     def request = Mock(HttpRequest)
     def headers = Mock(HttpHeaders)
     headers.getFirst("Authorization") >>
-        Optional.of('Bearer yupi{"username":"adhoc","privileges":["*.*.publish"]}')
+        Optional.of('Bearer yupi{"username":"adhoc","privileges":["*.*.maintain"]}')
     request.getHeaders() >> headers
 
     when:
@@ -81,7 +81,7 @@ class YupiSessionProviderTest extends Specification {
 
     then:
     session.username == "adhoc"
-    session.privileges == ["*.*.publish"] as Set
+    session.privileges == ["*.*.maintain"] as Set
   }
 
   def "non-yupi authorization header returns null"() {

--- a/termx-core/src/main/java/org/termx/core/Privilege.java
+++ b/termx-core/src/main/java/org/termx/core/Privilege.java
@@ -1,13 +1,13 @@
 package org.termx.core;
 
 public interface Privilege {
-  String S_VIEW = "Space.view";
-  String S_EDIT = "Space.edit";
+  String S_READ = "Space.read";
+  String S_WRITE = "Space.write";
 
-  String R_VIEW = "Release.view";
-  String R_EDIT = "Release.edit";
-  String R_PUBLISH = "Release.publish";
+  String R_READ = "Release.read";
+  String R_WRITE = "Release.write";
+  String R_MAINTAIN = "Release.maintain";
 
-  String C_VIEW = "Checklist.view";
-  String C_EDIT = "Checklist.edit";
+  String C_READ = "Checklist.read";
+  String C_WRITE = "Checklist.write";
 }

--- a/termx-core/src/main/java/org/termx/core/auth/SessionInfo.java
+++ b/termx-core/src/main/java/org/termx/core/auth/SessionInfo.java
@@ -48,8 +48,8 @@ public class SessionInfo {
 
   private String[] split(String p) {
     // Splits privilege into [resourceId, resourceType, action]
-    // Handles both standard format: "icd-10.CodeSystem.edit" → ["icd-10", "CodeSystem", "edit"]
-    // And hash format: "code-system#icd-10.Task.edit" → ["code-system#icd-10", "Task", "edit"]
+    // Handles both standard format: "icd-10.CodeSystem.write" → ["icd-10", "CodeSystem", "write"]
+    // And hash format: "code-system#icd-10.Task.write" → ["code-system#icd-10", "Task", "write"]
     String[] parts = p.split("\\.");
     return new String[]{String.join(".", ArrayUtils.subarray(parts, 0, parts.length - 2)), parts[parts.length - 2], parts[parts.length - 1]};
   }

--- a/termx-core/src/main/java/org/termx/core/fhir/KefhirAuthHttpInterceptor.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/KefhirAuthHttpInterceptor.java
@@ -46,20 +46,20 @@ public class KefhirAuthHttpInterceptor implements KefhirRequestExecutionIntercep
       return;
     }
     if (Objects.equals(InteractionType.READ, interaction) &&
-        !SessionStore.require().hasPrivilege(id + "." + resourcePrivileges.get(type) + ".view")) {
+        !SessionStore.require().hasPrivilege(id + "." + resourcePrivileges.get(type) + ".read")) {
       throw new FhirException(403, IssueType.FORBIDDEN, id + "." + type + "." + interaction + " not allowed");
     }
     if (Objects.equals(InteractionType.CREATE, interaction)
-        && !SessionStore.require().hasPrivilege("*." + resourcePrivileges.get(type) + ".edit")) {
+        && !SessionStore.require().hasPrivilege("*." + resourcePrivileges.get(type) + ".write")) {
       throw new FhirException(403, IssueType.FORBIDDEN, id + "." + type + "." + interaction + " not allowed");
     }
     if (Objects.equals(InteractionType.UPDATE, interaction)
-        && !SessionStore.require().hasPrivilege(id + "." + resourcePrivileges.get(type) + ".edit")) {
+        && !SessionStore.require().hasPrivilege(id + "." + resourcePrivileges.get(type) + ".write")) {
       throw new FhirException(403, IssueType.FORBIDDEN, id + "." + type + "." + interaction + " not allowed");
     }
     if (Objects.equals(InteractionType.OPERATION, interaction) && request.getPath().contains("/") /* instance operation */) {
       //check at least view privilege for instance operations. everything else  manually in operation implementation
-      if (!SessionStore.require().hasPrivilege(id + "." + resourcePrivileges.get(type) + ".view")) {
+      if (!SessionStore.require().hasPrivilege(id + "." + resourcePrivileges.get(type) + ".read")) {
         throw new FhirException(403, IssueType.FORBIDDEN, request.getPath() + "." + type + " not allowed");
       }
     }

--- a/termx-core/src/main/java/org/termx/core/file/AuthorizedFileReaderCustomChange.java
+++ b/termx-core/src/main/java/org/termx/core/file/AuthorizedFileReaderCustomChange.java
@@ -14,7 +14,7 @@ public abstract class AuthorizedFileReaderCustomChange extends FileReaderCustomC
     try {
       SessionInfo sessionInfo = new SessionInfo();
       sessionInfo.setUsername("liquibase");
-      sessionInfo.setPrivileges(Set.of("*.*.edit", "*.*.view", "*.*.publish"));
+      sessionInfo.setPrivileges(Set.of("*.*.write", "*.*.read", "*.*.maintain"));
       SessionStore.setLocal(sessionInfo);
 
       handleMigrationFile(name, content);

--- a/termx-core/src/main/java/org/termx/core/sequence/SysSequenceController.java
+++ b/termx-core/src/main/java/org/termx/core/sequence/SysSequenceController.java
@@ -22,33 +22,33 @@ import lombok.RequiredArgsConstructor;
 public class SysSequenceController {
   private final SysSequenceService sysSequenceService;
 
-  @Authorized("Sequence.view")
+  @Authorized("Sequence.read")
   @Get("{?params*}")
   public QueryResult<SysSequence> query(SysSequenceQueryParams params) {
     return sysSequenceService.query(params);
   }
 
-  @Authorized("Sequence.view")
+  @Authorized("Sequence.read")
   @Get("/{id}")
   public SysSequence load(@PathVariable Long id) {
     return sysSequenceService.load(id);
   }
 
-  @Authorized("Sequence.edit")
+  @Authorized("Sequence.write")
   @Post
   public SysSequence create(@Body @Valid SysSequence sequence) {
     sequence.setId(null);
     return load(sysSequenceService.save(sequence));
   }
 
-  @Authorized("Sequence.edit")
+  @Authorized("Sequence.write")
   @Put("/{id}")
   public SysSequence update(@PathVariable Long id, @Body @Valid SysSequence sequence) {
     sequence.setId(id);
     return load(sysSequenceService.save(sequence));
   }
 
-  @Authorized(privilege = "Sequence.view") //TODO: privilege
+  @Authorized(privilege = "Sequence.read") //TODO: privilege
   @Get("/{code}/next")
   public Map<String, Object> getNextValue(String code) {
     return Map.of("value", sysSequenceService.getNextValue(code));

--- a/termx-core/src/main/java/org/termx/core/sys/checklist/ChecklistController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/checklist/ChecklistController.java
@@ -46,13 +46,13 @@ public class ChecklistController {
 
   //----------------Checklist----------------
 
-  @Authorized(Privilege.C_VIEW)
+  @Authorized(Privilege.C_READ)
   @Get("{?params*}")
   public QueryResult<Checklist> search(ChecklistQueryParams params) {
     return service.query(params);
   }
 
-  @Authorized(privilege = Privilege.C_EDIT)
+  @Authorized(privilege = Privilege.C_WRITE)
   @Post()
   public HttpResponse<?> save(@Valid @Body ChecklistRequest request) {
     service.save(request.getChecklist(), request.getResourceType(), request.getResourceId());
@@ -62,7 +62,7 @@ public class ChecklistController {
 
   //----------------Rule----------------
 
-  @Authorized(privilege = Privilege.C_EDIT)
+  @Authorized(privilege = Privilege.C_WRITE)
   @Post("/rules")
   public ChecklistRule create(@Valid @Body ChecklistRule rule) {
     rule.setId(null);
@@ -70,7 +70,7 @@ public class ChecklistController {
     return rule;
   }
 
-  @Authorized(Privilege.C_EDIT)
+  @Authorized(Privilege.C_WRITE)
   @Put("/rules/{id}")
   public ChecklistRule update(@PathVariable Long id, @Valid @Body ChecklistRule rule) {
     rule.setId(id);
@@ -78,20 +78,20 @@ public class ChecklistController {
     return ruleService.save(rule);
   }
 
-  @Authorized(Privilege.C_VIEW)
+  @Authorized(Privilege.C_READ)
   @Get("/rules/{id}")
   public ChecklistRule load(@PathVariable Long id) {
     return ruleService.load(id);
   }
 
-  @Authorized(Privilege.C_VIEW)
+  @Authorized(Privilege.C_READ)
   @Get("/rules{?params*}")
   public QueryResult<ChecklistRule> search(ChecklistRuleQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.C_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.C_READ, Long::valueOf));
     return ruleService.query(params);
   }
 
-  @Authorized(Privilege.C_EDIT)
+  @Authorized(Privilege.C_WRITE)
   @Delete(uri = "/rules/{id}")
   public HttpResponse<?> deleteRule(@PathVariable Long id) {
     ruleService.delete(id);
@@ -100,26 +100,26 @@ public class ChecklistController {
 
   //----------------Assertions----------------
 
-  @Authorized(privilege = Privilege.C_EDIT)
+  @Authorized(privilege = Privilege.C_WRITE)
   @Post("/{id}/assertions")
   public ChecklistAssertion create(@PathVariable Long id, @Valid @Body AssertionRequest request) {
     return assertionService.create(id, request.getResourceVersion(), request.isPassed());
   }
 
-  @Authorized(privilege = Privilege.C_EDIT)
+  @Authorized(privilege = Privilege.C_WRITE)
   @Post("/assertions/run-checks")
   public HttpResponse<?> runChecks(@Valid @Body ChecklistValidationRequest request) {
     validationService.runChecks(request);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.C_VIEW)
+  @Authorized(Privilege.C_READ)
   @Get(uri = "/assertions/export{?params*}")
   public LorqueProcess exportAssertions(Map<String, String> params) {
     return assertionExportService.export(params.get("resourceType"), params.get("resourceId"), params.get("resourceVersion"));
   }
 
-  @Authorized(Privilege.C_VIEW)
+  @Authorized(Privilege.C_READ)
   @Get(value = "/assertions/export/result/{lorqueProcessId}", produces = "application/csv")
   public HttpResponse<?> getAssertionExportResult(Long lorqueProcessId) {
     MutableHttpResponse<byte[]> response = HttpResponse.ok(lorqueProcessService.load(lorqueProcessId).getResult());

--- a/termx-core/src/main/java/org/termx/core/sys/ecosystem/EcosystemController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/ecosystem/EcosystemController.java
@@ -20,30 +20,30 @@ import org.termx.sys.ecosystem.EcosystemQueryParams;
 public class EcosystemController {
   private final EcosystemService ecosystemService;
 
-  @Authorized(privilege = Privilege.S_EDIT)
+  @Authorized(privilege = Privilege.S_WRITE)
   @Post
   public Ecosystem create(@Valid @Body Ecosystem p) {
     p.setId(null);
     return ecosystemService.save(p);
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Put("{id}")
   public Ecosystem update(@PathVariable Long id, @Valid @Body Ecosystem p) {
     p.setId(id);
     return ecosystemService.save(p);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("{id}")
   public Ecosystem load(@PathVariable Long id) {
     return ecosystemService.load(id);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{?params*}")
   public QueryResult<Ecosystem> search(EcosystemQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.S_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.S_READ, Long::valueOf));
     return ecosystemService.query(params);
   }
 }

--- a/termx-core/src/main/java/org/termx/core/sys/provenance/ProvenanceController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/provenance/ProvenanceController.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 public class ProvenanceController {
   private final ProvenanceService service;
 
-  @Authorized("Provenance.view")
+  @Authorized("Provenance.read")
   @Get()
   public List<Provenance> query(@QueryValue String target) {
     return service.find(target);

--- a/termx-core/src/main/java/org/termx/core/sys/release/ReleaseController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/release/ReleaseController.java
@@ -41,7 +41,7 @@ public class ReleaseController {
 
   //----------------Release----------------
 
-  @Authorized(privilege = Privilege.R_EDIT)
+  @Authorized(privilege = Privilege.R_WRITE)
   @Post()
   public Release create(@Valid @Body Release release) {
     provenanceService.provenanceRelease("save", release.getCode(), () -> {
@@ -51,7 +51,7 @@ public class ReleaseController {
     return release;
   }
 
-  @Authorized(Privilege.R_EDIT)
+  @Authorized(Privilege.R_WRITE)
   @Put("{id}")
   public Release update(@PathVariable Long id, @Valid @Body Release release) {
     provenanceService.provenanceRelease("save", release.getCode(), () -> {
@@ -61,34 +61,34 @@ public class ReleaseController {
     return releaseService.save(release);
   }
 
-  @Authorized(Privilege.R_VIEW)
+  @Authorized(Privilege.R_READ)
   @Get("{id}")
   public Release load(@PathVariable Long id) {
     return releaseService.load(id);
   }
 
-  @Authorized(Privilege.R_VIEW)
+  @Authorized(Privilege.R_READ)
   @Get("/{?params*}")
   public QueryResult<Release> search(ReleaseQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.R_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.R_READ, Long::valueOf));
     return releaseService.query(params);
   }
 
-  @Authorized(Privilege.R_PUBLISH)
+  @Authorized(Privilege.R_MAINTAIN)
   @Post(uri = "/{id}/activate")
   public HttpResponse<?> activate(@PathVariable Long id) {
     provenanceService.provenanceRelease("activate", id, () -> releaseService.changeStatus(id, PublicationStatus.active));
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.R_PUBLISH)
+  @Authorized(Privilege.R_MAINTAIN)
   @Post(uri = "/{id}/retire")
   public HttpResponse<?> retire(@PathVariable Long id) {
     provenanceService.provenanceRelease("retire", id, () -> releaseService.changeStatus(id, PublicationStatus.retired));
     return HttpResponse.noContent();
   }
 
-  @Authorized(Privilege.R_PUBLISH)
+  @Authorized(Privilege.R_MAINTAIN)
   @Post(uri = "/{id}/draft")
   public HttpResponse<?> saveAsDraft(@PathVariable Long id) {
     provenanceService.provenanceRelease("save", id, () -> releaseService.changeStatus(id, PublicationStatus.draft));
@@ -97,13 +97,13 @@ public class ReleaseController {
 
   //----------------Release Resource----------------
 
-  @Authorized(Privilege.R_VIEW)
+  @Authorized(Privilege.R_READ)
   @Get("{id}/resources")
   public List<ReleaseResource> loadResources(@PathVariable Long id) {
     return releaseResourceService.loadAll(id);
   }
 
-  @Authorized(privilege = Privilege.R_EDIT)
+  @Authorized(privilege = Privilege.R_WRITE)
   @Post("{id}/resources")
   public HttpResponse<?> createResource(@PathVariable Long id, @Valid @Body ReleaseResource resource) {
     resource.setId(null);
@@ -111,7 +111,7 @@ public class ReleaseController {
     return HttpResponse.ok();
   }
 
-  @Authorized(privilege = Privilege.R_EDIT)
+  @Authorized(privilege = Privilege.R_WRITE)
   @Put("{id}/resources/{resourceId}")
   public HttpResponse<?> updateResource(@PathVariable Long id,  @PathVariable Long resourceId, @Valid @Body ReleaseResource resource) {
     resource.setId(resourceId);
@@ -119,7 +119,7 @@ public class ReleaseController {
     return HttpResponse.ok();
   }
 
-  @Authorized(privilege = Privilege.R_EDIT)
+  @Authorized(privilege = Privilege.R_WRITE)
   @Delete("{id}/resources/{resourceId}")
   public HttpResponse<?> deleteResource(@PathVariable Long id, @PathVariable Long resourceId) {
     releaseResourceService.cancel(id, resourceId);
@@ -129,7 +129,7 @@ public class ReleaseController {
 
   //----------------Release Provenance----------------
 
-  @Authorized(Privilege.R_VIEW)
+  @Authorized(Privilege.R_READ)
   @Get("{id}/provenances")
   public List<Provenance> loadProvenances(@PathVariable Long id) {
     return provenanceService.find(id);
@@ -137,14 +137,14 @@ public class ReleaseController {
 
   //----------------Release Server Sync----------------
 
-  @Authorized(privilege = Privilege.R_PUBLISH)
+  @Authorized(privilege = Privilege.R_MAINTAIN)
   @Post("{id}/server-sync")
   public HttpResponse<?> syncResources(@PathVariable Long id, @Valid @Body Map<String, Object> request) {
     JobLogResponse response = syncService.syncResources(id, (Long) request.get("resourceId"));
     return HttpResponse.accepted().body(response);
   }
 
-  @Authorized(privilege = Privilege.R_VIEW)
+  @Authorized(privilege = Privilege.R_READ)
   @Post("{id}/validate-sync")
   public HttpResponse<?> validateSync(@PathVariable Long id) {
     JobLogResponse response = syncService.validateSync(id);
@@ -153,19 +153,19 @@ public class ReleaseController {
 
   //----------------Release Notes----------------
 
-  @Authorized(privilege = Privilege.R_VIEW)
+  @Authorized(privilege = Privilege.R_READ)
   @Get("/{id}/notes")
   public List<ReleaseAttachment> getReleaseNotes(@PathVariable Long id) {
     return attachmentService.getAttachments(id);
   }
 
-  @Authorized(privilege = Privilege.R_VIEW)
+  @Authorized(privilege = Privilege.R_READ)
   @Get("/{id}/notes/{fileName}")
   public StreamedFile getFile(@PathVariable Long id, @PathVariable String fileName) {
     return attachmentService.getAttachmentContent(id, fileName);
   }
 
-  @Authorized(privilege = Privilege.R_EDIT)
+  @Authorized(privilege = Privilege.R_WRITE)
   @Post("/{id}/generate-notes")
   public HttpResponse<?> generateReleaseNotes(@PathVariable Long id) {
     notesService.generateNotes(id);

--- a/termx-core/src/main/java/org/termx/core/sys/server/TerminologyServerController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/TerminologyServerController.java
@@ -31,27 +31,27 @@ public class TerminologyServerController {
   private final TerminologyServerResourceService serverResourceService;
   private final TerminologyServerAuthoritativeService authoritativeService;
 
-  @Authorized("Server.view")
+  @Authorized("Server.read")
   @Get("/kinds")
   public List<String> getKinds() {
     return serverService.getKinds();
   }
 
-  @Authorized("Server.edit")
+  @Authorized("Server.write")
   @Post
   public TerminologyServer create(@Valid @Body TerminologyServer ts) {
     ts.setId(null);
     return serverService.save(ts).maskSensitiveData();
   }
 
-  @Authorized("Server.edit")
+  @Authorized("Server.write")
   @Put("/{id}")
   public TerminologyServer update(@PathVariable Long id, @Valid @Body TerminologyServer ts) {
     ts.setId(id);
     return serverService.save(ts).maskSensitiveData();
   }
 
-  @Authorized("Server.edit")
+  @Authorized("Server.write")
   @Get("/{id}")
   public TerminologyServer load(@PathVariable Long id) {
     return serverService.load(id).maskSensitiveData();
@@ -61,19 +61,19 @@ public class TerminologyServerController {
   @Get("/{?params*}")
   public QueryResult<TerminologyServer> search(TerminologyServerQueryParams params) {
     QueryResult<TerminologyServer> query = serverService.query(params);
-    if (!SessionStore.require().hasPrivilege("Server.edit")) {
+    if (!SessionStore.require().hasPrivilege("Server.write")) {
       return query.map(TerminologyServer::publicView).map(TerminologyServer::maskSensitiveData);
     }
     return query.map(TerminologyServer::maskSensitiveData);
   }
 
-  @Authorized("Server.edit")
+  @Authorized("Server.write")
   @Post("/resource")
   public TerminologyServerResourceResponse getResource(@Valid @Body TerminologyServerResourceRequest request) {
     return serverResourceService.getResource(request);
   }
 
-  @Authorized("Server.view")
+  @Authorized("Server.read")
   @Get("/export/ecosystem")
   public HttpResponse<String> exportEcosystem(@QueryValue Optional<Boolean> download) {
     String json = serverService.exportToEcosystemFormat();
@@ -88,14 +88,14 @@ public class TerminologyServerController {
     return response;
   }
 
-  @Authorized("Server.view")
+  @Authorized("Server.read")
   @Post("/{id}/authoritative/{type}/preview")
   public List<AuthoritativeResource> previewAuthoritative(@PathVariable Long id, @PathVariable String type,
                                                           @Body List<AuthoritativeResource> patterns) {
     return authoritativeService.findMatchingResources(type, patterns);
   }
 
-  @Authorized("Server.view")
+  @Authorized("Server.read")
   @Get("/{id}/resources/{type}")
   public List<AuthoritativeResource> getMatchingResources(@PathVariable Long id, @PathVariable String type) {
     TerminologyServer server = serverService.load(id);
@@ -116,7 +116,7 @@ public class TerminologyServerController {
     return authoritativeService.findMatchingResources(type, patterns);
   }
 
-  @Authorized("Server.edit")
+  @Authorized("Server.write")
   @Post("/import/ecosystem")
   public List<TerminologyServer> importEcosystem(@Body String json) {
     return serverService.importFromEcosystemFormat(json).stream()

--- a/termx-core/src/main/java/org/termx/core/sys/space/SpaceController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/space/SpaceController.java
@@ -40,47 +40,47 @@ public class SpaceController {
   private final ImportLogger importLogger;
   private static final String JOB_TYPE = "space-import";
 
-  @Authorized(privilege = Privilege.S_EDIT)
+  @Authorized(privilege = Privilege.S_WRITE)
   @Post()
   public Space create(@Valid @Body Space p) {
     p.setId(null);
     return spaceService.save(p);
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Put("{id}")
   public Space update(@PathVariable Long id, @Valid @Body Space p) {
     p.setId(id);
     return spaceService.save(p);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("{id}")
   public Space load(@PathVariable Long id) {
     return spaceService.load(id);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{?params*}")
   public QueryResult<Space> search(SpaceQueryParams params) {
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.S_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.S_READ, Long::valueOf));
     return spaceService.query(params);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}/overview")
   public SpaceOverviewResponse overview(@PathVariable Long id, @Nullable @QueryValue String packageCode, @Nullable @QueryValue String version) {
     return overviewService.compose(id, packageCode, version);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}/diff")
   public HttpResponse<?> diff(@PathVariable Long id, @Nullable @QueryValue String packageCode, @Nullable @QueryValue String version) {
     LorqueProcess lorqueProcess = diffService.findDiff(id, packageCode, version);
     return HttpResponse.accepted().body(lorqueProcess);
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Post("/{id}/sync")
   public HttpResponse<?> syncResources(@PathVariable Long id, @Body Map<String, Object> request) {
     JobLogResponse response = syncService.syncResources(id,
@@ -90,7 +90,7 @@ public class SpaceController {
     return HttpResponse.accepted().body(response);
   }
 
-  @Authorized(privilege = Privilege.S_EDIT)
+  @Authorized(privilege = Privilege.S_WRITE)
   @Post(value = "/sync", consumes = MediaType.MULTIPART_FORM_DATA)
   public HttpResponse<?> importSpace(@Nullable Publisher<CompletedFileUpload> file) {
     if (file == null) {

--- a/termx-core/src/main/java/org/termx/core/sys/space/SpaceGithubController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/space/SpaceGithubController.java
@@ -27,38 +27,38 @@ public class SpaceGithubController {
     return spaceGithubService.orElseThrow(() -> new ApiClientException("github not configured on the server"));
   }
 
-  @Authorized(privilege = Privilege.S_VIEW)
+  @Authorized(privilege = Privilege.S_READ)
   @Get("/github/providers")
   public Map<String, String> getProviders() {
     return spaceGithubService.map(SpaceGithubService::getProviders).orElse(Map.of());
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Post("/{id}/github/authenticate")
   public SpaceGithubAuthResult authenticate(@PathVariable Long id, @Body SpaceGithubAuthRequest r) {
     return service().authenticate(id, r.returnUrl);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}/github/status")
   public GithubStatus prepareFiles(@PathVariable Long id) {
     return service().status(id);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}/github/diff")
   public GithubDiff prepareFiles(@PathVariable Long id, @QueryValue String file) {
     return service().diff(id, file);
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Post("/{id}/github/push")
   public HttpResponse<?> push(@PathVariable Long id, @Body SpaceGithubCommitRequest req) {
     service().push(id, req.message, req.files);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Post("/{id}/github/pull")
   public HttpResponse<?> pull(@PathVariable Long id, @Body SpaceGithubPullRequest req) {
     service().pull(id, req.files);

--- a/termx-core/src/main/java/org/termx/core/sys/spacepackage/PackageController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/spacepackage/PackageController.java
@@ -22,44 +22,44 @@ public class PackageController {
   private final PackageService packageService;
   private final PackageVersionService packageVersionService;
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get()
   public List<Package> loadPackages(@PathVariable Long spaceId) {
     return packageService.loadAll(spaceId);
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Post()
   public Package savePackage(@PathVariable Long spaceId, @Body PackageTransactionRequest request) {
     return packageService.save(request, spaceId);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}")
   public Package load(@PathVariable Long spaceId, @PathVariable Long id) {
     return packageService.load(spaceId, id);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}/versions")
   public List<PackageVersion> loadVersions(@PathVariable Long spaceId, @PathVariable Long id) {
     return packageVersionService.loadAll(spaceId, id);
   }
 
-  @Authorized(Privilege.S_VIEW)
+  @Authorized(Privilege.S_READ)
   @Get("/{id}/versions/{versionId}")
   public PackageVersion loadVersion(@PathVariable Long spaceId, @PathVariable Long id, @PathVariable Long versionId) {
     return packageVersionService.load(spaceId, id, versionId);
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Delete("/{id}")
   public HttpResponse<?> delete(@PathVariable Long spaceId, @PathVariable Long id) {
     packageService.delete(spaceId, id);
     return HttpResponse.ok();
   }
 
-  @Authorized(Privilege.S_EDIT)
+  @Authorized(Privilege.S_WRITE)
   @Delete("/{id}/versions/{versionId}")
   public HttpResponse<?> deleteVersion(@PathVariable Long spaceId, @PathVariable Long id, @PathVariable Long versionId) {
     packageVersionService.delete(spaceId, id, versionId);

--- a/termx-core/src/main/java/org/termx/core/sys/spacepackage/resource/PackageResourceController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/spacepackage/resource/PackageResourceController.java
@@ -28,21 +28,21 @@ public class PackageResourceController {
   private final PackageResourceService packageResourceService;
   private final PackageResourceSyncService packageResourceSyncService;
 
-  @Authorized(privilege = Privilege.S_VIEW)
+  @Authorized(privilege = Privilege.S_READ)
   @Get("/{?params*}")
   public List<PackageResource> loadAll(@NotNull @QueryValue Long spaceId, @Nullable @QueryValue String packageCode, @Nullable @QueryValue String version) {
     return packageResourceService.loadAll(spaceId, packageCode, version);
   }
 
 
-  @Authorized(privilege = Privilege.S_EDIT) //TODO: fix this
+  @Authorized(privilege = Privilege.S_WRITE) //TODO: fix this
   @Put("/{id}")
   public PackageResource update(@PathVariable Long id, @Valid @Body PackageResourceSaveRequest request) {
     request.getResource().setId(id);
     return packageResourceService.save(request.getVersionId(), request.getResource());
   }
 
-  @Authorized(privilege = Privilege.S_EDIT)
+  @Authorized(privilege = Privilege.S_WRITE)
   @Post("/change-server")
   public HttpResponse<?> update(@Valid @Body PackageResourceChangeServerRequest request) {
     packageResourceService.changeServer(request.getResourceIds(), request.getTerminologyServer());
@@ -50,7 +50,7 @@ public class PackageResourceController {
   }
 
 
-  @Authorized(privilege = Privilege.S_EDIT)
+  @Authorized(privilege = Privilege.S_WRITE)
   @Post(value = "/{id}/sync")
   public HttpResponse<?> importResource(@PathVariable Long id, @Valid @Body PackageResourceSyncRequest request) {
     //TODO: auth?

--- a/termx-core/src/main/java/org/termx/core/user/UserController.java
+++ b/termx-core/src/main/java/org/termx/core/user/UserController.java
@@ -17,7 +17,7 @@ import org.apache.commons.lang3.StringUtils;
 public class UserController {
   private final UserProvider userProvider;
 
-  @Authorized("*.Users.view")
+  @Authorized("*.Users.read")
   @Get("{?params*}")
   public List<User> loadAll(UserSearchParams params) {
     //TODO: auth

--- a/uam/src/main/java/org/termx/uam/Privileges.java
+++ b/uam/src/main/java/org/termx/uam/Privileges.java
@@ -1,6 +1,6 @@
 package org.termx.uam;
 
 public interface Privileges {
-  String P_VIEW = "Privilege.view";
-  String P_EDIT = "Privilege.edit";
+  String P_READ = "Privilege.read";
+  String P_WRITE = "Privilege.write";
 }

--- a/uam/src/main/java/org/termx/uam/privilege/PrivilegeController.java
+++ b/uam/src/main/java/org/termx/uam/privilege/PrivilegeController.java
@@ -15,34 +15,34 @@ import io.micronaut.http.annotation.Put;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import static org.termx.uam.Privileges.P_EDIT;
-import static org.termx.uam.Privileges.P_VIEW;
+import static org.termx.uam.Privileges.P_WRITE;
+import static org.termx.uam.Privileges.P_READ;
 
 @Controller("/uam/privileges")
 @RequiredArgsConstructor
 public class PrivilegeController {
   private final PrivilegeService privilegeService;
 
-  @Authorized(P_VIEW)
+  @Authorized(P_READ)
   @Get("{?params*}")
   public QueryResult<Privilege> query(PrivilegeQueryParams params) {
     return privilegeService.query(params);
   }
 
-  @Authorized(P_VIEW)
+  @Authorized(P_READ)
   @Get("/{id}")
   public Privilege load(@PathVariable Long id) {
     return privilegeService.load(id);
   }
 
-  @Authorized(P_EDIT)
+  @Authorized(P_WRITE)
   @Post
   public HttpResponse<?> create(@Body @Valid Privilege privilege) {
     privilegeService.save(privilege);
     return HttpResponse.created(privilege);
   }
 
-  @Authorized(P_EDIT)
+  @Authorized(P_WRITE)
   @Put("/{id}")
   public HttpResponse<?> update(@PathVariable Long id, @Body @Valid Privilege privilege) {
     privilege.setId(id);
@@ -50,7 +50,7 @@ public class PrivilegeController {
     return HttpResponse.created(privilege);
   }
 
-  @Authorized(P_EDIT)
+  @Authorized(P_WRITE)
   @Delete("/{id}")
   public HttpResponse<?> delete(@PathVariable Long id) {
     privilegeService.delete(id);

--- a/uam/src/main/java/org/termx/uam/privilege/PrivilegeStore.java
+++ b/uam/src/main/java/org/termx/uam/privilege/PrivilegeStore.java
@@ -66,17 +66,17 @@ public class PrivilegeStore implements PrivilegeDataHandler {
       return List.of();
     }
     List<String> privileges = new ArrayList<>();
-    if (actions.isView()) {
-      privileges.add(dottedPrivilege(id, type, "view"));
+    if (actions.isRead()) {
+      privileges.add(dottedPrivilege(id, type, "read"));
     }
     if (actions.isTriage()) {
       privileges.add(dottedPrivilege(id, type, "triage"));
     }
-    if (actions.isEdit()) {
-      privileges.add(dottedPrivilege(id, type, "edit"));
+    if (actions.isWrite()) {
+      privileges.add(dottedPrivilege(id, type, "write"));
     }
-    if (actions.isPublish()) {
-      privileges.add(dottedPrivilege(id, type, "publish"));
+    if (actions.isMaintain()) {
+      privileges.add(dottedPrivilege(id, type, "maintain"));
     }
     return privileges;
   }

--- a/uam/src/test/groovy/org/termx/uam/privilege/PrivilegeStoreTriageTest.groovy
+++ b/uam/src/test/groovy/org/termx/uam/privilege/PrivilegeStoreTriageTest.groovy
@@ -24,7 +24,7 @@ class PrivilegeStoreTriageTest extends Specification {
 
   def "calculate emits *.X.triage when actions.triage is true"() {
     given:
-    def actions = new PrivilegeResourceActions(view: true, triage: true, edit: false, publish: false)
+    def actions = new PrivilegeResourceActions(read: true, triage: true, write: false, maintain: false)
     def privilege = priv("triage-role-1", res("CodeSystem", "icd-10", actions))
 
     when:
@@ -32,26 +32,26 @@ class PrivilegeStoreTriageTest extends Specification {
 
     then:
     1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
-    result == ["icd-10.CodeSystem.view", "icd-10.CodeSystem.triage"] as Set
+    result == ["icd-10.CodeSystem.read", "icd-10.CodeSystem.triage"] as Set
   }
 
   def "calculate does not emit triage when actions.triage is false (legacy row)"() {
     given:
-    def actions = new PrivilegeResourceActions(view: true, triage: false, edit: false, publish: false)
-    def privilege = priv("legacy-view-only", res("CodeSystem", "icd-10", actions))
+    def actions = new PrivilegeResourceActions(read: true, triage: false, write: false, maintain: false)
+    def privilege = priv("legacy-read-only", res("CodeSystem", "icd-10", actions))
 
     when:
-    Set<String> result = store.getPrivileges("legacy-view-only")
+    Set<String> result = store.getPrivileges("legacy-read-only")
 
     then:
     1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
-    result == ["icd-10.CodeSystem.view"] as Set
+    result == ["icd-10.CodeSystem.read"] as Set
     !result.any { it.endsWith(".triage") }
   }
 
   def "calculate emits all four actions when all flags are true"() {
     given:
-    def actions = new PrivilegeResourceActions(view: true, triage: true, edit: true, publish: true)
+    def actions = new PrivilegeResourceActions(read: true, triage: true, write: true, maintain: true)
     def privilege = priv("full-role", res("CodeSystem", "icd-10", actions))
 
     when:
@@ -60,10 +60,10 @@ class PrivilegeStoreTriageTest extends Specification {
     then:
     1 * privilegeService.query(_ as PrivilegeQueryParams) >> new QueryResult<Privilege>([privilege])
     result == [
-      "icd-10.CodeSystem.view",
+      "icd-10.CodeSystem.read",
       "icd-10.CodeSystem.triage",
-      "icd-10.CodeSystem.edit",
-      "icd-10.CodeSystem.publish"
+      "icd-10.CodeSystem.write",
+      "icd-10.CodeSystem.maintain"
     ] as Set
   }
 
@@ -82,7 +82,7 @@ class PrivilegeStoreTriageTest extends Specification {
     description       | actions
     "triage-false"    | new PrivilegeResourceActions(triage: false)
     "triage-true"     | new PrivilegeResourceActions(triage: true)
-    "all-flags-true"  | new PrivilegeResourceActions(view: true, triage: true, edit: true, publish: true)
+    "all-flags-true"  | new PrivilegeResourceActions(read: true, triage: true, write: true, maintain: true)
   }
 
   def "Any resource type emits triage as *.<Type>.triage"() {

--- a/ucum/src/main/java/org/termx/ucum/Privilege.java
+++ b/ucum/src/main/java/org/termx/ucum/Privilege.java
@@ -1,6 +1,6 @@
 package org.termx.ucum;
 
 public interface Privilege {
-  String UCUM_VIEW = "ucum.CodeSystem.view";
-  String UCUM_EDIT = "ucum.CodeSystem.edit";
+  String UCUM_READ = "ucum.CodeSystem.read";
+  String UCUM_WRITE = "ucum.CodeSystem.write";
 }

--- a/ucum/src/main/java/org/termx/ucum/controller/UcumController.java
+++ b/ucum/src/main/java/org/termx/ucum/controller/UcumController.java
@@ -68,7 +68,7 @@ public class UcumController {
         schema = @Schema(implementation = UcumVersionDto.class)
       )
     )
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/version")
     public HttpResponse<UcumVersionDto> getUcumVersionDetails() {
         UcumVersionDto response = ucumService.getUcumVersionDetails();
@@ -83,7 +83,7 @@ public class UcumController {
           schema = @Schema(implementation = ValidateResponseDto.class)
         )
     )
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/validate")
     public HttpResponse<ValidateResponseDto> validate(
             @QueryValue(defaultValue = "") @NotBlank String code) {
@@ -108,7 +108,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/analyse")
     public HttpResponse<AnalyseResponseDto> analyse(
             @QueryValue(defaultValue = "") @NotBlank String code) throws UcumException {
@@ -137,7 +137,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/convert")
     public HttpResponse<ConvertResponseDto> convert(
             @Nullable @NotNull @QueryValue BigDecimal value,
@@ -168,7 +168,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/canonicalise")
     public HttpResponse<CanonicaliseResponseDto> getCanonicalUnits(
             @QueryValue(defaultValue = "") @NotBlank String code) throws UcumException {
@@ -189,7 +189,7 @@ public class UcumController {
         schema = @Schema(implementation = DefinedUnitDto.class, type = "array")
       )
     )
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/defined-units")
     public HttpResponse<List<DefinedUnitDto>> getDefinedUnits() {
         List<DefinedUnitDto> response = ucumService.getDefinedUnits();
@@ -213,7 +213,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/defined-units/{code}")
     public HttpResponse<DefinedUnitDto> getDefinedUnitByCode(@PathVariable String code) {
         DefinedUnitDto response = ucumService.getDefinedUnitByCode(code);
@@ -234,7 +234,7 @@ public class UcumController {
         schema = @Schema(implementation = BaseUnitDto.class, type = "array")
       )
     )
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/base-units")
     public HttpResponse<List<BaseUnitDto>> getBaseUnits() {
         List<BaseUnitDto> response = ucumService.getBaseUnits();
@@ -258,7 +258,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/base-units/{code}")
     public HttpResponse<BaseUnitDto> getBaseUnitByCode(@PathVariable String code) {
         BaseUnitDto response = ucumService.getBaseUnitByCode(code);
@@ -279,7 +279,7 @@ public class UcumController {
         schema = @Schema(implementation = PrefixDto.class, type = "array")
       )
     )
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/prefixes")
     public HttpResponse<List<PrefixDto>> getPrefixes() {
         List<PrefixDto> response = ucumService.getPrefixes();
@@ -303,7 +303,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Get("/prefixes/{code}")
     public HttpResponse<PrefixDto> getPrefixByCode(@PathVariable String code) {
         PrefixDto response = ucumService.getPrefixByCode(code);
@@ -333,7 +333,7 @@ public class UcumController {
         )
       )
     })
-    @Authorized(Privilege.UCUM_EDIT)
+    @Authorized(Privilege.UCUM_WRITE)
     @Post(value = "/essence/import", consumes = MediaType.MULTIPART_FORM_DATA)
     public JobLogResponse importEssence(@Part("file") CompletedFileUpload file) {
         byte[] xml = FileUtil.readBytes(file);
@@ -361,7 +361,7 @@ public class UcumController {
         schema = @Schema(implementation = UcumExportResponseDto.class)
       )
     )
-    @Authorized(Privilege.UCUM_VIEW)
+    @Authorized(Privilege.UCUM_READ)
     @Post("/export")
     public HttpResponse<UcumExportResponseDto> export(@Nullable @Body UcumExportRequestDto request) {
         try {

--- a/ucum/src/main/java/org/termx/ucum/security/Privilege.java
+++ b/ucum/src/main/java/org/termx/ucum/security/Privilege.java
@@ -1,6 +1,6 @@
 package org.termx.ucum.security;
 
 public interface Privilege {
-  String UCUM_VIEW = "ucum.CodeSystem.view";
-  String UCUM_EDIT = "ucum.CodeSystem.edit";
+  String UCUM_READ = "ucum.CodeSystem.read";
+  String UCUM_WRITE = "ucum.CodeSystem.write";
 }

--- a/wiki/src/main/java/org/termx/wiki/Privilege.java
+++ b/wiki/src/main/java/org/termx/wiki/Privilege.java
@@ -1,7 +1,7 @@
 package org.termx.wiki;
 
 public interface Privilege {
-  String W_VIEW = "Wiki.view";
+  String W_READ = "Wiki.read";
   String W_TRIAGE = "Wiki.triage";
-  String W_EDIT = "Wiki.edit";
+  String W_WRITE = "Wiki.write";
 }

--- a/wiki/src/main/java/org/termx/wiki/page/PageController.java
+++ b/wiki/src/main/java/org/termx/wiki/page/PageController.java
@@ -49,88 +49,88 @@ public class PageController {
   private final PageLinkService linkService;
   private final ProvenanceService provenanceService;
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get("/{id}")
   public Page getPage(@PathVariable Long id) {
     Page page = pageService.load(id).orElseThrow(() -> new NotFoundException("Page not found: " + id));
-    SessionStore.require().checkPermitted(page.getSpaceId().toString(), Privilege.W_VIEW);
+    SessionStore.require().checkPermitted(page.getSpaceId().toString(), Privilege.W_READ);
     return page;
   }
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get("{?params*}")
   public QueryResult<Page> queryPages(PageQueryParams params) {
-    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_VIEW, Long::valueOf));
+    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_READ, Long::valueOf));
     return pageService.query(params);
   }
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get("/tree")
   public List<PageTreeItem> loadTree(@NotNull @QueryValue Long spaceId) {
     return pageService.loadTree(spaceId);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Post
   public HttpResponse<?> createPage(@Body @Valid PageRequest request) {
-    SessionStore.require().checkPermitted(request.getPage().getSpaceId().toString(), Privilege.W_EDIT);
+    SessionStore.require().checkPermitted(request.getPage().getSpaceId().toString(), Privilege.W_WRITE);
     request.getPage().setId(null);
     Page page = pageService.save(request.getPage(), request.getContent());
     provenanceService.create(new Provenance("created", "Page", page.getId().toString()));
     return HttpResponse.created(page);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Put("/{id}")
   public HttpResponse<?> updatePage(@PathVariable Long id, @Body @Valid PageRequest request) {
-    SessionStore.require().checkPermitted(request.getPage().getSpaceId().toString(), Privilege.W_EDIT);
+    SessionStore.require().checkPermitted(request.getPage().getSpaceId().toString(), Privilege.W_WRITE);
     request.getPage().setId(id);
     Page page = pageService.save(request.getPage(), request.getContent());
     provenanceService.create(new Provenance("modified", "Page", page.getId().toString()));
     return HttpResponse.created(page);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Delete("/{id}")
   public HttpResponse<?> deletePage(@PathVariable Long id) {
-    validate(id, Privilege.W_EDIT);
+    validate(id, Privilege.W_WRITE);
     pageService.delete(id);
     provenanceService.create(new Provenance("deleted", "Page", id.toString()));
     return HttpResponse.ok();
   }
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get("/{id}/path")
   public List<Long> getPath(@PathVariable Long id) {
-    validate(id, Privilege.W_VIEW);
+    validate(id, Privilege.W_READ);
     return linkService.getPath(id);
   }
 
 
   /* Content */
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Post("/{id}/contents")
   public HttpResponse<?> savePageContent(@PathVariable Long id, @Body PageContent content) {
-    validate(id, Privilege.W_EDIT);
+    validate(id, Privilege.W_WRITE);
     PageContent persisted = contentService.save(content, id);
     provenanceService.create(new Provenance("modified", "Page", id.toString()));
     return HttpResponse.created(persisted);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Put("/{id}/contents/{contentId}")
   public HttpResponse<?> updatePageContent(@PathVariable Long id, @PathVariable Long contentId, @Body PageContent content) {
-    validate(id, Privilege.W_EDIT);
+    validate(id, Privilege.W_WRITE);
     PageContent persisted = contentService.save(content.setId(contentId), id);
     provenanceService.create(new Provenance("modified", "Page", id.toString()));
     return HttpResponse.created(persisted);
   }
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get("/{id}/contents/{contentId}/history{?params*}")
   public QueryResult<PageContentHistoryItem> queryPageContentHistory(@PathVariable Long id, @PathVariable Long contentId, PageContentHistoryQueryParams params) {
-    validate(id, Privilege.W_VIEW);
+    validate(id, Privilege.W_READ);
     params.setPermittedPageIds(List.of(id));
     params.setPermittedPageContentIds(List.of(contentId));
     return contentService.queryHistory(params);
@@ -139,32 +139,32 @@ public class PageController {
 
   /* Files */
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Post(value = "/{id}/files", consumes = MediaType.MULTIPART_FORM_DATA)
   public Map<String, PageAttachment> uploadFiles(@PathVariable Long id, @Body MultipartBody partz) {
-    validate(id, Privilege.W_EDIT);
+    validate(id, Privilege.W_WRITE);
     MultipartBodyReader.MultipartBody body = MultipartBodyReader.readMultipart(partz);
     return attachmentService.saveAttachments(id, body.getAttachments());
   }
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get("/{id}/files")
   public List<PageAttachment> getFiles(@PathVariable Long id) {
-    validate(id, Privilege.W_VIEW);
+    validate(id, Privilege.W_READ);
     return attachmentService.getAttachments(id);
   }
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get("/{id}/files/{fileName}")
   public StreamedFile getFile(@PathVariable Long id, @PathVariable String fileName) {
-    validate(id, Privilege.W_VIEW);
+    validate(id, Privilege.W_READ);
     return attachmentService.getAttachmentContent(id, fileName);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Delete("/{id}/files/{fileName}")
   public void deleteFile(@PathVariable Long id, @PathVariable String fileName) {
-    validate(id, Privilege.W_EDIT);
+    validate(id, Privilege.W_WRITE);
     attachmentService.deleteAttachmentContent(id, fileName);
   }
 

--- a/wiki/src/main/java/org/termx/wiki/pagecomment/PageCommentController.java
+++ b/wiki/src/main/java/org/termx/wiki/pagecomment/PageCommentController.java
@@ -40,7 +40,7 @@ public class PageCommentController {
     return HttpResponse.created(commentService.create(comment));
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Put("/{id}")
   public HttpResponse<?> update(@PathVariable Long id, @Body @Valid PageComment comment) {
     SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_TRIAGE);
@@ -48,20 +48,20 @@ public class PageCommentController {
     return HttpResponse.ok(commentService.update(comment));
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Delete("/{id}")
   public HttpResponse<?> delete(@PathVariable Long id) {
     PageComment comment = commentService.load(id);
-    SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_EDIT);
+    SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_WRITE);
     commentService.delete(id);
     return HttpResponse.noContent();
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Post("/{id}/resolve")
   public HttpResponse<?> resolve(@PathVariable Long id) {
     PageComment comment = commentService.load(id);
-    SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_EDIT);
+    SessionStore.require().checkPermitted(pageContentService.load(comment.getPageContentId()).getSpaceId().toString(), Privilege.W_WRITE);
     return HttpResponse.ok(commentService.resolve(id));
   }
 }

--- a/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentController.java
+++ b/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentController.java
@@ -15,10 +15,10 @@ import lombok.RequiredArgsConstructor;
 public class PageContentController {
   private final PageContentService pageContentService;
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get(uri = "{?params*}")
   public QueryResult<PageContent> queryPageContents(PageContentQueryParams params) {
-    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_VIEW, Long::valueOf));
+    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_READ, Long::valueOf));
     return pageContentService.query(params);
   }
 }

--- a/wiki/src/main/java/org/termx/wiki/pagelink/PageLinkController.java
+++ b/wiki/src/main/java/org/termx/wiki/pagelink/PageLinkController.java
@@ -20,14 +20,14 @@ import lombok.RequiredArgsConstructor;
 public class PageLinkController {
   private final PageLinkService pageLinkService;
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get(uri = "{?params*}")
   public QueryResult<PageLink> queryPages(PageLinkQueryParams params) {
-    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_VIEW, Long::valueOf));
+    params.setPermittedSpaceIds(SessionStore.require().getPermittedResourceIds(Privilege.W_READ, Long::valueOf));
     return pageLinkService.query(params);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Post(uri = "/{id}/move")
   public List<PageLink> movePage(@PathVariable Long id, @Body PageLinkMoveRequest req) {
     //TODO: auth

--- a/wiki/src/main/java/org/termx/wiki/pagerelation/PageRelationController.java
+++ b/wiki/src/main/java/org/termx/wiki/pagerelation/PageRelationController.java
@@ -15,7 +15,7 @@ public class PageRelationController {
 
   private final PageRelationService pageRelationService;
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get(uri = "{?params*}")
   public QueryResult<PageRelation> queryPageRelations(PageRelationQueryParams params) {
     //TODO auth

--- a/wiki/src/main/java/org/termx/wiki/space/WikiSpaceController.java
+++ b/wiki/src/main/java/org/termx/wiki/space/WikiSpaceController.java
@@ -20,11 +20,11 @@ import lombok.experimental.Accessors;
 public class WikiSpaceController {
   private final SpaceService spaceService;
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get()
   public List<WikiSpace> listSpaces() {
     SpaceQueryParams params = new SpaceQueryParams();
-    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.W_VIEW, Long::valueOf));
+    params.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.W_READ, Long::valueOf));
     params.all();
     return spaceService.query(params).getData().stream()
         .map(WikiSpace::fromSpace)

--- a/wiki/src/main/java/org/termx/wiki/tag/TagController.java
+++ b/wiki/src/main/java/org/termx/wiki/tag/TagController.java
@@ -14,7 +14,7 @@ public class TagController {
 
   private final TagService tagService;
 
-  @Authorized(Privilege.W_VIEW)
+  @Authorized(Privilege.W_READ)
   @Get
   public List<Tag> getAll() {
     //TODO: auth

--- a/wiki/src/main/java/org/termx/wiki/template/TemplateController.java
+++ b/wiki/src/main/java/org/termx/wiki/template/TemplateController.java
@@ -21,32 +21,32 @@ import lombok.RequiredArgsConstructor;
 public class TemplateController {
   private final TemplateService service;
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get(uri = "/{id}")
   public Template getTemplate(@PathVariable Long id) {
     return service.load(id).orElseThrow(() -> new NotFoundException("Template not found: " + id));
   }
 
-  @Authorized(privilege = Privilege.W_VIEW)
+  @Authorized(privilege = Privilege.W_READ)
   @Get(uri = "{?params*}")
   public QueryResult<Template> queryTemplates(TemplateQueryParams params) {
     return service.query(params);
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Post
   public HttpResponse<?> saveTemplate(@Body Template template) {
     return HttpResponse.created(service.save(template));
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Put(uri = "/{id}")
   public HttpResponse<?> updateTemplate(@PathVariable Long id,@Body Template template) {
     template.setId(id);
     return HttpResponse.created(service.save(template));
   }
 
-  @Authorized(privilege = Privilege.W_EDIT)
+  @Authorized(privilege = Privilege.W_WRITE)
   @Delete(uri = "/{id}")
   public HttpResponse<?> deleteTemplate(@PathVariable Long id) {
     service.cancel(id);

--- a/wiki/src/test/groovy/org/termx/wiki/pagecomment/PageCommentAuthAnnotationTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/pagecomment/PageCommentAuthAnnotationTest.groovy
@@ -9,9 +9,9 @@ import java.lang.reflect.Method
 /**
  * Verifies the comment endpoints are gated correctly per Phase A.2:
  *  - query (GET) and create (POST) require W_TRIAGE  (positional @Authorized(value=...))
- *  - update / delete / resolve still require W_EDIT  (named @Authorized(privilege=...))
+ *  - update / delete / resolve still require W_WRITE  (named @Authorized(privilege=...))
  *
- * Per Q4 of the migration spec, comment read is gated by triage (not view).
+ * Per Q4 of the migration spec, comment read is gated by triage (not read).
  *
  * The two annotation styles are tested explicitly:
  *  - positional: value() populated, privilege() empty
@@ -31,12 +31,12 @@ class PageCommentAuthAnnotationTest extends Specification {
     methodName << ["query", "create"]
   }
 
-  def "#methodName uses named @Authorized(privilege=W_EDIT)"() {
+  def "#methodName uses named @Authorized(privilege=W_WRITE)"() {
     given:
     def annotation = findMethod(PageCommentController, methodName).getAnnotation(Authorized)
 
     expect:
-    annotation.privilege() == Privilege.W_EDIT
+    annotation.privilege() == Privilege.W_WRITE
     annotation.value().toList() == []
 
     where:


### PR DESCRIPTION
## Summary

Phase B of the GitHub-style permission migration. Renames the three pre-existing privilege actions:
- `view` → `read`
- `edit` → `write`
- `publish` → `maintain`

`triage` (added in Phase A, #107) and admin (`*.*.*`) are unchanged.

The matching algorithm is action-agnostic, so this is a pure rename with no fallback shim. The IdP / Keycloak side must be updated in lockstep so issued JWTs carry the new strings.

## What changed

### Java
- 15 `Privilege.java` interfaces across modules (terminology, modeler, wiki, IG, observation-definition, snomed, ucum, uam, task, edition-est/int/uzb, termx-core)
- 429 constant references in controllers/services
- Literal `*.*.view|edit|publish` strings (and per-resource forms: `Server.*`, `Provenance.*`, `Sequence.*`, `Users.*`, etc.)
- `PrivilegeResource.PrivilegeResourceActions` DTO fields: `read / triage / write / maintain`
- `PrivilegeStore.calculate()` now emits new action names; reads `isRead/isWrite/isMaintain`
- `SessionFilter` Task derivation switch updated
- `YupiSessionProvider` defaults + javadoc

### Database

New Liquibase changeset `termx:rename_actions_view_edit_publish_to_read_write_maintain` in `02-privilege-actions-rename.sql`:
- Rewrites JSONB keys in `uam.privilege_resource.actions` (`view` → `read`, `edit` → `write`, `publish` → `maintain`)
- Idempotent: guarded by `jsonb_exists_any(actions, array['view','edit','publish'])` so it no-ops if already migrated
- Uses the function form to avoid JDBC parsing the `?|` operator as a positional bind parameter
- `triage` is preserved; `admin` rows (NULL actions) are skipped
- Has a working `--rollback`

`01-privilege-defaults.sql` is intentionally **not** modified so its checksum stays valid against existing databases. Fresh DBs get the old keys from 01 and are immediately rewritten by 02 — net result is the same as if 01 had the new keys.

### Mock seeds
- `mock/users.json` + `mock/users-demo.json` updated

### Tests (updated to new vocabulary, all pass)
- `SessionFilterTaskDerivationTest`
- `YupiSessionProviderTest`
- `PrivilegeStoreTriageTest`
- `PageCommentAuthAnnotationTest`

### Docs
- README "Yupi privilege override" section
- 9 feature/release docs under `docs/features/` and `docs/release-notes/`

## Coordination

- **Frontend**: shipped in the parallel termx-web PR. Both must land in the same release.
- **IdP / Keycloak**: any external auth provider that issues JWTs with literal privilege strings must be updated to emit the new vocabulary. The server reads strings as-is from the session — it does **not** translate `view` → `read` on the wire.

## Out of scope

- No backwards-compatibility shim for old strings (clean rename, per Phase A precedent).
- No changes to ACL access levels (`AclAccess.view/edit` is a separate system, deliberately untouched).

## Test plan

- [ ] Liquibase migration applies cleanly on a copy of prod (PG14)
- [ ] `02-privilege-actions-rename.sql` rollback reverses the change
- [ ] `/auth/userinfo` returns new action names for `editor`/`publisher`/`viewer` mock users
- [ ] Frontend (termx-web PR) renders CodeSystem list, Tasks widget, privilege editor with new keys
- [ ] Yupi flow: `./_run_local.sh` boots, `*.*.read` / `*.*.write` / `*.*.maintain` overrides work as documented