### PR TITLE
Refresh CodeSystem coding-value version references + configurable FHIR _summary default

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
@@ -25,16 +25,15 @@ import org.termx.ts.codesystem.CodeSystemImportAction;
 import org.termx.ts.codesystem.CodeSystemQueryParams;
 import org.termx.ts.codesystem.CodeSystemVersion;
 import com.kodality.zmei.fhir.FhirMapper;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 
 @Slf4j
 @Singleton
-@RequiredArgsConstructor
 public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
   private final CodeSystemService codeSystemService;
   private final CodeSystemVersionService codeSystemVersionService;
@@ -42,6 +41,23 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
   private final ProvenanceService provenanceService;
   private final CodeSystemImportService importService;
   private final CodeSystemFhirMapper mapper;
+  private final String defaultSearchSummary;
+
+  public CodeSystemResourceStorage(CodeSystemService codeSystemService,
+                                   CodeSystemVersionService codeSystemVersionService,
+                                   CodeSystemEntityVersionService codeSystemEntityVersionService,
+                                   ProvenanceService provenanceService,
+                                   CodeSystemImportService importService,
+                                   CodeSystemFhirMapper mapper,
+                                   @Value("${termx.fhir.codesystem.search.default-summary:true}") String defaultSearchSummary) {
+    this.codeSystemService = codeSystemService;
+    this.codeSystemVersionService = codeSystemVersionService;
+    this.codeSystemEntityVersionService = codeSystemEntityVersionService;
+    this.provenanceService = provenanceService;
+    this.importService = importService;
+    this.mapper = mapper;
+    this.defaultSearchSummary = defaultSearchSummary;
+  }
 
   @Override
   public String getResourceType() {
@@ -110,10 +126,15 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
     QueryResult<CodeSystem> csResult = codeSystemService.query(CodeSystemFhirMapper.fromFhir(criteria));
     QueryResult<CodeSystemVersion> csvResult = codeSystemVersionService.query(CodeSystemFhirMapper.fromFhirCSVersionParams(criteria).limit(0));
     String code = criteria.getRawParams().containsKey("code") ? criteria.getRawParams().get("code").get(0) : null;
+    boolean lightweight = isLightweightSummary(criteria.getSummary() != null ? criteria.getSummary() : defaultSearchSummary);
     return new SearchResult(csvResult.getMeta().getTotal(), csResult.getData().stream().flatMap(cs -> cs.getVersions().stream().map(csv -> {
-      csv.setEntities(loadEntities(csv, code, false));
+      csv.setEntities(lightweight ? List.of() : loadEntities(csv, code, false));
       return toFhir(cs, csv);
     })).toList());
+  }
+
+  private static boolean isLightweightSummary(String summary) {
+    return summary != null && !summary.isBlank() && !"false".equalsIgnoreCase(summary);
   }
 
   private List<CodeSystemEntityVersion> loadEntities(CodeSystemVersion version, String code, boolean loadLargeEntities) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
@@ -16,20 +16,36 @@ import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
 import org.termx.ts.valueset.ValueSet;
 import org.termx.ts.valueset.ValueSetQueryParams;
 import org.termx.ts.valueset.ValueSetVersion;
+import org.termx.ts.valueset.ValueSetVersionRuleSet;
 import com.kodality.zmei.fhir.FhirMapper;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Singleton;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Optional;
 import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 
 @Singleton
