### PR TITLE
Configurable default _summary for FHIR ConceptMap search

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapResourceStorage.java
@@ -19,19 +19,33 @@ import org.termx.ts.mapset.MapSetAssociation;
 import org.termx.ts.mapset.MapSetAssociationQueryParams;
 import org.termx.ts.mapset.MapSetQueryParams;
 import org.termx.ts.mapset.MapSetVersion;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Singleton;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 
 @Singleton
-@RequiredArgsConstructor
 public class ConceptMapResourceStorage extends BaseFhirResourceHandler {
   private final MapSetService mapSetService;
   private final MapSetVersionService mapSetVersionService;
   private final MapSetAssociationService mapSetAssociationService;
   private final ProvenanceService provenanceService;
   private final ConceptMapFhirMapper mapper;
+  private final String defaultSearchSummary;
+
+  public ConceptMapResourceStorage(MapSetService mapSetService,
+                                   MapSetVersionService mapSetVersionService,
+                                   MapSetAssociationService mapSetAssociationService,
+                                   ProvenanceService provenanceService,
+                                   ConceptMapFhirMapper mapper,
+                                   @Value("${termx.fhir.conceptmap.search.default-summary:true}") String defaultSearchSummary) {
+    this.mapSetService = mapSetService;
+    this.mapSetVersionService = mapSetVersionService;
+    this.mapSetAssociationService = mapSetAssociationService;
+    this.provenanceService = provenanceService;
+    this.mapper = mapper;
+    this.defaultSearchSummary = defaultSearchSummary;
+  }
 
   @Override
   public String getResourceType() {
@@ -67,10 +81,15 @@ public class ConceptMapResourceStorage extends BaseFhirResourceHandler {
   @Override
   public SearchResult search(SearchCriterion criteria) {
     QueryResult<MapSet> result = mapSetService.query(ConceptMapFhirMapper.fromFhir(criteria));
+    boolean lightweight = isLightweightSummary(criteria.getSummary() != null ? criteria.getSummary() : defaultSearchSummary);
     return new SearchResult(result.getMeta().getTotal(), result.getData().stream().flatMap(ms -> ms.getVersions().stream().map(msv -> {
-      msv.setAssociations(loadAssociations(msv));
+      msv.setAssociations(lightweight ? List.of() : loadAssociations(msv));
       return toFhir(ms, msv);
     })).toList());
+  }
+
+  private static boolean isLightweightSummary(String summary) {
+    return summary != null && !summary.isBlank() && !"false".equalsIgnoreCase(summary);
   }
 
 

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -115,6 +115,11 @@ termx:
         # Same as codesystem.search.default-summary, but for GET /fhir/ValueSet.
         # When non-`false`, inline `compose.include.concept` lists are suppressed.
         default-summary: ${TERMX_FHIR_VS_SEARCH_DEFAULT_SUMMARY:true}
+    conceptmap:
+      search:
+        # Same as codesystem.search.default-summary, but for GET /fhir/ConceptMap.
+        # When non-`false`, the `group.element` mapping list is suppressed.
+        default-summary: ${TERMX_FHIR_CM_SEARCH_DEFAULT_SUMMARY:true}
 
 javamail:
   authentication:


### PR DESCRIPTION
## Summary

Follow-up to #109. That PR added a configurable default value of the FHIR `_summary` query parameter for `GET /fhir/CodeSystem` and `GET /fhir/ValueSet` search. This PR extends the same mechanism to `GET /fhir/ConceptMap`, so the three searchable terminology resources behave consistently.

- New config: `termx.fhir.conceptmap.search.default-summary` *(env `TERMX_FHIR_CM_SEARCH_DEFAULT_SUMMARY`, default `true`)*
- In `ConceptMapResourceStorage.search()`, when the effective summary is non-`false`, `loadAssociations` is skipped → the response omits the heavy `group.element` mapping list.
- Per-request `?_summary=...` still wins; `GET /fhir/ConceptMap/{id}` is unchanged.

## Test plan
- [ ] `GET /fhir/ConceptMap` returns resources without `group.element` by default.
- [ ] `GET /fhir/ConceptMap?_summary=false` returns resources with the full mapping list.
- [ ] `GET /fhir/ConceptMap/{id}` (single-resource read) still returns the full resource regardless of the config.
- [ ] Setting `TERMX_FHIR_CM_SEARCH_DEFAULT_SUMMARY=false` (or `termx.fhir.conceptmap.search.default-summary: false`) restores full-mapping search responses.