### PR TITLE
fix(liquibase): accept checksum drift on default_privileges_for_schema_* changesets

### DIFF
--- a/observation-definition/src/main/resources/observation-definition/changelog/def/def-schema.xml
+++ b/observation-definition/src/main/resources/observation-definition/changelog/def/def-schema.xml
@@ -9,6 +9,7 @@
 	</changeSet>
 
 	<changeSet id="default_privileges_for_schema_def" author="kodality">
+		<validCheckSum>ANY</validCheckSum>
 		<sql>
 			GRANT USAGE ON SCHEMA def TO ${app-username};
 			ALTER DEFAULT PRIVILEGES IN SCHEMA def GRANT USAGE ON SEQUENCES TO ${app-username};

--- a/task-taskforge/src/main/resources/taskforge/changelog/taskforge/taskforge-schema.xml
+++ b/task-taskforge/src/main/resources/taskforge/changelog/taskforge/taskforge-schema.xml
@@ -9,6 +9,7 @@
 	</changeSet>
 
 	<changeSet id="default_privileges_for_schema_taskforge" author="termx">
+		<validCheckSum>ANY</validCheckSum>
 		<sql>
 			GRANT USAGE ON SCHEMA taskforge TO ${app-username};
 			ALTER DEFAULT PRIVILEGES IN SCHEMA taskforge GRANT USAGE ON SEQUENCES TO ${app-username};

--- a/termx-core/src/main/resources/sys/changelog/sys/20-lorque_process.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/20-lorque_process.sql
@@ -22,6 +22,7 @@ select core.create_table_metadata('sys.lorque_process');
 --rollback drop table sys.lorque_process;
 
 --changeset kodality:grant-lorque_process-delete
+--validCheckSum ANY
 GRANT DELETE ON table sys.lorque_process TO ${app-username};
 --rollback select 1;
 

--- a/termx-core/src/main/resources/sys/changelog/sys/sys-schema.xml
+++ b/termx-core/src/main/resources/sys/changelog/sys/sys-schema.xml
@@ -10,6 +10,7 @@
 	</changeSet>
 
 	<changeSet id="default_privileges_for_schema_sys" author="kodality">
+		<validCheckSum>ANY</validCheckSum>
 		<sql>
 			GRANT USAGE ON SCHEMA sys TO ${app-username};
 			ALTER DEFAULT PRIVILEGES IN SCHEMA sys GRANT USAGE ON SEQUENCES TO ${app-username};

--- a/uam/src/main/resources/uam/changelog/uam-schema.xml
+++ b/uam/src/main/resources/uam/changelog/uam-schema.xml
@@ -10,6 +10,7 @@
     </changeSet>
 
     <changeSet id="default_privileges_for_schema_uam" author="uam">
+        <validCheckSum>ANY</validCheckSum>
         <sql>
             GRANT USAGE ON SCHEMA uam TO ${app-username};
             ALTER DEFAULT PRIVILEGES IN SCHEMA uam GRANT USAGE ON SEQUENCES TO ${app-username};

--- a/ucum/src/main/resources/ucum/changelog/ucum/ucum-schema.xml
+++ b/ucum/src/main/resources/ucum/changelog/ucum/ucum-schema.xml
@@ -9,6 +9,7 @@
 	</changeSet>
 
 	<changeSet id="default_privileges_for_schema_ucum" author="kodality">
+		<validCheckSum>ANY</validCheckSum>
 		<sql>
 			GRANT USAGE ON SCHEMA ucum TO ${app-username};
 			ALTER DEFAULT PRIVILEGES IN SCHEMA ucum GRANT USAGE ON SEQUENCES TO ${app-username};


### PR DESCRIPTION
## Summary

After renaming the configured DB users (`termserver_*` → `tx_*`), dev-server fails to start because Liquibase rejects 6 changesets whose checksums no longer match. The cause is that `\${app-username}` (resolved at runtime from `datasources.default.username`) is part of the SQL Liquibase hashes, and changing the username changes the resolved-SQL hash.

```
ValidationFailedException: Validation Failed:
   6 changesets check sum
     sys/changelog/sys/sys-schema.xml::default_privileges_for_schema_sys::kodality
     sys/changelog/sys/20-lorque_process.sql::grant-lorque_process-delete::kodality
     observation-definition/changelog/def/def-schema.xml::default_privileges_for_schema_def::kodality
     taskforge/changelog/taskforge/taskforge-schema.xml::default_privileges_for_schema_taskforge::termx
     uam/changelog/uam-schema.xml::default_privileges_for_schema_uam::uam
     ucum/changelog/ucum/ucum-schema.xml::default_privileges_for_schema_ucum::kodality
```

The matching `default_privileges__*__viewer` changeset in each schema already carries `<validCheckSum>ANY</validCheckSum>` — that's why the viewer-grant changesets don't fail on the same rename. This PR mirrors the same pattern on the 6 affected `default_privileges_for_schema_*` changesets (5 XML + 1 SQL).

The SQL is just `GRANT … TO \${app-username}` — idempotent and re-runnable across role renames or environment changes — so permanently ignoring its checksum is safe.

## Files
- `termx-core/src/main/resources/sys/changelog/sys/sys-schema.xml` — `default_privileges_for_schema_sys`
- `termx-core/src/main/resources/sys/changelog/sys/20-lorque_process.sql` — `grant-lorque_process-delete` *(SQL-format changeset, uses `--validCheckSum ANY`)*
- `observation-definition/src/main/resources/observation-definition/changelog/def/def-schema.xml` — `default_privileges_for_schema_def`
- `task-taskforge/src/main/resources/taskforge/changelog/taskforge/taskforge-schema.xml` — `default_privileges_for_schema_taskforge`
- `uam/src/main/resources/uam/changelog/uam-schema.xml` — `default_privileges_for_schema_uam`
- `ucum/src/main/resources/ucum/changelog/ucum/ucum-schema.xml` — `default_privileges_for_schema_ucum`

## Operational note — unsticking already-failing servers

Once this PR ships and the server has the new code, Liquibase will recompute and store the new checksum on next successful startup automatically — no DB intervention needed.

If you need to unstick a deployed server before this PR merges and ships (i.e. you can't redeploy yet), run **either** of these against the target DB as a one-off:

```sql
-- option A: clear just the offending rows; safe, Liquibase recomputes on next run
UPDATE public.databasechangelog SET md5sum = NULL
WHERE id IN (
  'default_privileges_for_schema_sys',
  'grant-lorque_process-delete',
  'default_privileges_for_schema_def',
  'default_privileges_for_schema_taskforge',
  'default_privileges_for_schema_uam',
  'default_privileges_for_schema_ucum'
);

-- option B: clear ALL checksums (Liquibase recomputes all rows on next run)
UPDATE public.databasechangelog SET md5sum = NULL;
```

Both are safe — Liquibase recomputes and persists the missing checksums during the next successful startup. Schema is untouched.

## Test plan
- [ ] Apply this PR's code to a deployed instance where the rename was already done → dev-server starts cleanly, Liquibase logs show the changesets being accepted with the new checksums.
- [ ] Fresh deploy on a brand-new DB with `tx_*` usernames → all 6 changesets run and the grants are applied; subsequent restarts validate cleanly.
- [ ] Future `\${app-username}` change (rename, additional env) → no Liquibase validation failure.