### PR TITLE
fix(concept): tree-search 500 "missing FROM-clause entry for table c_csv"

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptRepository.java
@@ -511,6 +511,14 @@ public class ConceptRepository extends BaseRepository {
   }
 
   private void appendVersionFilter(SqlBuilder sb, ConceptQueryParams params, String csvAlias) {
+    // buildDirectParentSelect only joins the code_system_version (csvAlias) table when
+    // hasVersionFilter is true; without that join, emitting a csvAlias.* predicate causes
+    // a "missing FROM-clause entry" SQL error. ConceptService.prepareParams copies
+    // params.codeSystem into params.codeSystemVersionCodeSystem, so this guard is what
+    // prevents the alias from being referenced when the join was skipped.
+    if (!hasVersionFilter(params)) {
+      return;
+    }
     if (StringUtils.isNotEmpty(params.getCodeSystemVersionCodeSystem())) {
       sb.and().in(csvAlias + ".code_system", splitCsv(params.getCodeSystemVersionCodeSystem()));
     }


### PR DESCRIPTION
## Summary

`GET /ts/code-systems/{cs}/concepts/tree-search` returns **500 Internal Server Error** when called without an explicit version filter and there is at least one matched concept (e.g. `?textContains=…`). The exact error from Postgres:

```
ERROR: missing FROM-clause entry for table "c_csv"
```

## Repro

```
GET /ts/code-systems/certainty-rating/concepts/tree-search
    ?limit=100&offset=0&textContains=test2&textContainsSep=%20
    &propertyValues=&associationType=is-a&sort=code
```

## Root cause

Pre-existing since commit `8334fc0e` (filtered tree view, April).

1. Controller `queryConceptTree` sets `params.codeSystem` from the path.
2. `ConceptService.prepareParams` unconditionally copies `params.codeSystem` into `params.codeSystemVersionCodeSystem` (this is intentional — the regular `query` path uses it).
3. `ConceptRepository.buildDirectParentSelect` only joins `code_system_version` (alias `c_csv` / `p_csv`) when `hasVersionFilter()` returns true. `hasVersionFilter` inspects the seven real version-shape params (`CodeSystemVersion`, `CodeSystemVersionId`, `CodeSystemVersions`, release/expiration dates) — **not** `CodeSystemVersionCodeSystem`.
4. `appendVersionFilter` then emits `and {csvAlias}.code_system = ?` whenever `CodeSystemVersionCodeSystem` is set, even though the alias was never joined → bad SQL grammar.

The non-tree `filter()` at line ~165 already has the right pattern (only adds the `csv.code_system` predicate when an actual version filter is also present); `appendVersionFilter` was missing it.

## Fix

Early-return from `appendVersionFilter` when `hasVersionFilter` is false. None of the predicates guarded inside that function would fire in that state anyway.

## Behavioural change

When no version filter is set, the implicit "parent's CS-version must be in the same code_system" predicate on the parent lookup is dropped. Functionally equivalent because the surrounding recursive walk already joins parents on `p.code_system = tree.code_system`, so cross-CS parents could not appear either way.

## Test plan
- [ ] Hit the repro URL → 200, tree returns.
- [ ] Hit tree-search with an explicit `codeSystemVersion=…` → version-scoped tree, unchanged behaviour.
- [ ] Hit tree-search with `codeSystemVersionId=…` → same.
- [ ] Hit tree-search with no `textContains` (matchedCodes empty) → early-return path in `queryTree` still returns empty list.