-@RequiredArgsConstructor
 public class ValueSetResourceStorage extends BaseFhirResourceHandler {
   private final ValueSetService valueSetService;
   private final ValueSetVersionService valueSetVersionService;
   private final ValueSetFhirImportService importService;
   private final ProvenanceService provenanceService;
   private final ValueSetFhirMapper mapper;
+  private final String defaultSearchSummary;
+
+  public ValueSetResourceStorage(ValueSetService valueSetService,
+                                 ValueSetVersionService valueSetVersionService,
+                                 ValueSetFhirImportService importService,
+                                 ProvenanceService provenanceService,
+                                 ValueSetFhirMapper mapper,
+                                 @Value("${termx.fhir.valueset.search.default-summary:true}") String defaultSearchSummary) {
+    this.valueSetService = valueSetService;
+    this.valueSetVersionService = valueSetVersionService;
+    this.importService = importService;
+    this.provenanceService = provenanceService;
+    this.mapper = mapper;
+    this.defaultSearchSummary = defaultSearchSummary;
+  }
 
   @Override
   public String getResourceType() {
@@ -80,8 +96,23 @@ public class ValueSetResourceStorage extends BaseFhirResourceHandler {
   public SearchResult search(SearchCriterion criteria) {
     QueryResult<ValueSet> vsResult = valueSetService.query(ValueSetFhirMapper.fromFhir(criteria));
     QueryResult<ValueSetVersion> vsvResult = valueSetVersionService.query(ValueSetFhirMapper.fromFhirVSVersionParams(criteria).limit(0));
+    boolean lightweight = isLightweightSummary(criteria.getSummary() != null ? criteria.getSummary() : defaultSearchSummary);
     return new SearchResult(vsvResult.getMeta().getTotal(),
-        vsResult.getData().stream().flatMap(vs -> vs.getVersions().stream().map(vsv -> toFhir(vs, vsv))).toList());
+        vsResult.getData().stream().flatMap(vs -> vs.getVersions().stream().map(vsv -> toFhir(vs, applyLightweight(vsv, lightweight)))).toList());
+  }
+
+  private static boolean isLightweightSummary(String summary) {
+    return summary != null && !summary.isBlank() && !"false".equalsIgnoreCase(summary);
+  }
+
+  private static ValueSetVersion applyLightweight(ValueSetVersion vsv, boolean lightweight) {
+    if (!lightweight || vsv == null) {
+      return vsv;
+    }
+    Optional.ofNullable(vsv.getRuleSet())
+        .map(ValueSetVersionRuleSet::getRules)
+        .ifPresent(rules -> rules.forEach(r -> r.setConcepts(null)));
+    return vsv;
   }
 
   private ResourceVersion toFhir(ValueSet vs, ValueSetVersion vsv) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueCodingEnrichmentService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueCodingEnrichmentService.java
@@ -4,11 +4,13 @@ import com.kodality.commons.util.JsonUtil;
 import org.termx.terminology.terminology.codesystem.concept.ConceptService;
 import org.termx.terminology.terminology.codesystem.designation.DesignationService;
 import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionRepository;
-import org.termx.ts.codesystem.ConceptSnapshot;
-import org.termx.ts.codesystem.ConceptQueryParams;
+import org.termx.ts.PublicationStatus;
 import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
+import org.termx.ts.codesystem.CodingValueUpdateCandidate;
 import org.termx.ts.codesystem.Concept;
+import org.termx.ts.codesystem.ConceptQueryParams;
+import org.termx.ts.codesystem.ConceptSnapshot;
 import org.termx.ts.codesystem.Designation;
 import org.termx.ts.codesystem.DesignationQueryParams;
 import org.termx.ts.codesystem.EntityPropertyValue;
@@ -20,12 +22,14 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -33,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EntityPropertyValueCodingEnrichmentService {
   private static final int DEFAULT_BATCH_SIZE = 100;
+  public static final int SYNC_RECALCULATE_THRESHOLD = 200;
   private final AtomicBoolean running = new AtomicBoolean(false);
 
   private final EntityPropertyValueUpdateQueueRepository queueRepository;
@@ -61,49 +66,115 @@ public class EntityPropertyValueCodingEnrichmentService {
 
   @Transactional
   protected boolean processSingleBatch(int limit) {
-    List<Pair<Long, Long>> queued = queueRepository.loadNextBatch(limit);
+    List<Triple<Long, Long, String>> queued = queueRepository.loadNextBatch(limit);
     if (queued.isEmpty()) {
       return false;
     }
     long started = System.currentTimeMillis();
-    List<Long> codeSystemEntityVersionIds = queued.stream().map(Pair::getRight).distinct().toList();
-    log.info("Coding enrichment batch started: queueItems={}, codeSystemEntityVersions={}", queued.size(), codeSystemEntityVersionIds.size());
-    enrichCodeSystemEntityVersions(codeSystemEntityVersionIds);
-    queueRepository.complete(queued.stream().map(Pair::getLeft).toList());
+    Map<String, List<Long>> grouped = queued.stream().collect(Collectors.groupingBy(
+        t -> Optional.ofNullable(t.getRight()).orElse(""),
+        Collectors.mapping(Triple::getMiddle, Collectors.toList())));
+    int totalIds = 0;
+    for (Map.Entry<String, List<Long>> entry : grouped.entrySet()) {
+      List<String> allowedStatuses = parseStatuses(entry.getKey());
+      List<Long> ids = entry.getValue().stream().distinct().toList();
+      totalIds += ids.size();
+      enrichCodeSystemEntityVersions(ids, allowedStatuses);
+    }
+    log.info("Coding enrichment batch started: queueItems={}, codeSystemEntityVersions={}", queued.size(), totalIds);
+    queueRepository.complete(queued.stream().map(Triple::getLeft).toList());
     log.info("Coding enrichment batch finished: queueItems={}, codeSystemEntityVersions={}, durationMs={}",
-        queued.size(), codeSystemEntityVersionIds.size(), System.currentTimeMillis() - started);
+        queued.size(), totalIds, System.currentTimeMillis() - started);
     return true;
   }
 
-  private void enrichCodeSystemEntityVersions(List<Long> codeSystemEntityVersionIds) {
+  @Transactional
+  public int recalculateForEntityVersion(Long csevId, List<String> allowedStatuses) {
+    return enrichCodeSystemEntityVersions(List.of(csevId), allowedStatuses);
+  }
+
+  public Map<String, Object> recalculateForCodeSystemVersion(String codeSystem, String version, List<String> allowedStatuses) {
+    List<Long> csevIds = entityPropertyValueRepository.loadCodeSystemEntityVersionIdsByCsAndVersion(codeSystem, version);
+    if (csevIds.isEmpty()) {
+      return Map.of("applied", 0);
+    }
+    if (csevIds.size() <= SYNC_RECALCULATE_THRESHOLD) {
+      int applied = enrichCodeSystemEntityVersions(csevIds, allowedStatuses);
+      return Map.of("applied", applied);
+    }
+    queueRepository.markForUpdate(csevIds, serializeStatuses(allowedStatuses));
+    return Map.of("queued", csevIds.size());
+  }
+
+  public List<CodingValueUpdateCandidate> findOutdatedCodingValuesForEntityVersion(Long csevId, List<String> allowedStatuses) {
+    return findOutdatedCodingValues(List.of(csevId), allowedStatuses);
+  }
+
+  public List<CodingValueUpdateCandidate> findOutdatedCodingValuesForCodeSystemVersion(String codeSystem, String version, List<String> allowedStatuses) {
+    List<Long> csevIds = entityPropertyValueRepository.loadCodeSystemEntityVersionIdsByCsAndVersion(codeSystem, version);
+    if (csevIds.isEmpty()) {
+      return List.of();
+    }
+    return findOutdatedCodingValues(csevIds, allowedStatuses);
+  }
+
+  private List<CodingValueUpdateCandidate> findOutdatedCodingValues(List<Long> codeSystemEntityVersionIds, List<String> allowedStatuses) {
     List<EntityPropertyValue> codingValues = entityPropertyValueRepository.loadCodingValuesByCodeSystemEntityVersionIds(codeSystemEntityVersionIds);
     if (codingValues.isEmpty()) {
-      return;
+      return List.of();
     }
+    Map<String, Map<String, Concept>> conceptsByCodeSystem = loadTargetConcepts(codingValues);
+    List<CodingValueUpdateCandidate> candidates = new ArrayList<>();
+    for (EntityPropertyValue pv : codingValues) {
+      EntityPropertyValueCodingValue cv = pv.asCodingValue();
+      if (StringUtils.isBlank(cv.getCode()) || StringUtils.isBlank(cv.getCodeSystem())) {
+        continue;
+      }
+      Concept concept = conceptsByCodeSystem.getOrDefault(cv.getCodeSystem(), Map.of()).get(cv.getCode());
+      if (concept == null) {
+        continue;
+      }
+      Pair<String, String> resolved = resolveTargetVersion(concept, allowedStatuses);
+      if (resolved == null) {
+        continue;
+      }
+      String candidateVersion = resolved.getLeft();
+      String candidateStatus = resolved.getRight();
+      if (!StringUtils.equals(cv.getVersion(), candidateVersion)) {
+        candidates.add(new CodingValueUpdateCandidate()
+            .setPropertyValueId(pv.getId())
+            .setCodeSystemEntityVersionId(pv.getCodeSystemEntityVersionId())
+            .setEntityProperty(pv.getEntityProperty())
+            .setTargetCodeSystem(cv.getCodeSystem())
+            .setTargetCode(cv.getCode())
+            .setCurrentVersion(cv.getVersion())
+            .setCandidateVersion(candidateVersion)
+            .setCandidateStatus(candidateStatus));
+      }
+    }
+    return candidates;
+  }
 
-    Map<String, List<EntityPropertyValue>> byCodeSystem = codingValues.stream()
-        .filter(pv -> StringUtils.isNotBlank(pv.asCodingValue().getCodeSystem()))
-        .collect(Collectors.groupingBy(pv -> pv.asCodingValue().getCodeSystem()));
-
-    Map<String, Map<String, Concept>> conceptsByCodeSystem = byCodeSystem.entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> loadConceptsByCode(e.getKey(), e.getValue())));
+  protected int enrichCodeSystemEntityVersions(List<Long> codeSystemEntityVersionIds, List<String> allowedStatuses) {
+    List<EntityPropertyValue> codingValues = entityPropertyValueRepository.loadCodingValuesByCodeSystemEntityVersionIds(codeSystemEntityVersionIds);
+    if (codingValues.isEmpty()) {
+      return 0;
+    }
+    Map<String, Map<String, Concept>> conceptsByCodeSystem = loadTargetConcepts(codingValues);
 
     List<EntityPropertyValue> changedValues = new ArrayList<>();
-    for (Map.Entry<String, List<EntityPropertyValue>> entry : byCodeSystem.entrySet()) {
-      Map<String, Concept> conceptsByCode = conceptsByCodeSystem.getOrDefault(entry.getKey(), Map.of());
-      for (EntityPropertyValue propertyValue : entry.getValue()) {
-        EntityPropertyValueCodingValue codingValue = propertyValue.asCodingValue();
-        if (StringUtils.isBlank(codingValue.getCode())) {
-          continue;
-        }
-        Concept concept = conceptsByCode.get(codingValue.getCode());
-        if (concept == null) {
-          continue;
-        }
-        if (applyEnrichment(codingValue, concept)) {
-          propertyValue.setValue(codingValue);
-          changedValues.add(propertyValue);
-        }
+    for (EntityPropertyValue propertyValue : codingValues) {
+      EntityPropertyValueCodingValue codingValue = propertyValue.asCodingValue();
+      if (StringUtils.isBlank(codingValue.getCode()) || StringUtils.isBlank(codingValue.getCodeSystem())) {
+        continue;
+      }
+      Concept concept = conceptsByCodeSystem.getOrDefault(codingValue.getCodeSystem(), Map.of()).get(codingValue.getCode());
+      if (concept == null) {
+        continue;
+      }
+      if (applyEnrichment(codingValue, concept, allowedStatuses)) {
+        propertyValue.setValue(codingValue);
+        changedValues.add(propertyValue);
       }
     }
     if (!changedValues.isEmpty()) {
@@ -111,6 +182,15 @@ public class EntityPropertyValueCodingEnrichmentService {
       log.debug("Updated {} coding property values for {} code_system_entity_version records", changedValues.size(), codeSystemEntityVersionIds.size());
     }
     updateSnapshots(codeSystemEntityVersionIds, codingValues);
+    return changedValues.size();
+  }
+
+  private Map<String, Map<String, Concept>> loadTargetConcepts(List<EntityPropertyValue> codingValues) {
+    Map<String, List<EntityPropertyValue>> byCodeSystem = codingValues.stream()
+        .filter(pv -> StringUtils.isNotBlank(pv.asCodingValue().getCodeSystem()))
+        .collect(Collectors.groupingBy(pv -> pv.asCodingValue().getCodeSystem()));
+    return byCodeSystem.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> loadConceptsByCode(e.getKey(), e.getValue())));
   }
 
   private Map<String, Concept> loadConceptsByCode(String codeSystem, List<EntityPropertyValue> values) {
@@ -131,19 +211,15 @@ public class EntityPropertyValueCodingEnrichmentService {
         .collect(Collectors.toMap(Concept::getCode, c -> c, (left, right) -> left));
   }
 
-  private boolean applyEnrichment(EntityPropertyValueCodingValue codingValue, Concept concept) {
+  private boolean applyEnrichment(EntityPropertyValueCodingValue codingValue, Concept concept, List<String> allowedStatuses) {
     List<EntityPropertyValueCodingDesignationValue> display = concept.getLastVersion()
         .map(CodeSystemEntityVersion::getDesignations)
         .orElse(List.of())
         .stream()
         .map(this::mapDesignation)
         .toList();
-    String version = concept.getLastVersion()
-        .map(CodeSystemEntityVersion::getVersions)
-        .filter(v -> v != null && !v.isEmpty())
-        .flatMap(v -> v.stream().findFirst())
-        .map(CodeSystemVersionReference::getVersion)
-        .orElse(null);
+    Pair<String, String> resolved = resolveTargetVersion(concept, allowedStatuses);
+    String version = resolved == null ? null : resolved.getLeft();
 
     boolean changed = false;
     if (!StringUtils.equals(JsonUtil.toJson(codingValue.getDisplay()), JsonUtil.toJson(display))) {
@@ -155,6 +231,26 @@ public class EntityPropertyValueCodingEnrichmentService {
       changed = true;
     }
     return changed;
+  }
+
+  private Pair<String, String> resolveTargetVersion(Concept concept, List<String> allowedStatuses) {
+    if (allowedStatuses == null || allowedStatuses.isEmpty()) {
+      return concept.getLastVersion()
+          .map(CodeSystemEntityVersion::getVersions)
+          .filter(v -> v != null && !v.isEmpty())
+          .flatMap(v -> v.stream().findFirst())
+          .map(csv -> Pair.of(csv.getVersion(), csv.getStatus()))
+          .orElse(null);
+    }
+    return Optional.ofNullable(concept.getVersions()).orElse(List.of()).stream()
+        .filter(ev -> !PublicationStatus.retired.equals(ev.getStatus()))
+        .flatMap(ev -> Optional.ofNullable(ev.getVersions()).orElse(List.of()).stream())
+        .filter(csv -> allowedStatuses.contains(csv.getStatus()))
+        .max(Comparator
+            .comparing(CodeSystemVersionReference::getReleaseDate, Comparator.nullsFirst(Comparator.naturalOrder()))
+            .thenComparing(CodeSystemVersionReference::getVersion, Comparator.nullsFirst(Comparator.naturalOrder())))
+        .map(csv -> Pair.of(csv.getVersion(), csv.getStatus()))
+        .orElse(null);
   }
 
   private EntityPropertyValueCodingDesignationValue mapDesignation(Designation designation) {
@@ -212,5 +308,19 @@ public class EntityPropertyValueCodingEnrichmentService {
         null,
         null
     );
+  }
+
+  static String serializeStatuses(List<String> allowedStatuses) {
+    if (allowedStatuses == null || allowedStatuses.isEmpty()) {
+      return null;
+    }
+    return allowedStatuses.stream().filter(Objects::nonNull).distinct().collect(Collectors.joining(","));
+  }
+
+  static List<String> parseStatuses(String csv) {
+    if (csv == null || csv.isBlank()) {
+      return List.of();
+    }
+    return java.util.Arrays.stream(csv.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueCodingRefreshController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueCodingRefreshController.java
@@ -1,0 +1,113 @@
+package org.termx.terminology.terminology.codesystem.entitypropertyvalue;
+
+import com.kodality.commons.exception.NotFoundException;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.HttpStatus;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.termx.core.auth.Authorized;
+import org.termx.core.auth.SessionStore;
+import org.termx.terminology.Privilege;
+import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService;
+import org.termx.ts.PublicationStatus;
+import org.termx.ts.codesystem.CodeSystemEntityVersion;
+import org.termx.ts.codesystem.CodingValueUpdateCandidate;
+
+@Controller("/ts")
+@RequiredArgsConstructor
+public class EntityPropertyValueCodingRefreshController {
+  private static final Set<String> VALID_STATUSES = Set.of(PublicationStatus.active, PublicationStatus.draft, PublicationStatus.retired);
+  private static final List<String> DEFAULT_STATUSES = List.of(PublicationStatus.active, PublicationStatus.draft);
+
+  private final EntityPropertyValueCodingEnrichmentService enrichmentService;
+  private final CodeSystemEntityVersionService codeSystemEntityVersionService;
+
+  @Authorized(privilege = Privilege.CS_WRITE)
+  @Get(uri = "/code-system-entity-versions/{id}/coding-value-update-candidates")
+  public List<CodingValueUpdateCandidate> getEntityVersionCandidates(@PathVariable Long id, @Nullable @QueryValue String allowedStatuses) {
+    checkEntityVersionWrite(id);
+    return enrichmentService.findOutdatedCodingValuesForEntityVersion(id, parseAndValidate(allowedStatuses));
+  }
+
+  @Authorized(privilege = Privilege.CS_WRITE)
+  @Post(uri = "/code-system-entity-versions/{id}/refresh-coding-values")
+  public Map<String, Object> refreshEntityVersion(@PathVariable Long id, @Nullable @Body RefreshRequest body) {
+    checkEntityVersionWrite(id);
+    int applied = enrichmentService.recalculateForEntityVersion(id, parseAndValidate(body == null ? null : body.getAllowedStatuses()));
+    return Map.of("applied", applied);
+  }
+
+  @Authorized(privilege = Privilege.CS_WRITE)
+  @Get(uri = "/code-systems/{codeSystem}/versions/{version}/coding-value-update-candidates")
+  public List<CodingValueUpdateCandidate> getCodeSystemVersionCandidates(@PathVariable String codeSystem,
+                                                                        @PathVariable String version,
+                                                                        @Nullable @QueryValue String allowedStatuses) {
+    SessionStore.require().checkPermitted(codeSystem, Privilege.CS_WRITE);
+    return enrichmentService.findOutdatedCodingValuesForCodeSystemVersion(codeSystem, version, parseAndValidate(allowedStatuses));
+  }
+
+  @Authorized(privilege = Privilege.CS_WRITE)
+  @Post(uri = "/code-systems/{codeSystem}/versions/{version}/refresh-coding-values")
+  public Map<String, Object> refreshCodeSystemVersion(@PathVariable String codeSystem,
+                                                     @PathVariable String version,
+                                                     @Nullable @Body RefreshRequest body) {
+    SessionStore.require().checkPermitted(codeSystem, Privilege.CS_WRITE);
+    return enrichmentService.recalculateForCodeSystemVersion(codeSystem, version, parseAndValidate(body == null ? null : body.getAllowedStatuses()));
+  }
+
+  private void checkEntityVersionWrite(Long id) {
+    CodeSystemEntityVersion csev = codeSystemEntityVersionService.load(id);
+    if (csev == null) {
+      throw new NotFoundException("CodeSystemEntityVersion not found: " + id);
+    }
+    SessionStore.require().checkPermitted(csev.getCodeSystem(), Privilege.CS_WRITE);
+  }
+
+  private List<String> parseAndValidate(String raw) {
+    List<String> statuses = parse(raw);
+    for (String s : statuses) {
+      if (!VALID_STATUSES.contains(s)) {
+        throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Invalid status: " + s);
+      }
+    }
+    return statuses;
+  }
+
+  private List<String> parseAndValidate(List<String> raw) {
+    if (raw == null) {
+      return DEFAULT_STATUSES;
+    }
+    for (String s : raw) {
+      if (!VALID_STATUSES.contains(s)) {
+        throw new HttpStatusException(HttpStatus.BAD_REQUEST, "Invalid status: " + s);
+      }
+    }
+    return raw.isEmpty() ? DEFAULT_STATUSES : raw;
+  }
+
+  private List<String> parse(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return DEFAULT_STATUSES;
+    }
+    List<String> parsed = Arrays.stream(raw.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
+    return parsed.isEmpty() ? DEFAULT_STATUSES : parsed;
+  }
+
+  @Getter
+  @Setter
+  public static class RefreshRequest {
+    private List<String> allowedStatuses;
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueRepository.java
@@ -151,6 +151,14 @@ public class EntityPropertyValueRepository extends BaseRepository {
     return getBeans(sb.getSql(), bp, sb.getParams());
   }
 
+  public List<Long> loadCodeSystemEntityVersionIdsByCsAndVersion(String codeSystem, String version) {
+    String sql = "select distinct evcsvm.code_system_entity_version_id " +
+        "from terminology.entity_version_code_system_version_membership evcsvm " +
+        "inner join terminology.code_system_version csv on csv.id = evcsvm.code_system_version_id and csv.sys_status = 'A' " +
+        "where evcsvm.sys_status = 'A' and csv.code_system = ? and csv.version = ?";
+    return jdbcTemplate.queryForList(sql, Long.class, codeSystem, version);
+  }
+
   public void updateValues(List<EntityPropertyValue> values) {
     if (values == null || values.isEmpty()) {
       return;

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueUpdateQueueRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueUpdateQueueRepository.java
@@ -8,21 +8,30 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 
 @Singleton
 public class EntityPropertyValueUpdateQueueRepository extends BaseRepository {
 
   public void markForUpdate(List<Long> codeSystemEntityVersionIds) {
+    markForUpdate(codeSystemEntityVersionIds, null);
+  }
+
+  public void markForUpdate(List<Long> codeSystemEntityVersionIds, String allowedStatuses) {
     if (codeSystemEntityVersionIds == null || codeSystemEntityVersionIds.isEmpty()) {
       return;
     }
-    String sql = "insert into terminology.code_system_entity_version_update_queue (code_system_entity_version_id) values (?) " +
-        "on conflict (code_system_entity_version_id) where sys_status = 'A' do nothing";
+    String sql = "insert into terminology.code_system_entity_version_update_queue (code_system_entity_version_id, allowed_statuses) values (?, ?) " +
+        "on conflict (code_system_entity_version_id) where sys_status = 'A' do update set allowed_statuses = excluded.allowed_statuses";
     jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
       @Override
       public void setValues(PreparedStatement ps, int i) throws SQLException {
         ps.setLong(1, codeSystemEntityVersionIds.get(i));
+        if (allowedStatuses == null) {
+          ps.setNull(2, java.sql.Types.VARCHAR);
+        } else {
+          ps.setString(2, allowedStatuses);
+        }
       }
 
       @Override
@@ -32,10 +41,12 @@ public class EntityPropertyValueUpdateQueueRepository extends BaseRepository {
     });
   }
 
-  public List<Pair<Long, Long>> loadNextBatch(int limit) {
-    String sql = "select id, code_system_entity_version_id from terminology.code_system_entity_version_update_queue " +
+  public List<Triple<Long, Long, String>> loadNextBatch(int limit) {
+    String sql = "select id, code_system_entity_version_id, allowed_statuses from terminology.code_system_entity_version_update_queue " +
         "where sys_status = 'A' order by id limit ? for update skip locked";
-    return jdbcTemplate.query(sql, (rs, rowNum) -> Pair.of(rs.getLong("id"), rs.getLong("code_system_entity_version_id")), limit);
+    return jdbcTemplate.query(sql,
+        (rs, rowNum) -> Triple.of(rs.getLong("id"), rs.getLong("code_system_entity_version_id"), rs.getString("allowed_statuses")),
+        limit);
   }
 
   public void complete(List<Long> queueIds) {

--- a/terminology/src/main/resources/terminology/changelog/terminology/13-update_queue_allowed_statuses.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/13-update_queue_allowed_statuses.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset kodality:code_system_entity_version_update_queue_allowed_statuses
+alter table terminology.code_system_entity_version_update_queue
+    add column if not exists allowed_statuses text;
+--rollback alter table terminology.code_system_entity_version_update_queue drop column if exists allowed_statuses;

--- a/terminology/src/main/resources/terminology/changelog/terminology/changelog.xml
+++ b/terminology/src/main/resources/terminology/changelog/terminology/changelog.xml
@@ -17,6 +17,7 @@
     <include file="09-naming_system.sql" relativeToChangelogFile="true"/>
     <include file="10-code_system_entity_version_update_queue.sql" relativeToChangelogFile="true"/>
     <include file="12-closure.sql" relativeToChangelogFile="true"/>
+    <include file="13-update_queue_allowed_statuses.sql" relativeToChangelogFile="true"/>
 
     <include file="views/concept_closure.sql" relativeToChangelogFile="true"/>
     <include file="views/concept_name.sql" relativeToChangelogFile="true"/>

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodingValueUpdateCandidate.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodingValueUpdateCandidate.java
@@ -1,0 +1,25 @@
+package org.termx.ts.codesystem;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Setter
+@Introspected
+@Accessors(chain = true)
+public class CodingValueUpdateCandidate {
+  private Long propertyValueId;
+  private Long codeSystemEntityVersionId;
+  private String entityProperty;
+  private String targetCodeSystem;
+  private String targetCode;
+  @Nullable
+  private String currentVersion;
+  @Nullable
+  private String candidateVersion;
+  @Nullable
+  private String candidateStatus;
+}

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -41,13 +41,13 @@ info:
 datasources:
   default:
     url: ${DB_URL:`jdbc:postgresql://localhost:5432/termx`}
-    username: termserver_app
+    username: tx_app
     password: ${DB_APP_PASSWORD:test}
     maximum-pool-size: ${DB_POOL_SIZE:10}
     driver-class-name: org.postgresql.Driver
   liquibase:
     url: ${DB_URL:`jdbc:postgresql://localhost:5432/termx`}
-    username: termserver_admin
+    username: tx_admin
     password: ${DB_ADMIN_PASSWORD:test}
     driver-class-name: org.postgresql.Driver
     maximum-pool-size: 1
@@ -104,6 +104,17 @@ termx:
     codesystem:
       lookup:
         default-property-mode: ALL
+      search:
+        # Default value applied to `_summary` when the client does not pass it
+        # on GET /fhir/CodeSystem search. Accepts: true | text | data | count | false.
+        # `true` (or any non-`false` value) suppresses the heavy `concept` list in
+        # search results. Override per request with `?_summary=...`.
+        default-summary: ${TERMX_FHIR_CS_SEARCH_DEFAULT_SUMMARY:true}
+    valueset:
+      search:
+        # Same as codesystem.search.default-summary, but for GET /fhir/ValueSet.
+        # When non-`false`, inline `compose.include.concept` lists are suppressed.
+        default-summary: ${TERMX_FHIR_VS_SEARCH_DEFAULT_SUMMARY:true}
 
 javamail:
   authentication:


### PR DESCRIPTION
## Summary

Two related backend changes reported by end-users:

**1. Refresh CodeSystem coding-value version references** *(Problem 10)*

Property values of type `Coding` store the referenced CodeSystem's version as a frozen string at property-save time, so importing a new version of the referenced CodeSystem does not propagate to existing references (e.g. LOINC pinned to `2.73` long after `2.75` is published).

- New `CodingValueUpdateCandidate` DTO + Liquibase changeset (`allowed_statuses` on `code_system_entity_version_update_queue`).
- `EntityPropertyValueCodingEnrichmentService` now resolves the target version against an optional allowed-status filter (default `active,draft`) and exposes `findOutdatedCodingValues...` / `recalculateForEntityVersion` / `recalculateForCodeSystemVersion`.
- New `EntityPropertyValueCodingRefreshController` under `/ts` with four endpoints (all `CS_WRITE`):
  - `GET /ts/code-system-entity-versions/{id}/coding-value-update-candidates`
  - `POST /ts/code-system-entity-versions/{id}/refresh-coding-values`
  - `GET /ts/code-systems/{cs}/versions/{v}/coding-value-update-candidates`
  - `POST /ts/code-systems/{cs}/versions/{v}/refresh-coding-values` *(sync ≤ 200 entity versions, async via the existing queue otherwise — the status filter is persisted per row)*
- Save-time enrichment is unchanged.

**2. Configurable default `_summary` for FHIR CS / VS / CM search** *(Problem 11)*

`GET /fhir/CodeSystem`, `/fhir/ValueSet`, and `/fhir/ConceptMap` were returning full resources (with all concepts / mappings) when the client omitted `_summary`, which is heavier than the previous behaviour. Adds three configuration keys that act as the default value of `_summary` when not supplied:

- `termx.fhir.codesystem.search.default-summary` *(env `TERMX_FHIR_CS_SEARCH_DEFAULT_SUMMARY`, default `true`)*
- `termx.fhir.valueset.search.default-summary` *(env `TERMX_FHIR_VS_SEARCH_DEFAULT_SUMMARY`, default `true`)*
- `termx.fhir.conceptmap.search.default-summary` *(env `TERMX_FHIR_CM_SEARCH_DEFAULT_SUMMARY`, default `true`)*

Any non-`false` value is treated as lightweight: CodeSystem omits the `concept` list; ValueSet omits inline `compose.include.concept`; ConceptMap omits `group.element` mappings. Per-request `?_summary=...` still wins. Single-resource `load(id)` is untouched.

## Commits
- `feat(coding-refresh): add infra for refreshing CodeSystem coding-value version references`
- `feat(coding-refresh): status-filter aware enrichment and refresh REST endpoints`
- `feat(fhir): configurable default _summary for CodeSystem and ValueSet search`
- `feat(fhir): configurable default _summary for ConceptMap search`

## Test plan
- [ ] Liquibase migration applies cleanly on existing DB; `code_system_entity_version_update_queue.allowed_statuses` is nullable text.
- [ ] Existing `EntityPropertyValueService.save` still enqueues + enriches without regression (legacy path, null allowed_statuses).
- [ ] Build CS-A with concept `X` referencing CS-B v1.0 (active), then create CS-B v1.1; `GET /ts/code-system-entity-versions/{X}/coding-value-update-candidates?allowedStatuses=active` returns one candidate, `POST .../refresh-coding-values` applies it, re-GET is empty.
- [ ] With CS-B v1.2 in `draft`: `allowedStatuses=active` keeps proposing v1.1; `allowedStatuses=active,draft` proposes v1.2.
- [ ] Bulk CS-version refresh with >200 affected entity versions returns `{queued: N}`; background job drains and snapshots are regenerated.
- [ ] Invalid status value returns 400; non-existent entity version returns 404; missing CS_WRITE returns 403.
- [ ] `GET /fhir/CodeSystem` returns resources without `concept` by default; `?_summary=false` returns full concepts.
- [ ] `GET /fhir/ValueSet` returns resources without inline `compose.include.concept` by default; `?_summary=false` includes them.
- [ ] `GET /fhir/ConceptMap` returns resources without `group.element` by default; `?_summary=false` includes the full mapping list.
- [ ] `GET /fhir/CodeSystem/{id}`, `GET /fhir/ValueSet/{id}`, `GET /fhir/ConceptMap/{id}` (single-resource reads) still return full resources.