### PR TITLE
Persist SNOMED per-concept effectiveTime and surface it on coding references

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/ts/SnomedMapper.java
+++ b/snomed/src/main/java/org/termx/snomed/ts/SnomedMapper.java
@@ -74,6 +74,7 @@ public class SnomedMapper {
       version.setDesignations(toConceptDesignations(snomedConcept.getPt(), snomedConcept.getFsn()));
     }
     version.setStatus(PublicationStatus.draft);
+    version.setEffectiveTime(snomedConcept.getEffectiveTime());
     return version;
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionRepository.java
@@ -49,6 +49,7 @@ public class CodeSystemEntityVersionRepository extends BaseRepository {
     ssb.property("code", version.getCode());
     ssb.property("description", version.getDescription());
     ssb.property("status", version.getStatus());
+    ssb.property("effective_time", version.getEffectiveTime());
     ssb.property("created", version.getCreated());
     ssb.property("base_entity_version_id", version.getBaseEntityVersionId());
 
@@ -210,7 +211,7 @@ public class CodeSystemEntityVersionRepository extends BaseRepository {
         .flatMap(es -> es.getValue().stream().map(v -> Pair.of(es.getKey(), v)))
         .filter(e -> e.getValue().getId() == null)
         .toList();
-    String query = "insert into terminology.code_system_entity_version (code_system_entity_id, code_system, code, description, status, created, base_entity_version_id) values (?,?,?,?,?,?::timestamp,NULLIF(?,0))";
+    String query = "insert into terminology.code_system_entity_version (code_system_entity_id, code_system, code, description, status, effective_time, created, base_entity_version_id) values (?,?,?,?,?,?,?::timestamp,NULLIF(?,0))";
     jdbcTemplate.batchUpdate(query, new BatchPreparedStatementSetter() {
       @Override
       public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -225,12 +226,12 @@ public class CodeSystemEntityVersionRepository extends BaseRepository {
         .flatMap(es -> es.getValue().stream().map(v -> Pair.of(es.getKey(), v)))
         .filter(e -> e.getValue().getId() != null)
         .toList();
-    query = "update terminology.code_system_entity_version set code_system_entity_id = ?, code_system = ?, code = ?, description = ?, status = ?, created = ?::timestamp, base_entity_version_id = NULLIF(?,0) where id = ?";
+    query = "update terminology.code_system_entity_version set code_system_entity_id = ?, code_system = ?, code = ?, description = ?, status = ?, effective_time = ?, created = ?::timestamp, base_entity_version_id = NULLIF(?,0) where id = ?";
     jdbcTemplate.batchUpdate(query, new BatchPreparedStatementSetter() {
       @Override
       public void setValues(PreparedStatement ps, int i) throws SQLException {
         CodeSystemEntityVersionRepository.this.setValues(ps, i, versionsToUpdate);
-        ps.setLong(8, versionsToUpdate.get(i).getValue().getId());
+        ps.setLong(9, versionsToUpdate.get(i).getValue().getId());
       }
       @Override
       public int getBatchSize() {return versionsToUpdate.size();}
@@ -255,8 +256,9 @@ public class CodeSystemEntityVersionRepository extends BaseRepository {
     ps.setString(3, versionsToInsert.get(i).getValue().getCode());
     ps.setString(4, versionsToInsert.get(i).getValue().getDescription());
     ps.setString(5, versionsToInsert.get(i).getValue().getStatus());
-    ps.setString(6, versionsToInsert.get(i).getValue().getCreated().toString());
-    ps.setLong(7, versionsToInsert.get(i).getValue().getBaseEntityVersionId() == null ? 0 : versionsToInsert.get(i).getValue().getBaseEntityVersionId());
+    ps.setString(6, versionsToInsert.get(i).getValue().getEffectiveTime());
+    ps.setString(7, versionsToInsert.get(i).getValue().getCreated().toString());
+    ps.setLong(8, versionsToInsert.get(i).getValue().getBaseEntityVersionId() == null ? 0 : versionsToInsert.get(i).getValue().getBaseEntityVersionId());
   }
 
   public void updateSnapshot(Long codeSystemEntityVersionId, ConceptSnapshot snapshot) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueCodingEnrichmentService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueCodingEnrichmentService.java
@@ -217,6 +217,7 @@ public class EntityPropertyValueCodingEnrichmentService {
             .map(this::mapDesignation)
             .toList();
     String version = resolved == null || resolved.csVersion() == null ? null : resolved.csVersion().getVersion();
+    String targetEffectiveTime = resolved == null ? null : resolved.entityVersion().getEffectiveTime();
 
     boolean changed = false;
     if (!StringUtils.equals(JsonUtil.toJson(codingValue.getDisplay()), JsonUtil.toJson(display))) {
@@ -225,6 +226,10 @@ public class EntityPropertyValueCodingEnrichmentService {
     }
     if (!StringUtils.equals(codingValue.getVersion(), version)) {
       codingValue.setVersion(version);
+      changed = true;
+    }
+    if (!StringUtils.equals(codingValue.getTargetEffectiveTime(), targetEffectiveTime)) {
+      codingValue.setTargetEffectiveTime(targetEffectiveTime);
       changed = true;
     }
     return changed;

--- a/terminology/src/main/resources/terminology/changelog/terminology/14-entity_version_effective_time.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/14-entity_version_effective_time.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset kodality:code_system_entity_version_effective_time
+--changeset termx:code_system_entity_version_effective_time
 alter table terminology.code_system_entity_version
     add column if not exists effective_time text;
 --rollback alter table terminology.code_system_entity_version drop column if exists effective_time;

--- a/terminology/src/main/resources/terminology/changelog/terminology/14-entity_version_effective_time.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/14-entity_version_effective_time.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+--changeset kodality:code_system_entity_version_effective_time
+alter table terminology.code_system_entity_version
+    add column if not exists effective_time text;
+--rollback alter table terminology.code_system_entity_version drop column if exists effective_time;

--- a/terminology/src/main/resources/terminology/changelog/terminology/changelog.xml
+++ b/terminology/src/main/resources/terminology/changelog/terminology/changelog.xml
@@ -18,6 +18,7 @@
     <include file="10-code_system_entity_version_update_queue.sql" relativeToChangelogFile="true"/>
     <include file="12-closure.sql" relativeToChangelogFile="true"/>
     <include file="13-update_queue_allowed_statuses.sql" relativeToChangelogFile="true"/>
+    <include file="14-entity_version_effective_time.sql" relativeToChangelogFile="true"/>
 
     <include file="views/concept_closure.sql" relativeToChangelogFile="true"/>
     <include file="views/concept_name.sql" relativeToChangelogFile="true"/>

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemEntityVersion.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemEntityVersion.java
@@ -20,6 +20,7 @@ public class CodeSystemEntityVersion {
   private String codeSystemBase;
   private String description;
   private String status;
+  private String effectiveTime;
   private ConceptSnapshot snapshot;
   private OffsetDateTime created;
 

--- a/termx-api/src/main/java/org/termx/ts/codesystem/EntityPropertyValue.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/EntityPropertyValue.java
@@ -44,6 +44,7 @@ public class EntityPropertyValue {
     private String codeSystem;
     private Object display;
     private String version;
+    private String targetEffectiveTime;
 
     public EntityPropertyValueCodingValue(String code, String codeSystem) {
       this.code = code;


### PR DESCRIPTION
## Summary

End-to-end plumbing so each TermX `CodeSystemEntityVersion` carries the SNOMED RF2 per-concept `effectiveTime`, and so coding-value references store the target's `effectiveTime` next to the FHIR version string. This lets dashboards or audit views show *"this concept was last modified in SNOMED 20240101"* even when the CodeSystem version reference points to a later release.

**FHIR `Coding.version` semantics are deliberately left unchanged** — the new value rides in a sibling field, not on top of `version`. No FHIR mapper changes; consumers that want to emit it later can do so via a FHIR extension.

> Depends on #111. Targets `fix/coding-refresh-display-uses-resolved-entity` so the enrichment-service edit sits cleanly on top of the display fix. Will be re-targeted to `main` once #111 merges.

## Changes

**Database**
- `terminology/14-entity_version_effective_time.sql` — `alter table … add column if not exists effective_time text`. Nullable; safe on existing rows.

**Domain**
- `CodeSystemEntityVersion.effectiveTime: String` — new field.
- `EntityPropertyValueCodingValue.targetEffectiveTime: String` — new optional field on the JSONB-stored coding value; no migration needed.

**Repository**
- `CodeSystemEntityVersionRepository.save` adds the column to `SaveSqlBuilder`.
- `batchUpsert` insert/update SQL strings + `setValues` parameter binding updated.
- SELECTs use `csev.*` so PgBeanProcessor picks the new column up automatically; no other read-paths touched.

**SNOMED import**
- `SnomedMapper.toConceptVersion` now calls `version.setEffectiveTime(snomedConcept.getEffectiveTime())`. Other importers (CSV/file) are unchanged.

**Enrichment**
- `applyEnrichment` reads `effectiveTime` from the resolved `TargetSelection.entityVersion` (the same one feeding `version` and designations after #111), and writes it to `EntityPropertyValueCodingValue.targetEffectiveTime`. The field participates in the change check, so a refresh propagates `effectiveTime` changes the same way it does version changes today.

## Test plan
- [ ] Liquibase migration applies cleanly on existing DB; `code_system_entity_version.effective_time` is nullable text.
- [ ] Re-import a SNOMED RF2 release containing concepts with known `effectiveTime` values: rows in `code_system_entity_version` now have the matching `effective_time`; old rows remain `null`.
- [ ] File-based CSV/FHIR imports continue to set `effective_time` to `null` (no behavioural change for non-SNOMED).
- [ ] Coding property value referencing a SNOMED concept: after a `POST .../refresh-coding-values` call, the stored JSONB now contains `"targetEffectiveTime": "20240101"` (or whichever release the resolved target points at).
- [ ] Re-import SNOMED with a new release where the target concept's `effectiveTime` advances: a subsequent refresh updates `targetEffectiveTime` and reports the property value as changed (via the candidate listing and the applied count).
- [ ] FHIR endpoints (`GET /fhir/CodeSystem`, `…/{id}`) emit unchanged output — `Coding.version` semantics are preserved.
- [ ] Save-time enrichment (queue rows with null `allowed_statuses`) continues to enrich coding values, including `targetEffectiveTime`, with no regression on the default path.