### PR TITLE
chore(security): add .gitguardian.yml ignoring local-dev/test credentials

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,0 +1,24 @@
+# GitGuardian configuration
+# https://docs.gitguardian.com/internal-repositories-monitoring/gim_settings#exclude-files-from-being-scanned
+#
+# Files listed here contain literal "test" credentials used ONLY by the local
+# development scripts and the integration-test stack (TestContainers). The
+# values are not real secrets; they are deliberately committed so contributors
+# can stand up a local Postgres without any extra configuration.
+#
+# If you add another file with a literal test credential, list it here too -
+# do NOT widen this list to a broad glob, because that would also hide any
+# real secret that lands in those directories by accident.
+
+version: 2
+
+secret:
+  ignored-paths:
+    # Local dev DB setup scripts (defaults to PASSWORD 'test')
+    - README.md
+    - recreate-termserver-db.sh
+    - termx-app/re-init-db.sh
+
+    # Integration-test stack (TestContainers brings up an ephemeral Postgres)
+    - termx-integtest/src/test/resources/init.sql
+    - termx-integtest/src/test/resources/application-test.yml


### PR DESCRIPTION
## Summary

Adds `.gitguardian.yml` to silence the false-positive GitGuardian Security Checks failure that fired on #116 (and would re-fire on any future change touching the same files). The five paths listed contain literal `PASSWORD 'test'` strings used **only** by the local-development setup and the integration-test stack — they're not real secrets.

## Files covered

- `README.md` — setup walkthrough that includes `PASSWORD 'test'`
- `recreate-termserver-db.sh` — `${DB_ADMIN_PASSWORD:-test}` / `${DB_APP_PASSWORD:-test}` defaults
- `termx-app/re-init-db.sh` — same defaults
- `termx-integtest/src/test/resources/init.sql` — `CREATE ROLE … PASSWORD 'test'`
- `termx-integtest/src/test/resources/application-test.yml` — `${DB_*_PASSWORD:test}` defaults

## Design choice — explicit paths, NOT a glob

The ignore rules list each path explicitly rather than something like `**/test/**` so a future real secret committed into those directories would still be caught. If another file with a literal test credential is added, the rule should be extended by hand.

## Test plan
- [ ] GitGuardian Security Checks turns green on this PR.
- [ ] Future PRs that only modify code (not these 5 files) still get scanned normally — no regression.
- [ ] A canary commit adding a fake `password 'fakekey123'` line in, say, `terminology/src/main/java/...` should still be flagged. (Don't actually merge that; just spot-check.)