### PR TITLE
chore(liquibase): rename changeset 13 author from kodality to termx

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/13-update_queue_allowed_statuses.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/13-update_queue_allowed_statuses.sql
@@ -1,6 +1,6 @@
 --liquibase formatted sql
 
---changeset kodality:code_system_entity_version_update_queue_allowed_statuses
+--changeset termx:code_system_entity_version_update_queue_allowed_statuses
 alter table terminology.code_system_entity_version_update_queue
     add column if not exists allowed_statuses text;
 --rollback alter table terminology.code_system_entity_version_update_queue drop column if exists allowed_statuses;


### PR DESCRIPTION
## Summary

Cleanup per project policy: new code must not reference "kodality", and existing references should be reduced. Renames the author of changeset `13-update_queue_allowed_statuses.sql` (introduced in #109) from `kodality` to `termx`.

## Why this is safe even though the changeset is already applied

A Liquibase changeset is tracked in `databasechangelog` by the `author:id` pair. Renaming an applied changeset normally means Liquibase will re-run it on existing databases. In this case the SQL is:

```sql
alter table terminology.code_system_entity_version_update_queue
    add column if not exists allowed_statuses text;
```

The `add column if not exists` guard makes the SQL a no-op when the column is already there. So on a previously-deployed database:

- Liquibase sees the new `termx:code_system_entity_version_update_queue_allowed_statuses` as unapplied
- Runs the SQL → no schema change (column already exists)
- Writes a fresh row to `databasechangelog`

The only side-effect is an extra `databasechangelog` row. The old `kodality:...` row is left in place (Liquibase doesn't clean those up automatically); that's cosmetic and can be cleaned up later by hand if desired.

For non-idempotent SQL we would NOT do this rename without a coordinated `databasechangelog` cleanup — the guard here is what makes it safe.

## Test plan
- [ ] Fresh DB: Liquibase applies `termx:code_system_entity_version_update_queue_allowed_statuses` cleanly; column exists.
- [ ] Existing DB that already had the `kodality:...` version applied: Liquibase re-runs the renamed changeset, SQL is a no-op, `databasechangelog` gains one row, schema unchanged.
- [ ] No application-level code references the `author:id` pair (Liquibase tracks it internally only).