### PR TITLE
docs: SNOMED RF2 import redesign — Minio + Lorque + delta-generator-tool

### DIFF
--- a/docs/features/large-terminology-import.md
+++ b/docs/features/large-terminology-import.md
@@ -17,7 +17,8 @@ It replaces the previous synchronous upload flow that buffered the entire archiv
 - Async import via the existing Lorque job framework. UI returns immediately with a `LorqueProcess` id and polls `/lorque-processes/{id}/status` for progress (same pattern the dry-run scan already uses).
 - **SNOMED:** delta-against-previous-version import when a baseline exists in Minio. First-ever import of an edition pushes the full snapshot.
 - **LOINC:** streamed-full-import — same upload/Minio/Lorque path, no delta tool (there isn't one for LOINC).
-- Backfill API for both terminologies — admins can upload archives that match versions already imported, storing them in Minio without re-importing into Snowstorm / LOINC. Required so the delta path has baselines for SNOMED.
+- *Uploads* sub-resource (`/imports/uploads`) for both terminologies — admins can store archives in Minio without triggering an import, list everything currently stored, trigger an import from any stored archive, and delete archives manually. Required so the SNOMED delta path has baselines, and useful in its own right for recovery / audit.
+- *Stored uploads* UI component — a new list view in the SNOMED and LOINC pages shows everything in Minio with filters (edition, status, effective time), per-row *Trigger import* and *Delete* actions, and an *Upload archive (no import)* button for seeding baselines.
 - All failures (Snowstorm unavailable, malformed archive, `delta-generator-tool` non-zero exit) land as `lorqueProcessService.fail(...)` with the underlying error in `result_text`, never as an HTTP 500 or a dropped connection.
 
 ## Configuration
@@ -39,8 +40,8 @@ It replaces the previous synchronous upload flow that buffered the entire archiv
 
 | Privilege | Used for |
 |---|---|
-| `snomed-ct.CodeSystem.write` | Trigger SNOMED import or backfill. |
-| `loinc.CodeSystem.write` | Trigger LOINC import or backfill. |
+| `snomed-ct.CodeSystem.write` | Trigger SNOMED import; upload, list, or delete entries in *Stored uploads*. |
+| `loinc.CodeSystem.write` | Trigger LOINC import; upload, list, or delete entries in *Stored uploads*. |
 | `snomed-ct.CodeSystem.read` / `loinc.CodeSystem.read` | View import job status, list archives. |
 
 ### Storage layout
@@ -59,7 +60,14 @@ terminology-archives/
             └── Loinc_2.79.zip
 ```
 
-Archives are referenced from the `terminology_import` table (columns `id, terminology, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`). Status values: `RUNNING`, `COMPLETED`, `FAILED`, `BACKFILLED`.
+Archives are referenced from the `terminology_import` table (columns `id, terminology, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`). Status values:
+
+| Status | Meaning |
+|---|---|
+| `UPLOADED` | Archive sits in Minio, no Snowstorm/LOINC processing happened. Created by `POST /imports/uploads`. |
+| `RUNNING` | Lorque job is currently importing this archive. |
+| `COMPLETED` | Import finished successfully. |
+| `FAILED` | Import failed. See the associated `LorqueProcess.result_text` for the error. |
 
 ### Retention
 
@@ -94,18 +102,31 @@ LOINC has no delta-generator equivalent; this path is always full-import.
 4. Background job downloads from Minio to `/tmp`, hands the file path to `LoincService.importLoinc(...)` (reading from disk, not a `byte[]`).
 5. Progress updates as the CSV parser advances; success / failure routes through the same Lorque mechanism.
 
-### Scenario 4: Backfill a SNOMED edition that's already in Snowstorm
+### Scenario 4: Seed a baseline for an already-imported edition
 
 A deployment has been running for months with a SNOMED International edition imported pre-redesign; the archive isn't in Minio yet, so the next normal import would skip the delta step (no baseline available).
 
 1. Admin grabs the original zip from their archive (the file IHTSDO published).
-2. Calls `POST /snomed/imports/backfill` with form fields `edition=international`, `effectiveTime=20260101`, and the file as multipart.
-3. Endpoint streams the upload → Minio, writes a `terminology_import` row with `status=BACKFILLED`. **Nothing is pushed to Snowstorm.**
-4. The next normal SNOMED import (Scenario 1) finds the backfilled row as its baseline and computes a delta against it.
+2. Opens *Stored uploads* in the SNOMED page and clicks *Upload archive (no import)*.
+3. Picks the file and fills in `edition=international`, `effectiveTime=20260101`. UI calls `POST /snomed/imports/uploads`.
+4. Endpoint streams the upload → Minio, writes a `terminology_import` row with `status=UPLOADED`. **Nothing is pushed to Snowstorm.** The new row appears in the *Stored uploads* table.
+5. The next normal SNOMED import (Scenario 1) finds the uploaded row as its baseline and computes a delta against it.
 
-LOINC backfill works the same way through `POST /loinc/imports/backfill`.
+LOINC seeding works the same way through `POST /loinc/imports/uploads` and the LOINC *Stored uploads* page.
 
-### Scenario 5: Snowstorm crashes mid-import
+### Scenario 5: Browse and manage stored uploads
+
+An operator wants to audit what's currently in Minio, free up an old archive, or re-import from a stored archive without re-uploading the file.
+
+1. Opens *Stored uploads* in the SNOMED page → table lists every `terminology_import` row for SNOMED. Columns: *Edition*, *Effective time*, *Filename*, *Status*, *Size*, *Stored at*.
+2. Filters by status (`UPLOADED`, `COMPLETED`, `RUNNING`, `FAILED`) and by edition.
+3. Per row:
+    - *Trigger import* — calls `POST /snomed/imports?fromUploadId={id}` to start a Lorque job against the stored Minio object, no new upload required. Useful for retrying a failed import after fixing Snowstorm.
+    - *Delete* — calls `DELETE /snomed/imports/uploads/{id}`. Soft-deletes the row and removes the Minio object. Prompts for confirmation if the row is the most-recent baseline for an edition.
+
+The LOINC *Stored uploads* page works identically.
+
+### Scenario 6: Snowstorm crashes mid-import
 
 A long-running SNOMED import is in progress when Snowstorm becomes unreachable.
 
@@ -118,14 +139,33 @@ A long-running SNOMED import is in progress when Snowstorm becomes unreachable.
 
 | Method + path | Purpose | Returns |
 |---|---|---|
-| `POST /snomed/imports` (replacing existing) | Trigger SNOMED import; multipart file. | `LorqueProcess` (HTTP 202) |
-| `POST /snomed/imports/backfill` | Backfill SNOMED archive into Minio without import; form fields `edition`, `effectiveTime` + multipart file. | `terminology_import` row id |
-| `POST /loinc/imports` (replacing existing) | Trigger LOINC import; multipart file. | `LorqueProcess` |
-| `POST /loinc/imports/backfill` | Backfill LOINC archive into Minio without import. | `terminology_import` row id |
-| `GET /lorque-processes/{id}/status` (existing) | Poll job status. | `{status, progress, note}` |
-| `GET /lorque-processes/{id}` (existing) | Full job record incl. `result_text` on failure. | `LorqueProcess` |
+| `POST /snomed/imports` *(replacing existing)* | Trigger SNOMED import. Multipart file OR `?fromUploadId={id}` query param to import an already-stored archive. | `LorqueProcess` (HTTP 202) |
+| `POST /snomed/imports/uploads` | Store an archive in Minio without importing; form fields `edition`, `effectiveTime` + multipart file. | `terminology_import` row |
+| `GET /snomed/imports/uploads` | List stored archives. Query params: `?edition=…&effectiveTime=…&status=…`. | `terminology_import[]` |
+| `GET /snomed/imports/uploads/{id}` | Single archive metadata. | `terminology_import` |
+| `DELETE /snomed/imports/uploads/{id}` | Remove the row + Minio object. | 204 No Content |
+| `POST /loinc/imports` *(replacing existing)* | LOINC equivalent of the SNOMED import endpoint. | `LorqueProcess` |
+| `POST /loinc/imports/uploads` | LOINC equivalent of the SNOMED uploads endpoint. | `terminology_import` row |
+| `GET /loinc/imports/uploads` | List LOINC stored archives. | `terminology_import[]` |
+| `DELETE /loinc/imports/uploads/{id}` | Remove a LOINC stored archive. | 204 No Content |
+| `GET /lorque-processes/{id}/status` *(existing)* | Poll job status. | `{status, progress, note}` |
+| `GET /lorque-processes/{id}` *(existing)* | Full job record incl. `result_text` on failure. | `LorqueProcess` |
 
 The synchronous upload paths that buffer everything in heap are **removed**, not deprecated. There is no fallback to the old behavior.
+
+## UI surface (new)
+
+A new *Stored uploads* component lives on both the SNOMED and LOINC CodeSystem pages. It renders the result of `GET /<terminology>/imports/uploads` as a filterable, paginated table:
+
+- **Columns:** Edition · Effective time · Filename · Status · Size · Stored at · Actions
+- **Filters:** Edition (free text), Effective time (range), Status (`UPLOADED` / `RUNNING` / `COMPLETED` / `FAILED`)
+- **Per-row actions:**
+  - *Trigger import* — only visible when row status is `UPLOADED` or `FAILED`. Calls `POST /<terminology>/imports?fromUploadId={id}` to start an import job against the already-stored Minio object — no new upload.
+  - *View job* — visible when the row has a `lorque_process_id`. Routes to the job-status modal already used by the dry-run scan.
+  - *Delete* — calls `DELETE /<terminology>/imports/uploads/{id}`. Confirmation prompt; warns if the row is the most-recent baseline for an edition (deleting it means the next SNOMED import skips the delta step).
+- **Top-of-page actions:**
+  - *Upload archive (no import)* — opens a small modal: file picker + `edition` + `effectiveTime`. Calls `POST /<terminology>/imports/uploads`.
+  - *Import new release* — opens the existing import modal (the streamed-upload flow described in Scenarios 1–3).
 
 ## Out of scope for the initial rollout
 

--- a/docs/features/large-terminology-import.md
+++ b/docs/features/large-terminology-import.md
@@ -17,8 +17,9 @@ It replaces the previous synchronous upload flow that buffered the entire archiv
 - Async import via the existing Lorque job framework. UI returns immediately with a `LorqueProcess` id and polls `/lorque-processes/{id}/status` for progress (same pattern the dry-run scan already uses).
 - **SNOMED:** delta-against-previous-version import when a baseline exists in Minio. First-ever import of an edition pushes the full snapshot.
 - **LOINC:** streamed-full-import — same upload/Minio/Lorque path, no delta tool (there isn't one for LOINC).
-- *Uploads* sub-resource (`/imports/uploads`) for both terminologies — admins can store archives in Minio without triggering an import, list everything currently stored, trigger an import from any stored archive, and delete archives manually. Required so the SNOMED delta path has baselines, and useful in its own right for recovery / audit.
-- *Stored uploads* UI component — a new list view in the SNOMED and LOINC pages shows everything in Minio with filters (edition, status, effective time), per-row *Trigger import* and *Delete* actions, and an *Upload archive (no import)* button for seeding baselines.
+- Storage is the existing `bob.object` / `bob.object_storage` schema — same backing tables and same Minio bucket the Wiki module already uses. New container values `snomed` and `loinc` sit alongside the existing `wiki` rows; no migration of existing data.
+- Generic `/bob/objects` REST API for upload, list, get, patch, delete — built on `BobObjectService`. Per-container authz: `snomed` requires `snomed-ct.CodeSystem.*`, `loinc` requires `loinc.CodeSystem.*`, `wiki` keeps existing Wiki privileges. The UI consumes this directly.
+- *Stored archives* UI component — a new list view in the SNOMED and LOINC pages renders `GET /bob/objects?container={terminology}` with filters (edition, status, effective time), per-row *Trigger import* and *Delete* actions, and a top-of-page *Upload archive (no import)* button for seeding baselines.
 - All failures (Snowstorm unavailable, malformed archive, `delta-generator-tool` non-zero exit) land as `lorqueProcessService.fail(...)` with the underlying error in `result_text`, never as an HTTP 500 or a dropped connection.
 
 ## Configuration
@@ -46,32 +47,33 @@ It replaces the previous synchronous upload flow that buffered the entire archiv
 
 ### Storage layout
 
-```
-terminology-archives/
-├── snomed/
-│   └── international/
-│       ├── 20260101/
-│       │   └── SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip
-│       └── 20260401/
-│           └── SnomedCT_InternationalRF2_PRODUCTION_20260401T120000Z.zip
-└── loinc/
-    └── international/
-        └── 2.79/
-            └── Loinc_2.79.zip
+Archives live in the existing `bob.object` + `bob.object_storage` tables. Each archive is one `BobObject` row with metadata in the JSONB `meta` column:
+
+```json
+{
+  "terminology": "snomed",
+  "edition": "international",
+  "effectiveTime": "20260101",
+  "filename": "SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip",
+  "importStatus": "COMPLETED",
+  "lorqueProcessId": 12345
+}
 ```
 
-Archives are referenced from the `terminology_import` table (columns `id, terminology, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`). Status values:
+The corresponding `bob.object_storage` row holds `container="snomed"` (or `loinc`), `path="/<edition>/<effective-time>/"`, `filename="<original-filename>"`. Wiki rows use `container="wiki"` with their own `meta` schema (`page`, `fileName`) — the two coexist in the same table without conflict.
+
+`meta.importStatus` values:
 
 | Status | Meaning |
 |---|---|
-| `UPLOADED` | Archive sits in Minio, no Snowstorm/LOINC processing happened. Created by `POST /imports/uploads`. |
-| `RUNNING` | Lorque job is currently importing this archive. |
-| `COMPLETED` | Import finished successfully. |
-| `FAILED` | Import failed. See the associated `LorqueProcess.result_text` for the error. |
+| *(absent)* | Archive was uploaded but no import has been triggered against it. The `POST /bob/objects` upload-only path leaves `importStatus` unset. |
+| `RUNNING` | A Lorque job is currently importing this archive. `lorqueProcessId` points to the live job. |
+| `COMPLETED` | Import finished successfully. The archive is eligible to be used as a baseline by the next SNOMED import. |
+| `FAILED` | Import failed. See the associated `LorqueProcess.result_text` for the error. The archive is still in Minio and can be retried (`POST /snomed/imports?fromObjectId={uuid}`). |
 
 ### Retention
 
-The cleanup job (`TerminologyArchiveCleanupService.scheduledCleanup`, schedule mirroring the existing dry-run-scan cleanup — every 6 h, initial delay 10 min) keeps the most recent `termx.terminology-archive.retention-per-edition` archives per (terminology, edition) tuple in Minio. `terminology_import` rows are kept indefinitely as historical metadata; only the Minio objects are deleted.
+A new cleanup job (`BobObjectRetentionService.scheduledCleanup`, every 6 h, initial delay 10 min) keeps the most recent `termx.terminology-archive.retention-per-edition` archives per (container, `meta.edition`) tuple. Older `bob.object` rows are soft-deleted (`sys_status='C'`) and their Minio objects removed. The retention policy is scoped to `container in (snomed, loinc)`; the `wiki` container is not touched.
 
 ## Use-Cases
 
@@ -84,13 +86,13 @@ A terminology manager has the new quarterly RF2 zip and a previous edition alrea
 3. The endpoint returns a `LorqueProcess` immediately. UI switches to a progress modal polling `/lorque-processes/{id}/status`.
 4. Background job downloads the new archive + the previous baseline from Minio to `/tmp`, runs `delta-generator-tool` to produce `/tmp/delta.zip`, then pushes the delta through the Snowstorm two-step (`createImportJob` → `uploadRF2File`).
 5. Progress updates land at each phase (`stored to Minio`, `computing delta`, `pushing to Snowstorm`).
-6. On success, modal closes; the new `terminology_import` row has `status=COMPLETED`. If Snowstorm errors out, the job is marked `FAILED` with the response body in `result_text`.
+6. On success, modal closes; the new `bob.object` row has `meta.importStatus=COMPLETED`. If Snowstorm errors out, the job is marked `FAILED` with the response body in `result_text` and `meta.importStatus=FAILED`.
 
 ### Scenario 2: First-ever import of a new SNOMED edition
 
 The terminology manager is bootstrapping a fresh deployment, no previous archives in Minio.
 
-Same flow as Scenario 1 with one difference: the job sees no baseline for the edition in `terminology_import`, skips `delta-generator-tool`, and pushes the full snapshot to Snowstorm. From the user's perspective the only visible change is progress text reading `pushing full snapshot to Snowstorm` instead of `computing delta`.
+Same flow as Scenario 1 with one difference: the job queries `BobObjectService` for the most-recent `meta.importStatus=COMPLETED` row in `container=snomed` with matching `meta.edition`, finds none, skips `delta-generator-tool`, and pushes the full snapshot to Snowstorm. From the user's perspective the only visible change is progress text reading `pushing full snapshot to Snowstorm` instead of `computing delta`.
 
 ### Scenario 3: Import the latest LOINC release
 
@@ -104,27 +106,27 @@ LOINC has no delta-generator equivalent; this path is always full-import.
 
 ### Scenario 4: Seed a baseline for an already-imported edition
 
-A deployment has been running for months with a SNOMED International edition imported pre-redesign; the archive isn't in Minio yet, so the next normal import would skip the delta step (no baseline available).
+A deployment has been running for months with a SNOMED International edition imported pre-redesign; the archive isn't in Bob yet, so the next normal import would skip the delta step (no baseline available).
 
 1. Admin grabs the original zip from their archive (the file IHTSDO published).
-2. Opens *Stored uploads* in the SNOMED page and clicks *Upload archive (no import)*.
-3. Picks the file and fills in `edition=international`, `effectiveTime=20260101`. UI calls `POST /snomed/imports/uploads`.
-4. Endpoint streams the upload → Minio, writes a `terminology_import` row with `status=UPLOADED`. **Nothing is pushed to Snowstorm.** The new row appears in the *Stored uploads* table.
+2. Opens *Stored archives* in the SNOMED page and clicks *Upload archive (no import)*.
+3. Picks the file and fills in `edition=international`, `effectiveTime=20260101`. UI calls `POST /bob/objects?container=snomed` with those values + the file as multipart.
+4. Endpoint streams the upload → Minio, writes a `bob.object` row with `meta={"terminology":"snomed","edition":"international","effectiveTime":"20260101","filename":"..."}` and `meta.importStatus` unset. **Nothing is pushed to Snowstorm.** The new row appears in the *Stored archives* table.
 5. The next normal SNOMED import (Scenario 1) finds the uploaded row as its baseline and computes a delta against it.
 
-LOINC seeding works the same way through `POST /loinc/imports/uploads` and the LOINC *Stored uploads* page.
+LOINC seeding works the same way through `POST /bob/objects?container=loinc` and the LOINC *Stored archives* page.
 
-### Scenario 5: Browse and manage stored uploads
+### Scenario 5: Browse and manage stored archives
 
-An operator wants to audit what's currently in Minio, free up an old archive, or re-import from a stored archive without re-uploading the file.
+An operator wants to audit what's currently in Bob, free up an old archive, or re-import from a stored archive without re-uploading the file.
 
-1. Opens *Stored uploads* in the SNOMED page → table lists every `terminology_import` row for SNOMED. Columns: *Edition*, *Effective time*, *Filename*, *Status*, *Size*, *Stored at*.
-2. Filters by status (`UPLOADED`, `COMPLETED`, `RUNNING`, `FAILED`) and by edition.
+1. Opens *Stored archives* in the SNOMED page → table lists every `bob.object` row with `container="snomed"`. Columns: *Edition*, *Effective time*, *Filename*, *Import status*, *Size*, *Stored at*.
+2. Filters by status (unset / `RUNNING` / `COMPLETED` / `FAILED`) and by edition.
 3. Per row:
-    - *Trigger import* — calls `POST /snomed/imports?fromUploadId={id}` to start a Lorque job against the stored Minio object, no new upload required. Useful for retrying a failed import after fixing Snowstorm.
-    - *Delete* — calls `DELETE /snomed/imports/uploads/{id}`. Soft-deletes the row and removes the Minio object. Prompts for confirmation if the row is the most-recent baseline for an edition.
+    - *Trigger import* — calls `POST /snomed/imports?fromObjectId={uuid}` to start a Lorque job against the stored Minio object, no new upload required. Useful for retrying a failed import after fixing Snowstorm.
+    - *Delete* — calls `DELETE /bob/objects/{uuid}`. Soft-deletes the row and removes the Minio object. Prompts for confirmation if the row is the most-recent baseline for an edition.
 
-The LOINC *Stored uploads* page works identically.
+The LOINC *Stored archives* page works identically. Wiki archives are not surfaced here — they have their own page-attachment UI.
 
 ### Scenario 6: Snowstorm crashes mid-import
 
@@ -137,35 +139,47 @@ A long-running SNOMED import is in progress when Snowstorm becomes unreachable.
 
 ## API surface (new)
 
+### Generic Bob storage endpoints
+
+These are new endpoints on `BobObjectController`, used by every terminology and by the Wiki module's read paths.
+
 | Method + path | Purpose | Returns |
 |---|---|---|
-| `POST /snomed/imports` *(replacing existing)* | Trigger SNOMED import. Multipart file OR `?fromUploadId={id}` query param to import an already-stored archive. | `LorqueProcess` (HTTP 202) |
-| `POST /snomed/imports/uploads` | Store an archive in Minio without importing; form fields `edition`, `effectiveTime` + multipart file. | `terminology_import` row |
-| `GET /snomed/imports/uploads` | List stored archives. Query params: `?edition=…&effectiveTime=…&status=…`. | `terminology_import[]` |
-| `GET /snomed/imports/uploads/{id}` | Single archive metadata. | `terminology_import` |
-| `DELETE /snomed/imports/uploads/{id}` | Remove the row + Minio object. | 204 No Content |
-| `POST /loinc/imports` *(replacing existing)* | LOINC equivalent of the SNOMED import endpoint. | `LorqueProcess` |
-| `POST /loinc/imports/uploads` | LOINC equivalent of the SNOMED uploads endpoint. | `terminology_import` row |
-| `GET /loinc/imports/uploads` | List LOINC stored archives. | `terminology_import[]` |
-| `DELETE /loinc/imports/uploads/{id}` | Remove a LOINC stored archive. | 204 No Content |
+| `POST /bob/objects?container=snomed\|loinc\|wiki` | Streamed multipart upload. Form fields: `description`, `meta` (JSON), file part. Stores in `bob.object` + Minio. Authz keyed off `container`. | `BobObject` |
+| `GET /bob/objects?container=…&meta.key=value&…` | List, filterable on container + JSONB meta keys. Reuses existing `BobObjectQueryParams`. | `BobObject[]` |
+| `GET /bob/objects/{uuid}` | Single object metadata. | `BobObject` |
+| `GET /bob/objects/{uuid}/content` | Streamed download (`StreamedFile`). | binary |
+| `PATCH /bob/objects/{uuid}` | Update `meta` / `description`. Used by the import job to write back `importStatus` and `lorqueProcessId`. | `BobObject` |
+| `DELETE /bob/objects/{uuid}` | Soft-delete the row + remove the Minio object. | 204 No Content |
+
+### Terminology import endpoints
+
+| Method + path | Purpose | Returns |
+|---|---|---|
+| `POST /snomed/imports` *(replacing existing)* | Trigger SNOMED import. EITHER `?fromObjectId={uuid}` (use a previously-stored archive) OR multipart file (one-step: stores via `BobObjectService` then triggers). | `LorqueProcess` (HTTP 202) |
+| `POST /loinc/imports` *(replacing existing)* | Same shape for LOINC. | `LorqueProcess` |
 | `GET /lorque-processes/{id}/status` *(existing)* | Poll job status. | `{status, progress, note}` |
 | `GET /lorque-processes/{id}` *(existing)* | Full job record incl. `result_text` on failure. | `LorqueProcess` |
 
-The synchronous upload paths that buffer everything in heap are **removed**, not deprecated. There is no fallback to the old behavior.
+The synchronous upload paths that buffer everything in heap are **removed**, not deprecated. There is no fallback to the old behaviour.
+
+There is no separate `/snomed/imports/uploads` endpoint. Upload-only goes through `POST /bob/objects?container=snomed`. The per-container authorizer applies the same `snomed-ct.CodeSystem.write` privilege check that a wrapper would have, so a wrapper would have been pure indirection.
 
 ## UI surface (new)
 
-A new *Stored uploads* component lives on both the SNOMED and LOINC CodeSystem pages. It renders the result of `GET /<terminology>/imports/uploads` as a filterable, paginated table:
+A new *Stored archives* component lives on both the SNOMED and LOINC CodeSystem pages. It renders `GET /bob/objects?container={terminology}` as a filterable, paginated table:
 
-- **Columns:** Edition · Effective time · Filename · Status · Size · Stored at · Actions
-- **Filters:** Edition (free text), Effective time (range), Status (`UPLOADED` / `RUNNING` / `COMPLETED` / `FAILED`)
+- **Columns:** Edition · Effective time · Filename · Import status · Size · Stored at · Actions
+- **Filters:** Edition (free text), Effective time (range), Import status (*unset* / `RUNNING` / `COMPLETED` / `FAILED`)
 - **Per-row actions:**
-  - *Trigger import* — only visible when row status is `UPLOADED` or `FAILED`. Calls `POST /<terminology>/imports?fromUploadId={id}` to start an import job against the already-stored Minio object — no new upload.
-  - *View job* — visible when the row has a `lorque_process_id`. Routes to the job-status modal already used by the dry-run scan.
-  - *Delete* — calls `DELETE /<terminology>/imports/uploads/{id}`. Confirmation prompt; warns if the row is the most-recent baseline for an edition (deleting it means the next SNOMED import skips the delta step).
+  - *Trigger import* — visible when `meta.importStatus` is unset or `FAILED`. Calls `POST /<terminology>/imports?fromObjectId={uuid}` to start an import job against the already-stored Minio object — no new upload.
+  - *View job* — visible when the row has a `meta.lorqueProcessId`. Routes to the job-status modal already used by the dry-run scan.
+  - *Delete* — calls `DELETE /bob/objects/{uuid}`. Confirmation prompt; warns if the row is the most-recent successful baseline for an edition (deleting it means the next SNOMED import skips the delta step).
 - **Top-of-page actions:**
-  - *Upload archive (no import)* — opens a small modal: file picker + `edition` + `effectiveTime`. Calls `POST /<terminology>/imports/uploads`.
+  - *Upload archive (no import)* — opens a small modal: file picker + `edition` + `effectiveTime`. Calls `POST /bob/objects?container={terminology}` with those values as `meta` keys.
   - *Import new release* — opens the existing import modal (the streamed-upload flow described in Scenarios 1–3).
+
+The Wiki page-attachment UI is **not** changed. It keeps calling `/pages/{id}/files` because that's the right convenience layer for page-bound attachments. The new generic `/bob/objects?container=wiki` endpoints exist for future cross-cutting tooling (e.g. an admin "all Bob objects" view) but aren't wired into the existing Wiki UI.
 
 ## Out of scope for the initial rollout
 

--- a/docs/features/large-terminology-import.md
+++ b/docs/features/large-terminology-import.md
@@ -1,0 +1,142 @@
+# Large-Terminology Import (SNOMED + LOINC)
+
+**Status:** Planned · Design doc: [`docs/snomed-rf2-import-redesign.md`](../snomed-rf2-import-redesign.md) · Not yet implemented.
+
+## Description
+
+This feature lets a terminology manager upload large terminology archives — full SNOMED CT International edition (~1 GB RF2 zip) or full LOINC release-bundle — through the TermX UI without crashing the server. Heavy work runs as a background Lorque job; the UI polls a status endpoint and shows progress until the import either completes against Snowstorm / the LOINC importer or fails with a clear diagnostic.
+
+For SNOMED specifically, if a previous successful import of the same edition is stored, TermX computes the delta against it using the IHTSDO [`delta-generator-tool`](https://github.com/IHTSDO/delta-generator-tool) and pushes only the delta to Snowstorm — dramatically smaller payload, much faster import, lower memory pressure end to end.
+
+It replaces the previous synchronous upload flow that buffered the entire archive into the JVM heap (`FileUtil.readBytes(... .blockingGet())`) and caused `OutOfMemoryError` on dev-server with `-Xmx1800m`.
+
+**Key capabilities**
+
+- Streamed multipart upload — bytes go from the network straight to a temp file on disk, then to Minio. The JVM never holds the full archive.
+- Archive storage in Minio under a stable key: `terminology-archives/<terminology>/<edition>/<effective-time>/<original-filename>`. Bucket retention defaults to the most recent **N=3** archives per edition; older ones are reclaimed by a scheduled cleanup job.
+- Async import via the existing Lorque job framework. UI returns immediately with a `LorqueProcess` id and polls `/lorque-processes/{id}/status` for progress (same pattern the dry-run scan already uses).
+- **SNOMED:** delta-against-previous-version import when a baseline exists in Minio. First-ever import of an edition pushes the full snapshot.
+- **LOINC:** streamed-full-import — same upload/Minio/Lorque path, no delta tool (there isn't one for LOINC).
+- Backfill API for both terminologies — admins can upload archives that match versions already imported, storing them in Minio without re-importing into Snowstorm / LOINC. Required so the delta path has baselines for SNOMED.
+- All failures (Snowstorm unavailable, malformed archive, `delta-generator-tool` non-zero exit) land as `lorqueProcessService.fail(...)` with the underlying error in `result_text`, never as an HTTP 500 or a dropped connection.
+
+## Configuration
+
+### Properties
+
+| Property | Env variable | Default | Description |
+|---|---|---|---|
+| `bob.minio.url` | `BOB_MINIO_URL` | (deployment) | Minio endpoint. Already used by [`bob/`](../../bob/). |
+| `bob.minio.access-key` / `secret-key` | `BOB_MINIO_ACCESS_KEY` / `BOB_MINIO_SECRET_KEY` | (deployment) | Minio credentials. |
+| `termx.terminology-archive.bucket` | — | `terminology-archives` | Minio bucket name; auto-created on first write. |
+| `termx.terminology-archive.retention-per-edition` | — | `3` | How many most-recent archives to keep per edition; older soft-deleted by the cleanup job. |
+| `termx.snomed.delta-generator.jar` | `SNOMED_DELTA_GENERATOR_JAR` | `/opt/delta-generator-tool.jar` | Path to the `delta-generator-tool` jar inside the container. |
+| `termx.snomed.delta-generator.timeout-seconds` | — | `1800` (30 min) | Hard cap on the delta-generator subprocess. |
+| `snowstorm.url` / `snowstorm.user` / `snowstorm.password` | — | (deployment) | Snowstorm endpoint + Basic Auth. Unchanged from current. |
+| `micronaut.server.max-request-size` | — | `1610612736` (1.5 GB) | Hard cap on multipart upload size; SNOMED International is ~1 GB and growing. |
+
+### Privileges
+
+| Privilege | Used for |
+|---|---|
+| `snomed-ct.CodeSystem.write` | Trigger SNOMED import or backfill. |
+| `loinc.CodeSystem.write` | Trigger LOINC import or backfill. |
+| `snomed-ct.CodeSystem.read` / `loinc.CodeSystem.read` | View import job status, list archives. |
+
+### Storage layout
+
+```
+terminology-archives/
+├── snomed/
+│   └── international/
+│       ├── 20260101/
+│       │   └── SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip
+│       └── 20260401/
+│           └── SnomedCT_InternationalRF2_PRODUCTION_20260401T120000Z.zip
+└── loinc/
+    └── international/
+        └── 2.79/
+            └── Loinc_2.79.zip
+```
+
+Archives are referenced from the `terminology_import` table (columns `id, terminology, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`). Status values: `RUNNING`, `COMPLETED`, `FAILED`, `BACKFILLED`.
+
+### Retention
+
+The cleanup job (`TerminologyArchiveCleanupService.scheduledCleanup`, schedule mirroring the existing dry-run-scan cleanup — every 6 h, initial delay 10 min) keeps the most recent `termx.terminology-archive.retention-per-edition` archives per (terminology, edition) tuple in Minio. `terminology_import` rows are kept indefinitely as historical metadata; only the Minio objects are deleted.
+
+## Use-Cases
+
+### Scenario 1: Import the latest SNOMED International edition
+
+A terminology manager has the new quarterly RF2 zip and a previous edition already imported.
+
+1. Navigates to the SNOMED CodeSystem edit page → opens *Import from RF2*.
+2. Picks the file → clicks *Confirm*. The browser streams the upload; the server writes it to a temp file and pushes it to Minio under `terminology-archives/snomed/international/<effectiveTime>/...`.
+3. The endpoint returns a `LorqueProcess` immediately. UI switches to a progress modal polling `/lorque-processes/{id}/status`.
+4. Background job downloads the new archive + the previous baseline from Minio to `/tmp`, runs `delta-generator-tool` to produce `/tmp/delta.zip`, then pushes the delta through the Snowstorm two-step (`createImportJob` → `uploadRF2File`).
+5. Progress updates land at each phase (`stored to Minio`, `computing delta`, `pushing to Snowstorm`).
+6. On success, modal closes; the new `terminology_import` row has `status=COMPLETED`. If Snowstorm errors out, the job is marked `FAILED` with the response body in `result_text`.
+
+### Scenario 2: First-ever import of a new SNOMED edition
+
+The terminology manager is bootstrapping a fresh deployment, no previous archives in Minio.
+
+Same flow as Scenario 1 with one difference: the job sees no baseline for the edition in `terminology_import`, skips `delta-generator-tool`, and pushes the full snapshot to Snowstorm. From the user's perspective the only visible change is progress text reading `pushing full snapshot to Snowstorm` instead of `computing delta`.
+
+### Scenario 3: Import the latest LOINC release
+
+LOINC has no delta-generator equivalent; this path is always full-import.
+
+1. Navigates to the LOINC CodeSystem edit page → opens *Import LOINC release*.
+2. Picks the file → clicks *Confirm*. Same streamed upload → Minio path as SNOMED.
+3. Returns `LorqueProcess` id; UI polls.
+4. Background job downloads from Minio to `/tmp`, hands the file path to `LoincService.importLoinc(...)` (reading from disk, not a `byte[]`).
+5. Progress updates as the CSV parser advances; success / failure routes through the same Lorque mechanism.
+
+### Scenario 4: Backfill a SNOMED edition that's already in Snowstorm
+
+A deployment has been running for months with a SNOMED International edition imported pre-redesign; the archive isn't in Minio yet, so the next normal import would skip the delta step (no baseline available).
+
+1. Admin grabs the original zip from their archive (the file IHTSDO published).
+2. Calls `POST /snomed/imports/backfill` with form fields `edition=international`, `effectiveTime=20260101`, and the file as multipart.
+3. Endpoint streams the upload → Minio, writes a `terminology_import` row with `status=BACKFILLED`. **Nothing is pushed to Snowstorm.**
+4. The next normal SNOMED import (Scenario 1) finds the backfilled row as its baseline and computes a delta against it.
+
+LOINC backfill works the same way through `POST /loinc/imports/backfill`.
+
+### Scenario 5: Snowstorm crashes mid-import
+
+A long-running SNOMED import is in progress when Snowstorm becomes unreachable.
+
+1. The Lorque job's Snowstorm push fails. `lorqueProcessService.fail(processId, ProcessResult.text("Snowstorm error: <body>"))` is called.
+2. UI polling sees `status=FAILED` and shows the recorded error text.
+3. Operator restarts Snowstorm. They re-trigger the import; because the archive is already in Minio, the system could (future enhancement) offer a "retry without re-uploading" — for now, the operator re-runs the same flow and the archive is overwritten in Minio (or skipped if file hash matches).
+4. TermX JVM heap is unaffected — the failure stays in the background thread.
+
+## API surface (new)
+
+| Method + path | Purpose | Returns |
+|---|---|---|
+| `POST /snomed/imports` (replacing existing) | Trigger SNOMED import; multipart file. | `LorqueProcess` (HTTP 202) |
+| `POST /snomed/imports/backfill` | Backfill SNOMED archive into Minio without import; form fields `edition`, `effectiveTime` + multipart file. | `terminology_import` row id |
+| `POST /loinc/imports` (replacing existing) | Trigger LOINC import; multipart file. | `LorqueProcess` |
+| `POST /loinc/imports/backfill` | Backfill LOINC archive into Minio without import. | `terminology_import` row id |
+| `GET /lorque-processes/{id}/status` (existing) | Poll job status. | `{status, progress, note}` |
+| `GET /lorque-processes/{id}` (existing) | Full job record incl. `result_text` on failure. | `LorqueProcess` |
+
+The synchronous upload paths that buffer everything in heap are **removed**, not deprecated. There is no fallback to the old behavior.
+
+## Out of scope for the initial rollout
+
+- Refactoring the dry-run scan (`/snomed/imports/scan`) to also use Minio storage — it already works async via Lorque from a DB-blob cache; migration tracked in the design doc as Q3.
+- Memory-efficient parsing inside `SnomedRF2ZipParser` — once `delta-generator-tool` does the heavy lifting on disk, the scan's in-memory accumulators don't affect the import path.
+- Other terminology imports (FHIR CodeSystem upload, UCUM, …) — different code paths, different scale; re-evaluate per-terminology if OOM reports appear.
+- Presigned upload URLs (browser → Minio direct, skipping TermX as proxy) — tracked as a Phase 4 follow-up in the design doc.
+
+## Related
+
+- Design doc: [`docs/snomed-rf2-import-redesign.md`](../snomed-rf2-import-redesign.md)
+- Existing async pattern this mirrors: [`docs/features/snomed-rf2-dry-run-scan.md`](snomed-rf2-dry-run-scan.md)
+- Minio wrapper used: [`bob/.../MinioService.java`](../../bob/src/main/java/org/termx/bob/minio/MinioService.java)
+- IHTSDO delta-generator-tool: <https://github.com/IHTSDO/delta-generator-tool>

--- a/docs/snomed-rf2-import-redesign.md
+++ b/docs/snomed-rf2-import-redesign.md
@@ -51,21 +51,34 @@ Reference points (LOINC):
 
 ## Proposed architecture
 
-The diagram below shows the SNOMED case. **LOINC follows the same shape with one difference:** there is no equivalent of the IHTSDO delta-generator tool for LOINC, so the LOINC job downloads the new archive from Minio and pushes it straight to the LOINC importer (`LoincService`) — no delta computation. Everything else — streamed upload, Minio storage, Lorque async, status polling — is identical and shared.
+All file storage goes through TermX's existing `bob.object` / `bob.object_storage` tables, which the Wiki module already uses. We add a new container value `"snomed"` / `"loinc"` alongside the existing `"wiki"`, plus new generic REST endpoints on `/bob/objects` so the UI can list everything in storage. Wiki rows are preserved untouched — same table, same Minio bucket; the container value distinguishes them.
 
 ```
-  UI ──upload──▶ SnomedController (streamed)
-                  │  ① stream multipart → temp file on disk
-                  │  ② upload temp file → Minio bucket
-                  │  ③ create LorqueProcess(status=RUNNING)
-                  │  ④ kick off virtual-thread job, return processId immediately
+  UI ──upload──▶ POST /bob/objects?container=snomed
+                  │ (streamed multipart)
+                  │
                   ▼
-                                                ┌────────────────────────┐
-              SnomedRF2ImportJob (async) ───────│  Minio                 │
-                  │                              │  snomed-imports/      │
-                  │  download new + baseline    │   <edition>/<eff>/    │
-                  │   from Minio → /tmp         │     <filename>.zip    │
-                  │                              └────────────────────────┘
+              BobObjectService.store
+                  │  ① stream multipart → temp file on disk
+                  │  ② BobStorage row with container="snomed",
+                  │     path="/<edition>/<effective-time>/"
+                  │  ③ MinioService.store(object, file)
+                  │  ④ BobObject row, meta = {terminology, edition,
+                  │       effectiveTime, lorqueProcessId? ...}
+                  ▼
+                Returns BobObject
+
+  UI ──trigger──▶ POST /snomed/imports?fromObjectId={uuid}
+                  │
+                  │  ① create LorqueProcess(status=RUNNING)
+                  │  ② kick off virtual-thread job, return processId
+                  ▼
+              SnomedRF2ImportJob (async) ──── BobObjectService.loadContent
+                  │                          (streams from Minio to /tmp)
+                  │
+                  │  look up most-recent COMPLETED BobObject for same edition,
+                  │  download baseline to /tmp
+                  │
                   │  invoke delta-generator-tool
                   │   (subprocess on /tmp/new + /tmp/baseline → /tmp/delta.zip)
                   │
@@ -73,23 +86,39 @@ The diagram below shows the SNOMED case. **LOINC follows the same shape with one
                   │  SnowstormClient.uploadRF2File(jobId, delta.zip)
                   │
                   │  lorqueProcessService.complete(processId, …)
+                  │  patch BobObject meta with importStatus="COMPLETED",
+                  │    lorqueProcessId
                   ▼
                 Snowstorm
 
-  UI ──poll──▶ LorqueProcessController GET /lorque-processes/{id}/status
+  UI ──list──▶  GET /bob/objects?container=snomed
+  UI ──poll──▶  GET /lorque-processes/{id}/status
 ```
+
+The diagram shows SNOMED. **LOINC follows the same shape with one difference:** there is no equivalent of `delta-generator-tool` for LOINC, so the LOINC job downloads the archive from Bob/Minio and pushes it straight to `LoincService` (which now reads from a `Path` instead of a `byte[]`). Everything else — `/bob/objects` upload, Lorque async, status polling, list UI — is identical and shared.
+
+For convenience the import endpoint also accepts a multipart file directly (`POST /snomed/imports` with a `file` part). That path internally stores the file via `BobObjectService` first, then starts the same Lorque job — so the storage layer is always the single source of truth.
 
 ## Key decisions
 
-### D1. Where uploads land — Minio, not DB blob, not memory
+### D1. Where uploads land — existing Bob storage, new container values
 
-**Decision:** Stream the multipart upload to a temp file on disk inside the controller, then `MinioService.store(...)` it under `snomed-imports/<edition-id>/<effective-time>/<original-filename>.zip`. Delete the temp file once uploaded. Remove the DB-blob caching path entirely (or repurpose it for metadata only).
+**Decision:** Reuse TermX's existing `BobObjectService` (`bob/src/main/java/org/termx/bob/BobObjectService.java:15–79`). Wiki already uses it with container `"wiki"`; we add `"snomed"` and `"loinc"` for these terminologies. Per-archive metadata (terminology, edition id, effective time, optional lorque process id, import status) goes into the existing `bob.object.meta` JSONB column, which is already GIN-indexed for fast filtering.
 
 **Why:**
-- Minio already wraps this — `bob/src/main/java/org/termx/bob/minio/MinioService.java:35–108` (`store`, `retrieve`, `delete`).
-- Configuration already wired — `bob.minio.url` / `access-key` / `secret-key` in `MinioClientFactory`.
-- Auto-creates the bucket on first write.
-- Confirmed running in dev and prod.
+- `bob.object` + `bob.object_storage` schema already exists and is in production with Wiki rows in it (`bob/src/main/resources/bob/changelog/bob/01-object.sql`, `02-object_storage.sql`).
+- `BobObjectService` already wraps `MinioService` with the transaction boundary, soft-delete semantics, and meta-based querying (`BobObjectQueryParams`).
+- No new tables, no new bucket layer, no new service class. Wiki container `"wiki"` is untouched.
+
+**Not introducing:** a new `terminology_import` table, a new `TerminologyArchiveService`. Both were in the previous draft of this doc; both were unnecessary once we realised Bob already does everything we needed.
+
+### D1b. Existing Wiki data is preserved
+
+`bob.object` already holds rows with `container="wiki"` and `meta={"page": pageId, "fileName": …}` written by `WikiAttachmentBobHandler:36–49`. Our changes:
+- **Do not touch** Wiki rows. Different `container` value, different `meta` shape — they coexist in the same table without conflict.
+- **Do not change** the existing `meta` schema for Wiki rows. SNOMED/LOINC rows use new `meta` keys (`terminology`, `edition`, `effectiveTime`, …) that don't collide with Wiki's keys (`page`, `fileName`).
+- **Do not require** a data migration. New columns are not needed because everything fits in the existing JSONB.
+- The Wiki module's own endpoints (`/pages/{id}/files`) keep working unchanged. They're domain-specific endpoints layered on top of `BobObjectService`, same as the new SNOMED/LOINC endpoints will be.
 
 ### D2. Heavy work moves to a Lorque async job
 
@@ -121,7 +150,33 @@ The `SnowstormClient` already does `createImportJob(req)` → returns Location h
 
 Reference: `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:157–175`.
 
-### D6. Retention
+### D6a. Generic `/bob/objects` REST API for the UI
+
+**Decision:** Add a new generic controller exposing `BobObjectService`:
+- `POST /bob/objects` — multipart upload with form fields `container`, `meta` (JSON), `description`. Streams to disk → Minio. Returns the created `BobObject`.
+- `GET /bob/objects?container=&meta.key=value&…` — list with filtering. Reuses `BobObjectQueryParams` (existing).
+- `GET /bob/objects/{uuid}` — single object metadata.
+- `GET /bob/objects/{uuid}/content` — streamed download.
+- `PATCH /bob/objects/{uuid}` — update `meta` / `description` only. Used by the import job to write back `importStatus` and `lorqueProcessId` once the import completes.
+- `DELETE /bob/objects/{uuid}` — soft-delete + Minio object removal.
+
+**Authz:** per-container. Each container value has registered `BobContainerAuthorizer` beans that map to the relevant module's privileges:
+
+| Container | Read privilege | Write privilege |
+| --- | --- | --- |
+| `snomed` | `snomed-ct.CodeSystem.read` | `snomed-ct.CodeSystem.write` |
+| `loinc` | `loinc.CodeSystem.read` | `loinc.CodeSystem.write` |
+| `wiki` | existing Wiki read | existing Wiki write |
+
+The Wiki container is registered through the same plugin so `/bob/objects?container=wiki` works with existing Wiki privileges without behavioural change. If a request hits a container with no registered authorizer it's rejected with 403.
+
+### D6b. SNOMED/LOINC `/imports/uploads` wrappers — **dropped**
+
+The previous draft proposed `POST /snomed/imports/uploads`, `POST /loinc/imports/uploads` as upload-only endpoints. With D6a in place these are redundant: admins use `POST /bob/objects?container=snomed` directly, the per-container authz model gives them the same privilege gate, and the UI uses the same list endpoint as everything else.
+
+A wrapper would only be justified if SNOMED or LOINC needed extra upload-time validation that doesn't apply to other containers (e.g. "verify the zip really is an RF2 archive before storing"). We may revisit this if such validation becomes required; for now, none of it is, and the design ships without `/imports/uploads` endpoints.
+
+### D6c. Retention
 
 - Per-edition: keep the most recent **N** raw uploads in Minio (default `N=3`). Older ones get GC'd by a scheduled job mirroring the existing 6-hour cleanup loop in `SnomedRF2UploadCacheService:53–54`.
 - Delta archives (intermediate): delete from `/tmp` after the Snowstorm upload completes — they're regenerable.
@@ -132,74 +187,63 @@ Reference: `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:15
 - **Skip delta-generator when no baseline exists.** First-ever import of an edition (or LOINC version) imports the full snapshot directly. Subsequent imports look up the previous version from Minio and run delta-generator.
 - **No fallback to the current synchronous upload.** The existing `/imports` and LOINC `/import` are being replaced, not kept alongside. The current path is the bug; preserving it as a fallback just preserves the bug.
 - **delta-generator-tool runs as a subprocess** (D3). Tool is officially SNOMED-supported; subprocess gives clean OOM isolation and avoids dragging its full dependency tree into TermX's classpath.
-- **Resource naming: `uploads`, not `backfill`.** What was called the "backfill" endpoint in the first draft is modeled as an `/imports/uploads` sub-resource: `POST /snomed/imports/uploads` (and `/loinc/imports/uploads`) to store, `GET /snomed/imports/uploads` to list, `DELETE …/{id}` to remove. Matches the existing `SnomedRF2Upload` entity name in the codebase. Better than "backfill" because it isn't an awkward verb-as-noun and naturally supports list/get/delete operations for the new UI component.
-- **Q6 — Backfill source: admin re-uploads the original archive.** The admin always has the source file (they imported it once already), so a re-upload through `POST /snomed/imports/uploads` is universal, predictable, and requires zero migration code on the server. The alternative (reading from `SnomedRF2UploadCacheService` DB-blob cache) only covers archives uploaded in the last 7 days, can't be relied on, and would block on database I/O — rejected.
+- **Storage uses the existing Bob backend; no new tables, no new service.** `BobObjectService` is the only storage API; we add new container values (`snomed`, `loinc`) alongside the existing `wiki`. All per-archive metadata sits in the existing JSONB `bob.object.meta` column. Wiki rows are preserved unchanged.
+- **Upload + list go through new generic `/bob/objects` REST endpoints**, not per-terminology wrappers. SNOMED- and LOINC-specific upload-only endpoints (`/snomed/imports/uploads`) from the previous draft are dropped — see D6b. The UI list components call `GET /bob/objects?container=snomed` / `?container=loinc`.
+- **Per-container authz** is implemented as a plugin point (`BobContainerAuthorizer`), so each module owns its own privilege mapping. Wiki container keeps its existing privileges; SNOMED uses `snomed-ct.CodeSystem.*`; LOINC uses `loinc.CodeSystem.*`.
+- **Q6 — Backfill source: admin re-uploads the original archive** through `POST /bob/objects?container=snomed` (or `loinc`). Always available because the admin has the source file; no migration code on the server. The alternative (reading from `SnomedRF2UploadCacheService` DB-blob cache) only covers archives uploaded in the last 7 days, can't be relied on, and is rejected.
 
 ## Open questions
 
 | # | Question | Notes |
 | --- | --- | --- |
-| Q1 | New `snomed_import` table or extend `lorque_process`? | A dedicated table makes baseline lookup ("most recent succeeded import for edition X") trivial and survives Lorque cleanup. Recommend new table (probably generalized as `terminology_import` to also cover LOINC); keep Lorque as the *job-status* mechanism only. |
 | Q2 | Exact `delta-generator-tool` CLI shape? | Confirm against [github.com/IHTSDO/delta-generator-tool](https://github.com/IHTSDO/delta-generator-tool) README. Best done by whoever picks up the implementation. |
-| Q3 | Should `SnomedRF2UploadCacheService` (DB-blob cache for the dry-run scan) move to Minio too? | Probably yes for consistency, but out-of-scope for this redesign. Track separately. |
-| Q4 | Authorization on the Minio bucket | Read/write from TermX server only, or also presigned URLs for direct browser → Minio uploads (would skip TermX as proxy entirely)? Presigned is more work but eliminates one more "JVM holds the file" path. Deferred to Phase 4. |
+| Q3 | Should `SnomedRF2UploadCacheService` (DB-blob cache for the dry-run scan) move to Bob too? | Probably yes for consistency, but out-of-scope for this redesign. Track separately. |
 | Q5 | What happens if delta-generator fails / produces empty delta? | If empty → no-op, mark Lorque complete with "no changes". If failure → fail Lorque with the subprocess stderr captured. |
+| Q7 | `BobContainerAuthorizer` registration mechanism — plugin beans (one bean per module that declares its container + privileges) or central config in `application.yml`? | Lean plugin: each module declares its own, keeps coupling local. Final shape decided at implementation time. |
+
+*Q1 (new table vs. extend Lorque), Q4 (authz on Minio bucket), Q6 (backfill source) were resolved in the "Resolved during review" section above.*
 
 ## Phased delivery
 
-Four PRs, deployable independently. Each leaves the system in a better state than before; later phases build on earlier ones.
+Three PRs, deployable independently. Each leaves the system in a better state than before; later phases build on earlier ones.
 
-### Phase 1 — Streamed upload + Minio + Lorque, for both SNOMED and LOINC
+### Phase 1 — Generic `/bob/objects` REST + import controllers backed by Bob, for both SNOMED and LOINC
 
-Smallest unit of work that eliminates the OOM. Does **not** introduce delta-generator yet — SNOMED imports a full snapshot just like before, just streamed through disk + Minio + a Lorque async job. LOINC's only fix is this phase; the rest doesn't apply to it.
+Smallest unit of work that eliminates the OOM. Does **not** introduce delta-generator yet — SNOMED imports a full snapshot just like before, just streamed through Bob and a Lorque async job. LOINC's only fix is this phase; the rest doesn't apply to it.
 
-A new shared building block:
-- `TerminologyArchiveService` (in `termx-core` or a new shared module) wraps `MinioService` with a stable object-key convention: `terminology-archives/<terminology>/<edition>/<effective-time>/<original-filename>`. `terminology` is `snomed` or `loinc`. Used by both SNOMED and LOINC paths.
-- New table `terminology_import` (resolves Q1): `id, terminology, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`. One row per import attempt; queried as "most recent succeeded for this edition" when Phase 2 lands.
+What lands in this PR:
+- **New `BobObjectController`** under `bob/` exposing `POST/GET/PATCH/DELETE /bob/objects` and `GET /bob/objects/{uuid}/content` (the surface described in D6a). Stream-friendly — `StreamingFileUpload` for upload so bytes never sit in heap; streamed body on download. Per-container authz via `BobContainerAuthorizer` beans (D6a).
+- **Authorizers registered**: `WikiBobContainerAuthorizer` (preserves existing Wiki behaviour), `SnomedBobContainerAuthorizer`, `LoincBobContainerAuthorizer`.
+- **SNOMED** — `SnomedController.import(...)` rewritten as a thin endpoint that accepts either `?fromObjectId={uuid}` (use an already-stored BobObject) or a multipart file (one-step: stores via `BobObjectService` internally, then triggers the same job). Starts a Lorque job (`SnomedRF2ImportJob`), returns the `LorqueProcess`. The job uses `BobObjectService.loadContent(...)` to stream from Minio to `/tmp`, calls `SnowstormClient.createImportJob` → `uploadRF2File` reading from a `Path`, reports progress through `lorqueProcessService.reportProgress(...)`, and patches the BobObject's `meta` with the final `importStatus` and `lorqueProcessId`. Old synchronous code path deleted.
+- **LOINC** — `LoincController.import(...)` (`edition-int/.../LoincController.java:34`) gets the same refactor — accepts `?fromObjectId={uuid}` or multipart, starts a Lorque job, hands a `Path` to `LoincService` (which already reads from an `InputStream`). Old synchronous code path deleted.
+- **UI — Stored uploads list view.** A new Angular component renders the result of `GET /bob/objects?container={terminology}` as a filterable table on both the SNOMED and LOINC CodeSystem pages. Per-row actions: `Trigger import` (calls `POST /snomed/imports?fromObjectId={uuid}`) and `Delete` (calls `DELETE /bob/objects/{uuid}`). Top-of-page *Upload archive (no import)* button posts to `POST /bob/objects?container={terminology}`. Status polling on the import job reuses the existing `/lorque-processes/{id}/status` flow.
 
-Per-terminology changes:
-- **SNOMED** — `SnomedController.import(...)` rewritten to stream the multipart body to a temp file (no `blockingGet()`, no full `byte[]`), `TerminologyArchiveService.store(...)` it, start a Lorque job (`SnomedRF2ImportJob`), return the `LorqueProcess`. The job downloads from Minio to `/tmp`, calls `SnowstormClient.createImportJob` → `uploadRF2File` reading from a `Path`, reports progress, completes/fails Lorque. Old synchronous code path deleted.
-- **LOINC** — `LoincController.import(...)` (`edition-int/.../LoincController.java:34`) gets the same streamed-to-disk + Lorque-async refactor. The CSV parser already reads from an `InputStream`, so wiring it to a file path is mechanical. Old synchronous code path deleted.
-- **UI** — both buttons switch to start polling `/lorque-processes/{id}/status` the same way `/imports/scan` already does (the polling helper exists).
+No new tables, no new shared service layer. Everything sits on top of `BobObjectService` and the existing `bob.object` / `bob.object_storage` schema, with new container values `"snomed"` / `"loinc"`. Wiki rows untouched.
 
-Acceptance: International SNOMED edition (~1 GB) imports successfully on dev-server with current `-Xmx1800m`; LOINC release-bundle imports the same way; heap usage stays bounded; failure cases (Snowstorm down, malformed archive) surface as `lorqueProcessService.fail` instead of HTTP 500.
+Acceptance:
+- International SNOMED edition (~1 GB) imports successfully on dev-server with current `-Xmx1800m`; LOINC release-bundle imports the same way; heap usage stays bounded; failure cases (Snowstorm down, malformed archive) surface as `lorqueProcessService.fail` instead of HTTP 500.
+- `GET /bob/objects?container=wiki` returns the existing Wiki rows unchanged; Wiki page-attachment uploads/lists/deletes still work through both the existing `/pages/{id}/files` endpoints AND the new generic `/bob/objects` endpoints.
+- An admin can upload an archive without triggering an import (`POST /bob/objects?container=snomed` with `edition`/`effectiveTime` keys in `meta`), and subsequent imports for the next release use it as the baseline once Phase 2 lands.
 
-### Phase 2 — Uploads API + UI list
+### Phase 2 — SNOMED delta-generator-tool integration
 
-Small, depends only on Phase 1's `TerminologyArchiveService` + `terminology_import` table. Useful in its own right (recovery / audit / manual baseline seeding) and a prerequisite for Phase 3 to be effective — delta-generator needs a baseline already in Minio.
-
-**Server endpoints** (one set per terminology, same shape):
-- `POST /snomed/imports/uploads` — multipart file + form fields `edition`, `effectiveTime`. Streams the upload to Minio, records a `terminology_import` row with `status=UPLOADED`. Does **not** push anything to Snowstorm.
-- `GET /snomed/imports/uploads` — list stored archives for the terminology. Supports query params `?edition=…&effectiveTime=…&status=…` for filtering. Returns one entry per `terminology_import` row (id, terminology, edition, effective time, filename, minio key, status, created at, optional Lorque process id).
-- `GET /snomed/imports/uploads/{id}` — single archive metadata.
-- `DELETE /snomed/imports/uploads/{id}` — soft-delete the `terminology_import` row and remove the Minio object. Used to free up baseline slots before the retention job runs.
-- Same four endpoints under `/loinc/imports/uploads`.
-
-Implementation reuses Phase 1's streamed-upload + `TerminologyArchiveService.store` plumbing; the only difference vs. a normal import is that the controller stops after the Minio store, never starts a Lorque job, and never calls Snowstorm.
-
-**UI — Stored uploads list view.** A new Angular component (`stored-uploads-list`) renders the result of `GET …/uploads` as a table with columns *Edition*, *Effective time*, *Filename*, *Status*, *Size*, *Stored at*, *Actions*. Filters on terminology (SNOMED / LOINC), edition, status. Per-row actions: `Delete`, `Trigger import from this archive` (calls a new `POST /snomed/imports?fromUploadId={id}` shortcut that skips the upload step and starts the Lorque job directly against the stored Minio object). An *Upload archive (no import)* button on the page hits the `POST …/uploads` endpoint, useful for seeding baselines.
-
-Acceptance: admin uploads the SNOMED archive that matches what is already in Snowstorm/TermX today via the UI; the row appears in the stored-uploads list with `status=UPLOADED`; subsequent normal import for the next release sees it as the baseline (after Phase 3). Deleting an entry removes the Minio object.
-
-### Phase 3 — SNOMED delta-generator-tool integration
-
-Builds on Phases 1 and 2.
+Builds on Phase 1.
 
 - Add `delta-generator-tool` jar to the `termx-app` Docker image (multi-stage: download the released jar from IHTSDO releases, copy into the final image).
 - New `DeltaGeneratorRunner` service that takes two `Path`s (baseline, new) and a target output `Path`, runs the jar via `ProcessBuilder`, streams stderr to logs, has a configurable timeout, and captures the exit code into the Lorque `result_text` on failure.
 - `SnomedRF2ImportJob` gains a delta step between download and Snowstorm upload:
-  - Look up the most-recent succeeded baseline for the edition (from `terminology_import`).
+  - Look up the most-recent succeeded baseline for the edition: query `BobObjectService` for `container=snomed`, `meta.terminology=snomed`, `meta.edition=<…>`, `meta.importStatus=COMPLETED`, ordered by `created` desc.
   - If none → push the full snapshot (Phase 1 behaviour).
-  - If found → download baseline + new to `/tmp`, run delta-generator → `/tmp/delta.zip`, push the delta archive via Snowstorm two-step.
+  - If found → load baseline + new to `/tmp` via `BobObjectService.loadContent(...)`, run delta-generator → `/tmp/delta.zip`, push the delta archive via Snowstorm two-step.
 - Same job framework + UI; no surface change.
 
 Acceptance: a second import of the same edition with one concept changed produces a delta archive dramatically smaller than the source ZIP, and Snowstorm shows the expected diff applied. Empty delta is a clean no-op with Lorque marked complete + "no changes" message.
 
 This phase is **SNOMED-only.** LOINC stays on Phase 1's full-snapshot model — no equivalent diff tool exists.
 
-### Phase 4 — Presigned upload URLs (optional / nice-to-have)
+### Phase 3 — Presigned upload URLs (optional / nice-to-have)
 
-UI requests a presigned PUT URL from TermX, browser uploads directly to Minio, TermX receives only the object key over a small JSON callback. Eliminates the last "TermX proxies a multi-hundred-MB file" path entirely. Applies to both SNOMED and LOINC. Could be folded into Phase 1 but tracked separately because it touches the UI and the Minio policy model.
+UI requests a presigned PUT URL from a new `POST /bob/objects/presigned-upload-url` endpoint (which writes a placeholder `BobObject` row and returns the Minio presigned URL + object UUID); browser PUTs the file directly to Minio; UI then notifies TermX via `POST /bob/objects/{uuid}/finalize` so the row is moved out of the placeholder state. Eliminates the last "TermX proxies a multi-hundred-MB file" path entirely. Applies to every container (SNOMED, LOINC, Wiki, future modules) — same plumbing. Could be folded into Phase 1 but tracked separately because it touches the UI and the Minio policy model (presigned URLs require a Minio policy that permits direct PUTs).
 
 ## Out of scope for this design
 
@@ -211,10 +255,12 @@ UI requests a presigned PUT URL from TermX, browser uploads directly to Minio, T
 ## Verification plan (when implementation lands)
 
 1. **Phase 1 — SNOMED.** Local: `JAVA_OPTS=-Xmx1800m` (current dev-server) + International edition import → completes without OOM, peak RSS stays under 2 GB.
-2. **Phase 1 — LOINC.** Same: a full LOINC release-bundle import via the new endpoint completes without OOM under the same heap limits.
-3. **Phase 1 — failure mode.** Kill Snowstorm mid-import → Lorque process moves to FAILED with the connection error in `result_text`; UI shows it. No process holding onto a stale `byte[]` in heap.
-4. **Phase 2 — stored uploads.** Admin uploads the SNOMED archive that matches what's already in TermX today via `POST /snomed/imports/uploads` → row appears in `terminology_import` with `status=UPLOADED`; nothing pushed to Snowstorm; archive readable from Minio; `GET /snomed/imports/uploads` returns the row; UI list shows it; `DELETE …/{id}` removes both the row (soft-delete) and the Minio object.
-5. **Phase 3 — delta path.** With a baseline present from Phase 2, a normal import of the next release produces a delta archive dramatically smaller than the source ZIP; Snowstorm shows only the expected diff applied.
-6. **Phase 3 — empty delta.** Re-import an identical archive → delta-generator produces an empty delta → Lorque marked complete with "no changes" message; nothing pushed to Snowstorm.
-7. **Phase 3 — failure mode.** Feed delta-generator a corrupted ZIP → subprocess exits non-zero; Lorque captures stderr and marks FAILED; TermX JVM heap unaffected.
-8. **Minio retention.** Trigger 4 imports for the same edition; oldest 1 is deleted by the cleanup job (retention policy = N most recent per edition, default `N=3`).
+2. **Phase 1 — LOINC.** A full LOINC release-bundle import via the new endpoint completes without OOM under the same heap limits.
+3. **Phase 1 — Wiki preserved.** Existing Wiki page-attachment rows in `bob.object` remain readable through both `/pages/{id}/files` (existing) and the new `GET /bob/objects?container=wiki` (new). Uploading a new Wiki attachment continues to work through `/pages/{id}/files`. No data migration needed.
+4. **Phase 1 — generic Bob authz.** A user with `snomed-ct.CodeSystem.read` can `GET /bob/objects?container=snomed` but is rejected with 403 on `?container=wiki`. The Wiki authorizer keeps its existing privilege semantics.
+5. **Phase 1 — stored uploads UI.** Admin uploads a SNOMED archive without triggering an import (`POST /bob/objects?container=snomed` with edition/effectiveTime in `meta`); the row appears in the UI list; *Trigger import* on that row calls `POST /snomed/imports?fromObjectId={uuid}` and starts a Lorque job without re-uploading; *Delete* removes both the row and the Minio object.
+6. **Phase 1 — failure mode.** Kill Snowstorm mid-import → Lorque process moves to FAILED with the connection error in `result_text`; UI shows it. No process holding onto a stale `byte[]` in heap.
+7. **Phase 2 — delta path.** With a baseline BobObject present, a normal import of the next release produces a delta archive dramatically smaller than the source ZIP; Snowstorm shows only the expected diff applied. The new BobObject is patched with `meta.importStatus=COMPLETED` and a back-reference to the Lorque process.
+8. **Phase 2 — empty delta.** Re-import an identical archive → delta-generator produces an empty delta → Lorque marked complete with "no changes" message; nothing pushed to Snowstorm.
+9. **Phase 2 — failure mode.** Feed delta-generator a corrupted ZIP → subprocess exits non-zero; Lorque captures stderr and marks FAILED; TermX JVM heap unaffected.
+10. **Minio retention.** Trigger 4 imports for the same edition; oldest 1 is deleted by the cleanup job (retention policy = N most recent per edition, default `N=3`).

--- a/docs/snomed-rf2-import-redesign.md
+++ b/docs/snomed-rf2-import-redesign.md
@@ -1,20 +1,26 @@
-# SNOMED RF2 import redesign
+# Large-terminology import redesign (SNOMED + LOINC)
 
 **Status:** Draft for review · No implementation yet
 **Authors:** TermX team
-**Related code:** [`snomed/`](../snomed/), [`bob/`](../bob/), [`termx-core/sys/lorque/`](../termx-core/src/main/java/org/termx/core/sys/lorque/)
+**Related code:** [`snomed/`](../snomed/), [`edition-int/loinc/`](../edition-int/src/main/java/org/termx/editionint/loinc/), [`bob/`](../bob/), [`termx-core/sys/lorque/`](../termx-core/src/main/java/org/termx/core/sys/lorque/)
 
 ## Context
 
 Uploading a full SNOMED CT International edition through the UI ("Import from RF2") crashes the server with `java.lang.OutOfMemoryError: Java heap space`. The stack trace lands in Micronaut's reactive HTTP pipeline before the import even reaches Snowstorm.
 
-The crash is not a Snowstorm or RF2 problem — it's a TermX-side architecture problem:
+**The same pattern affects LOINC import** (`edition-int/.../LoincController.java:62`) — `FileUtil.readBytes(Flowable.fromPublisher(file).firstOrError().blockingGet())` — and the same fix applies.
 
-1. The controller materializes the ~1 GB ZIP into a `byte[]` in JVM heap before doing anything.
-2. The parser (used by the dry-run scan flow) further accumulates every concept / description / relationship row in `List<…>` fields in heap.
+The crash is not a Snowstorm / RF2 / LOINC problem — it's a TermX-side architecture problem:
+
+1. The controller materializes the multi-hundred-MB upload into a `byte[]` in JVM heap before doing anything.
+2. For SNOMED, the parser (used by the dry-run scan flow) further accumulates every concept / description / relationship row in `List<…>` fields in heap.
 3. The dev-server container runs with `-Xmx1800m`, which has no realistic chance of holding all of that plus normal request traffic.
 
-Bumping heap or catching `OutOfMemoryError` is a band-aid. This doc proposes the durable fix: stream uploads to Minio, do all heavy lifting in a background Lorque job, and use the official IHTSDO `delta-generator-tool` so we push the smallest possible payload to Snowstorm.
+Bumping heap or catching `OutOfMemoryError` is a band-aid. This doc proposes the durable fix:
+
+- **Both SNOMED and LOINC** — stream uploads to Minio and do all heavy lifting in a background Lorque job.
+- **SNOMED specifically** — use the official IHTSDO `delta-generator-tool` so we push only the diff against the previous version to Snowstorm, not the full snapshot.
+- **No fallback to the current synchronous upload path** — the existing flow is fundamentally OOM-prone and is being replaced, not kept around as a backup.
 
 ## Current architecture
 
@@ -33,14 +39,19 @@ Bumping heap or catching `OutOfMemoryError` is a band-aid. This doc proposes the
                 Snowstorm
 ```
 
-Reference points:
+Reference points (SNOMED):
 - `snomed/src/main/java/org/termx/snomed/integration/SnomedController.java:252–267` — the upload endpoint, with `FileUtil.readBytes(Flowable.fromPublisher(file).firstOrError().blockingGet())` at line 255.
 - `snomed/src/main/java/org/termx/snomed/integration/SnomedService.java:123–149` — chains `snowstormClient.createImportJob(req).join()` then `uploadRF2File(jobId, importFile).join()`.
 - `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:157–175` — already exposes the two-step Snowstorm import API.
 - `snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java:21–32` — caches uploaded bytes as a **DB blob**; cleanup every 6 hours, 7-day retention.
 - `snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java:45–59` — file-name patterns (`sct2_Concept_*`, `sct2_Description_*`, `sct2_TextDefinition_*`, `sct2_Relationship_*` / `sct2_StatedRelationship_*`, `der2_cRefset_Language*`).
 
+Reference points (LOINC):
+- `edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java:34–62` — same `byte[]`-in-heap pattern. The CSV parser at `LoincService` reads from a `ByteArrayInputStream`, so the entire archive sits in heap exactly the way SNOMED does.
+
 ## Proposed architecture
+
+The diagram below shows the SNOMED case. **LOINC follows the same shape with one difference:** there is no equivalent of the IHTSDO delta-generator tool for LOINC, so the LOINC job downloads the new archive from Minio and pushes it straight to the LOINC importer (`LoincService`) — no delta computation. Everything else — streamed upload, Minio storage, Lorque async, status polling — is identical and shared.
 
 ```
   UI ──upload──▶ SnomedController (streamed)
@@ -115,56 +126,89 @@ Reference: `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:15
 - Per-edition: keep the most recent **N** raw uploads in Minio (default `N=3`). Older ones get GC'd by a scheduled job mirroring the existing 6-hour cleanup loop in `SnomedRF2UploadCacheService:53–54`.
 - Delta archives (intermediate): delete from `/tmp` after the Snowstorm upload completes — they're regenerable.
 
+## Resolved during review
+
+- **Generalize across terminologies.** The storage + async-job foundation (Phase 1) is shared between SNOMED and LOINC. The delta-generator-tool integration (Phase 2) stays SNOMED-specific because the IHTSDO tool only understands RF2; LOINC has no equivalent delta tool and is handled as a streamed-full-import job.
+- **Skip delta-generator when no baseline exists.** First-ever import of an edition (or LOINC version) imports the full snapshot directly. Subsequent imports look up the previous version from Minio and run delta-generator.
+- **No fallback to the current synchronous upload.** The existing `/imports` and LOINC `/import` are being replaced, not kept alongside. The current path is the bug; preserving it as a fallback just preserves the bug.
+- **delta-generator-tool runs as a subprocess** (D3). Tool is officially SNOMED-supported; subprocess gives clean OOM isolation and avoids dragging its full dependency tree into TermX's classpath.
+
 ## Open questions
 
 | # | Question | Notes |
 | --- | --- | --- |
-| Q1 | New `snomed_import` table or extend `lorque_process`? | A dedicated table makes baseline lookup ("most recent succeeded import for edition X") trivial and survives Lorque cleanup. Recommend new table; keep Lorque as the *job-status* mechanism only. |
+| Q1 | New `snomed_import` table or extend `lorque_process`? | A dedicated table makes baseline lookup ("most recent succeeded import for edition X") trivial and survives Lorque cleanup. Recommend new table (probably generalized as `terminology_import` to also cover LOINC); keep Lorque as the *job-status* mechanism only. |
 | Q2 | Exact `delta-generator-tool` CLI shape? | Confirm against [github.com/IHTSDO/delta-generator-tool](https://github.com/IHTSDO/delta-generator-tool) README. Best done by whoever picks up the implementation. |
-| Q3 | Should `SnomedRF2UploadCacheService` (DB-blob cache for the dry-run scan) move to Minio too? | Probably yes for consistency, but out-of-scope for this PR. Track separately. |
-| Q4 | Authorization on the Minio bucket | Read/write from TermX server only, or also presigned URLs for direct browser → Minio uploads (would skip TermX as proxy entirely)? Presigned is more work but eliminates one more "JVM holds the file" path. Recommend deferring to Phase 3. |
+| Q3 | Should `SnomedRF2UploadCacheService` (DB-blob cache for the dry-run scan) move to Minio too? | Probably yes for consistency, but out-of-scope for this redesign. Track separately. |
+| Q4 | Authorization on the Minio bucket | Read/write from TermX server only, or also presigned URLs for direct browser → Minio uploads (would skip TermX as proxy entirely)? Presigned is more work but eliminates one more "JVM holds the file" path. Deferred to Phase 4. |
 | Q5 | What happens if delta-generator fails / produces empty delta? | If empty → no-op, mark Lorque complete with "no changes". If failure → fail Lorque with the subprocess stderr captured. |
+| Q6 | Where do existing-but-unstored-in-Minio versions come from for the backfill? | Realistic options: (a) admin uploads the original archive from their own filesystem through the same upload endpoint with a `skipImport=true` flag; (b) read from the existing `SnomedRF2UploadCacheService` DB blobs where available. (a) is simpler and covers every case (admin always has the source); recommend (a). |
 
 ## Phased delivery
 
-Three PRs, deployable independently. Each leaves the system in a better state than before; later phases build on earlier ones.
+Four PRs, deployable independently. Each leaves the system in a better state than before; later phases build on earlier ones.
 
-### Phase 1 — Stream upload to Minio, route `/imports` through Lorque
+### Phase 1 — Streamed upload + Minio + Lorque, for both SNOMED and LOINC
 
-Smallest unit of work that eliminates the OOM. Does **not** introduce delta-generator yet.
+Smallest unit of work that eliminates the OOM. Does **not** introduce delta-generator yet — SNOMED imports a full snapshot just like before, just streamed through disk + Minio + a Lorque async job. LOINC's only fix is this phase; the rest doesn't apply to it.
 
-- `SnomedController.import(...)` rewritten to stream the multipart body to a temp file (no `blockingGet()`, no full `byte[]`), then `MinioService.store(...)`, then start a Lorque job, then return `LorqueProcess`.
-- New `SnomedRF2ImportJob` (or extend `SnomedService`) that downloads from Minio to `/tmp`, calls `SnowstormClient.createImportJob` → `uploadRF2File`, reports progress, completes/fails the Lorque process.
-- New table (if Q1 is "yes"): `snomed_import` with columns `id, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`.
-- UI: switch the "Import from RF2" button to start polling the Lorque status the same way `/imports/scan` already does.
+A new shared building block:
+- `TerminologyArchiveService` (in `termx-core` or a new shared module) wraps `MinioService` with a stable object-key convention: `terminology-archives/<terminology>/<edition>/<effective-time>/<original-filename>`. `terminology` is `snomed` or `loinc`. Used by both SNOMED and LOINC paths.
+- New table `terminology_import` (resolves Q1): `id, terminology, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`. One row per import attempt; queried as "most recent succeeded for this edition" when Phase 2 lands.
 
-Acceptance: International edition (~1 GB) imports successfully on dev-server with current `-Xmx1800m`; heap usage stays bounded; failure cases (Snowstorm down, malformed ZIP) surface as `lorqueProcessService.fail` instead of HTTP 500.
+Per-terminology changes:
+- **SNOMED** — `SnomedController.import(...)` rewritten to stream the multipart body to a temp file (no `blockingGet()`, no full `byte[]`), `TerminologyArchiveService.store(...)` it, start a Lorque job (`SnomedRF2ImportJob`), return the `LorqueProcess`. The job downloads from Minio to `/tmp`, calls `SnowstormClient.createImportJob` → `uploadRF2File` reading from a `Path`, reports progress, completes/fails Lorque. Old synchronous code path deleted.
+- **LOINC** — `LoincController.import(...)` (`edition-int/.../LoincController.java:34`) gets the same streamed-to-disk + Lorque-async refactor. The CSV parser already reads from an `InputStream`, so wiring it to a file path is mechanical. Old synchronous code path deleted.
+- **UI** — both buttons switch to start polling `/lorque-processes/{id}/status` the same way `/imports/scan` already does (the polling helper exists).
 
-### Phase 2 — Wire delta-generator-tool
+Acceptance: International SNOMED edition (~1 GB) imports successfully on dev-server with current `-Xmx1800m`; LOINC release-bundle imports the same way; heap usage stays bounded; failure cases (Snowstorm down, malformed archive) surface as `lorqueProcessService.fail` instead of HTTP 500.
 
-Builds on Phase 1's job framework.
+### Phase 2 — Backfill API: store existing previously-imported versions in Minio
 
-- Add `delta-generator-tool` jar to the `termx-app` Docker image (multi-stage: download the released jar, copy into final image).
-- New `DeltaGeneratorRunner` service that takes two `Path`s (baseline, new) and a target output `Path`, runs the jar via `ProcessBuilder`, streams stderr to logs, times out at configurable threshold.
-- `SnomedRF2ImportJob` gains a delta step between download and Snowstorm upload: look up baseline, run delta-generator, push delta. First-ever-import path skips delta.
+Small, depends only on Phase 1's `TerminologyArchiveService` + `terminology_import` table. Useful in its own right (recovery / audit) and a prerequisite for Phase 3 to be effective — delta-generator needs a baseline.
 
-Acceptance: a second import of the same edition (with concept changes between) uploads a delta archive that is dramatically smaller than the source ZIP, and Snowstorm shows the expected diff applied.
+Two endpoints (one per terminology, same shape):
+- `POST /snomed/imports/backfill` — accepts the same multipart payload as a regular import, plus form fields `edition`, `effectiveTime`. Stores in Minio, records a `terminology_import` row with `status=BACKFILLED`. Does **not** push anything to Snowstorm.
+- `POST /loinc/imports/backfill` — analogous.
 
-### Phase 3 — Presigned upload URLs (optional / nice-to-have)
+Implementation is mostly reuse of Phase 1's streamed-upload + `TerminologyArchiveService.store` plumbing, just without the Lorque/Snowstorm step at the end.
 
-UI uploads directly to Minio via a presigned URL; TermX server receives only the object key. Eliminates the last "TermX proxies a 1 GB file" path. Could be folded into Phase 1 if we want, but tracking separately because it touches the UI and adds Minio policy considerations.
+Acceptance: admin uploads the SNOMED archive that matches what is already in Snowstorm/TermX today; row appears in `terminology_import`; subsequent normal import for the next release sees it as the baseline (after Phase 3).
+
+### Phase 3 — SNOMED delta-generator-tool integration
+
+Builds on Phases 1 and 2.
+
+- Add `delta-generator-tool` jar to the `termx-app` Docker image (multi-stage: download the released jar from IHTSDO releases, copy into the final image).
+- New `DeltaGeneratorRunner` service that takes two `Path`s (baseline, new) and a target output `Path`, runs the jar via `ProcessBuilder`, streams stderr to logs, has a configurable timeout, and captures the exit code into the Lorque `result_text` on failure.
+- `SnomedRF2ImportJob` gains a delta step between download and Snowstorm upload:
+  - Look up the most-recent succeeded baseline for the edition (from `terminology_import`).
+  - If none → push the full snapshot (Phase 1 behaviour).
+  - If found → download baseline + new to `/tmp`, run delta-generator → `/tmp/delta.zip`, push the delta archive via Snowstorm two-step.
+- Same job framework + UI; no surface change.
+
+Acceptance: a second import of the same edition with one concept changed produces a delta archive dramatically smaller than the source ZIP, and Snowstorm shows the expected diff applied. Empty delta is a clean no-op with Lorque marked complete + "no changes" message.
+
+This phase is **SNOMED-only.** LOINC stays on Phase 1's full-snapshot model — no equivalent diff tool exists.
+
+### Phase 4 — Presigned upload URLs (optional / nice-to-have)
+
+UI requests a presigned PUT URL from TermX, browser uploads directly to Minio, TermX receives only the object key over a small JSON callback. Eliminates the last "TermX proxies a multi-hundred-MB file" path entirely. Applies to both SNOMED and LOINC. Could be folded into Phase 1 but tracked separately because it touches the UI and the Minio policy model.
 
 ## Out of scope for this design
 
 - Refactoring the existing dry-run scan (`/imports/scan`) — it already uses Lorque, just from a DB-blob cache rather than Minio. Migration tracked via Q3.
-- Memory-efficient parsing inside `SnomedRF2ZipParser` — once delta-generator is doing the heavy lifting, the scan's in-memory accumulators stop mattering for the import path. Keep scan as-is.
-- Changes to other terminology imports (FHIR CodeSystem, etc.) — different code paths, different scale.
+- Memory-efficient parsing inside `SnomedRF2ZipParser` — once delta-generator is doing the heavy lifting on disk, the scan's in-memory accumulators stop mattering for the import path. Keep scan as-is.
+- Changes to other terminology imports beyond SNOMED and LOINC (FHIR CodeSystem upload, UCUM, etc.) — different code paths, different scale. Re-evaluate per-terminology if OOM reports come in.
+- Keeping the current synchronous `/imports` / LOINC `/import` as a fallback — the existing flow is the bug we're fixing, not a backup worth preserving.
 
 ## Verification plan (when implementation lands)
 
-1. Local: `JAVA_OPTS=-Xmx1800m` (current dev-server) + International edition import → completes without OOM. (Phase 1 alone.)
-2. Local: second import of the same edition with one concept changed → delta archive is < 1 MB; Snowstorm shows only that change. (Phase 2.)
-3. Failure injection: kill Snowstorm mid-import → Lorque process moves to FAILED with the connection error in `result_text`; UI shows it.
-4. Failure injection: feed delta-generator a corrupted ZIP → subprocess exits non-zero; Lorque captures stderr and marks FAILED.
-5. Container memory: peak RSS during a full import stays under 2 GB.
-6. Minio retention: trigger 4 imports for the same edition; oldest 1 is deleted by the cleanup job.
+1. **Phase 1 — SNOMED.** Local: `JAVA_OPTS=-Xmx1800m` (current dev-server) + International edition import → completes without OOM, peak RSS stays under 2 GB.
+2. **Phase 1 — LOINC.** Same: a full LOINC release-bundle import via the new endpoint completes without OOM under the same heap limits.
+3. **Phase 1 — failure mode.** Kill Snowstorm mid-import → Lorque process moves to FAILED with the connection error in `result_text`; UI shows it. No process holding onto a stale `byte[]` in heap.
+4. **Phase 2 — backfill.** Admin uploads the SNOMED archive that matches what's already in TermX today via `/snomed/imports/backfill` → row appears in `terminology_import` with `status=BACKFILLED`; nothing pushed to Snowstorm; archive readable from Minio.
+5. **Phase 3 — delta path.** With a baseline present from Phase 2, a normal import of the next release produces a delta archive dramatically smaller than the source ZIP; Snowstorm shows only the expected diff applied.
+6. **Phase 3 — empty delta.** Re-import an identical archive → delta-generator produces an empty delta → Lorque marked complete with "no changes" message; nothing pushed to Snowstorm.
+7. **Phase 3 — failure mode.** Feed delta-generator a corrupted ZIP → subprocess exits non-zero; Lorque captures stderr and marks FAILED; TermX JVM heap unaffected.
+8. **Minio retention.** Trigger 4 imports for the same edition; oldest 1 is deleted by the cleanup job (retention policy = N most recent per edition, default `N=3`).

--- a/docs/snomed-rf2-import-redesign.md
+++ b/docs/snomed-rf2-import-redesign.md
@@ -1,0 +1,170 @@
+# SNOMED RF2 import redesign
+
+**Status:** Draft for review · No implementation yet
+**Authors:** TermX team
+**Related code:** [`snomed/`](../snomed/), [`bob/`](../bob/), [`termx-core/sys/lorque/`](../termx-core/src/main/java/org/termx/core/sys/lorque/)
+
+## Context
+
+Uploading a full SNOMED CT International edition through the UI ("Import from RF2") crashes the server with `java.lang.OutOfMemoryError: Java heap space`. The stack trace lands in Micronaut's reactive HTTP pipeline before the import even reaches Snowstorm.
+
+The crash is not a Snowstorm or RF2 problem — it's a TermX-side architecture problem:
+
+1. The controller materializes the ~1 GB ZIP into a `byte[]` in JVM heap before doing anything.
+2. The parser (used by the dry-run scan flow) further accumulates every concept / description / relationship row in `List<…>` fields in heap.
+3. The dev-server container runs with `-Xmx1800m`, which has no realistic chance of holding all of that plus normal request traffic.
+
+Bumping heap or catching `OutOfMemoryError` is a band-aid. This doc proposes the durable fix: stream uploads to Minio, do all heavy lifting in a background Lorque job, and use the official IHTSDO `delta-generator-tool` so we push the smallest possible payload to Snowstorm.
+
+## Current architecture
+
+```
+  UI ──upload──▶ SnomedController @Post /snomed/imports
+                  │
+                  │  blockingGet() — entire ZIP → byte[] in heap
+                  ▼
+              SnomedService.importRF2File
+                  │
+                  │  byte[] → MultipartBodyPublisher
+                  ▼
+              SnowstormClient (two-step: createImportJob → uploadRF2File)
+                  │
+                  ▼
+                Snowstorm
+```
+
+Reference points:
+- `snomed/src/main/java/org/termx/snomed/integration/SnomedController.java:252–267` — the upload endpoint, with `FileUtil.readBytes(Flowable.fromPublisher(file).firstOrError().blockingGet())` at line 255.
+- `snomed/src/main/java/org/termx/snomed/integration/SnomedService.java:123–149` — chains `snowstormClient.createImportJob(req).join()` then `uploadRF2File(jobId, importFile).join()`.
+- `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:157–175` — already exposes the two-step Snowstorm import API.
+- `snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java:21–32` — caches uploaded bytes as a **DB blob**; cleanup every 6 hours, 7-day retention.
+- `snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java:45–59` — file-name patterns (`sct2_Concept_*`, `sct2_Description_*`, `sct2_TextDefinition_*`, `sct2_Relationship_*` / `sct2_StatedRelationship_*`, `der2_cRefset_Language*`).
+
+## Proposed architecture
+
+```
+  UI ──upload──▶ SnomedController (streamed)
+                  │  ① stream multipart → temp file on disk
+                  │  ② upload temp file → Minio bucket
+                  │  ③ create LorqueProcess(status=RUNNING)
+                  │  ④ kick off virtual-thread job, return processId immediately
+                  ▼
+                                                ┌────────────────────────┐
+              SnomedRF2ImportJob (async) ───────│  Minio                 │
+                  │                              │  snomed-imports/      │
+                  │  download new + baseline    │   <edition>/<eff>/    │
+                  │   from Minio → /tmp         │     <filename>.zip    │
+                  │                              └────────────────────────┘
+                  │  invoke delta-generator-tool
+                  │   (subprocess on /tmp/new + /tmp/baseline → /tmp/delta.zip)
+                  │
+                  │  SnowstormClient.createImportJob → Location
+                  │  SnowstormClient.uploadRF2File(jobId, delta.zip)
+                  │
+                  │  lorqueProcessService.complete(processId, …)
+                  ▼
+                Snowstorm
+
+  UI ──poll──▶ LorqueProcessController GET /lorque-processes/{id}/status
+```
+
+## Key decisions
+
+### D1. Where uploads land — Minio, not DB blob, not memory
+
+**Decision:** Stream the multipart upload to a temp file on disk inside the controller, then `MinioService.store(...)` it under `snomed-imports/<edition-id>/<effective-time>/<original-filename>.zip`. Delete the temp file once uploaded. Remove the DB-blob caching path entirely (or repurpose it for metadata only).
+
+**Why:**
+- Minio already wraps this — `bob/src/main/java/org/termx/bob/minio/MinioService.java:35–108` (`store`, `retrieve`, `delete`).
+- Configuration already wired — `bob.minio.url` / `access-key` / `secret-key` in `MinioClientFactory`.
+- Auto-creates the bucket on first write.
+- Confirmed running in dev and prod.
+
+### D2. Heavy work moves to a Lorque async job
+
+**Decision:** Mirror the pattern already used by `SnomedRF2ScanService` (the dry-run scan endpoint). The controller returns a `LorqueProcess` immediately; a virtual-thread runs the actual import; status flows through `lorqueProcessService.start/reportProgress/complete/fail`.
+
+**Why:**
+- Pattern is already established — see `snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java:39–66` and `termx-core/src/main/java/org/termx/core/sys/lorque/LorqueProcessService.java:39–72`.
+- UI already polls `GET /lorque-processes/{id}/status` (controller line 24).
+- OOM-class failures land on a background thread, away from the HTTP pipeline. Even if something goes wrong, the user gets a job-failed status, not a dropped connection.
+
+### D3. delta-generator-tool runs as a subprocess
+
+**Decision:** Invoke the IHTSDO `delta-generator-tool` jar via `ProcessBuilder`. Ship the jar in the Docker image (multi-stage Dockerfile: stage one downloads / builds the jar; stage two copies it). The Java service runs it with `--input-snapshot=<baseline.zip> --input-snapshot=<new.zip> --output-delta=<out.zip>` (exact CLI to be confirmed against the tool's README).
+
+**Alternative considered:** add as a Maven dependency. **Rejected because:** the tool isn't published to Maven Central in a form we control, its own dependency tree is large, and subprocess gives us clean process isolation — an OOM in the delta computation doesn't bring down the TermX JVM.
+
+**Risks:**
+- No existing subprocess pattern in the codebase (greenfield).
+- Need to surface stdout/stderr into the Lorque process's progress / failure messages.
+- Need a strict timeout; delta generation on a full International edition is minutes, not seconds, but should not be unbounded.
+
+### D4. Baseline retrieval
+
+**Decision:** Look up the most-recent successful import for the same edition (same `<edition-id>`) from the `lorque_process` table (or a small new `snomed_import` table — see Q1 below), download that ZIP from Minio to `/tmp`, and use it as the baseline for delta-generator. If no baseline exists (first-ever import for the edition), skip the delta step and import the full snapshot directly via the same Snowstorm two-step.
+
+### D5. The two-step Snowstorm flow stays — already correct
+
+The `SnowstormClient` already does `createImportJob(req)` → returns Location header → `uploadRF2File(jobId, …)`. No change needed there, except the input becomes a `Path` or `InputStream` instead of `byte[]` so the JVM never holds the full archive (the delta archive is smaller, but on principle).
+
+Reference: `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:157–175`.
+
+### D6. Retention
+
+- Per-edition: keep the most recent **N** raw uploads in Minio (default `N=3`). Older ones get GC'd by a scheduled job mirroring the existing 6-hour cleanup loop in `SnomedRF2UploadCacheService:53–54`.
+- Delta archives (intermediate): delete from `/tmp` after the Snowstorm upload completes — they're regenerable.
+
+## Open questions
+
+| # | Question | Notes |
+| --- | --- | --- |
+| Q1 | New `snomed_import` table or extend `lorque_process`? | A dedicated table makes baseline lookup ("most recent succeeded import for edition X") trivial and survives Lorque cleanup. Recommend new table; keep Lorque as the *job-status* mechanism only. |
+| Q2 | Exact `delta-generator-tool` CLI shape? | Confirm against [github.com/IHTSDO/delta-generator-tool](https://github.com/IHTSDO/delta-generator-tool) README. Best done by whoever picks up the implementation. |
+| Q3 | Should `SnomedRF2UploadCacheService` (DB-blob cache for the dry-run scan) move to Minio too? | Probably yes for consistency, but out-of-scope for this PR. Track separately. |
+| Q4 | Authorization on the Minio bucket | Read/write from TermX server only, or also presigned URLs for direct browser → Minio uploads (would skip TermX as proxy entirely)? Presigned is more work but eliminates one more "JVM holds the file" path. Recommend deferring to Phase 3. |
+| Q5 | What happens if delta-generator fails / produces empty delta? | If empty → no-op, mark Lorque complete with "no changes". If failure → fail Lorque with the subprocess stderr captured. |
+
+## Phased delivery
+
+Three PRs, deployable independently. Each leaves the system in a better state than before; later phases build on earlier ones.
+
+### Phase 1 — Stream upload to Minio, route `/imports` through Lorque
+
+Smallest unit of work that eliminates the OOM. Does **not** introduce delta-generator yet.
+
+- `SnomedController.import(...)` rewritten to stream the multipart body to a temp file (no `blockingGet()`, no full `byte[]`), then `MinioService.store(...)`, then start a Lorque job, then return `LorqueProcess`.
+- New `SnomedRF2ImportJob` (or extend `SnomedService`) that downloads from Minio to `/tmp`, calls `SnowstormClient.createImportJob` → `uploadRF2File`, reports progress, completes/fails the Lorque process.
+- New table (if Q1 is "yes"): `snomed_import` with columns `id, edition_id, effective_time, filename, minio_key, lorque_process_id, status, created_at`.
+- UI: switch the "Import from RF2" button to start polling the Lorque status the same way `/imports/scan` already does.
+
+Acceptance: International edition (~1 GB) imports successfully on dev-server with current `-Xmx1800m`; heap usage stays bounded; failure cases (Snowstorm down, malformed ZIP) surface as `lorqueProcessService.fail` instead of HTTP 500.
+
+### Phase 2 — Wire delta-generator-tool
+
+Builds on Phase 1's job framework.
+
+- Add `delta-generator-tool` jar to the `termx-app` Docker image (multi-stage: download the released jar, copy into final image).
+- New `DeltaGeneratorRunner` service that takes two `Path`s (baseline, new) and a target output `Path`, runs the jar via `ProcessBuilder`, streams stderr to logs, times out at configurable threshold.
+- `SnomedRF2ImportJob` gains a delta step between download and Snowstorm upload: look up baseline, run delta-generator, push delta. First-ever-import path skips delta.
+
+Acceptance: a second import of the same edition (with concept changes between) uploads a delta archive that is dramatically smaller than the source ZIP, and Snowstorm shows the expected diff applied.
+
+### Phase 3 — Presigned upload URLs (optional / nice-to-have)
+
+UI uploads directly to Minio via a presigned URL; TermX server receives only the object key. Eliminates the last "TermX proxies a 1 GB file" path. Could be folded into Phase 1 if we want, but tracking separately because it touches the UI and adds Minio policy considerations.
+
+## Out of scope for this design
+
+- Refactoring the existing dry-run scan (`/imports/scan`) — it already uses Lorque, just from a DB-blob cache rather than Minio. Migration tracked via Q3.
+- Memory-efficient parsing inside `SnomedRF2ZipParser` — once delta-generator is doing the heavy lifting, the scan's in-memory accumulators stop mattering for the import path. Keep scan as-is.
+- Changes to other terminology imports (FHIR CodeSystem, etc.) — different code paths, different scale.
+
+## Verification plan (when implementation lands)
+
+1. Local: `JAVA_OPTS=-Xmx1800m` (current dev-server) + International edition import → completes without OOM. (Phase 1 alone.)
+2. Local: second import of the same edition with one concept changed → delta archive is < 1 MB; Snowstorm shows only that change. (Phase 2.)
+3. Failure injection: kill Snowstorm mid-import → Lorque process moves to FAILED with the connection error in `result_text`; UI shows it.
+4. Failure injection: feed delta-generator a corrupted ZIP → subprocess exits non-zero; Lorque captures stderr and marks FAILED.
+5. Container memory: peak RSS during a full import stays under 2 GB.
+6. Minio retention: trigger 4 imports for the same edition; oldest 1 is deleted by the cleanup job.

--- a/docs/snomed-rf2-import-redesign.md
+++ b/docs/snomed-rf2-import-redesign.md
@@ -128,10 +128,12 @@ Reference: `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:15
 
 ## Resolved during review
 
-- **Generalize across terminologies.** The storage + async-job foundation (Phase 1) is shared between SNOMED and LOINC. The delta-generator-tool integration (Phase 2) stays SNOMED-specific because the IHTSDO tool only understands RF2; LOINC has no equivalent delta tool and is handled as a streamed-full-import job.
+- **Generalize across terminologies.** The storage + async-job foundation (Phase 1) is shared between SNOMED and LOINC. The delta-generator-tool integration (Phase 3) stays SNOMED-specific because the IHTSDO tool only understands RF2; LOINC has no equivalent delta tool and is handled as a streamed-full-import job.
 - **Skip delta-generator when no baseline exists.** First-ever import of an edition (or LOINC version) imports the full snapshot directly. Subsequent imports look up the previous version from Minio and run delta-generator.
 - **No fallback to the current synchronous upload.** The existing `/imports` and LOINC `/import` are being replaced, not kept alongside. The current path is the bug; preserving it as a fallback just preserves the bug.
 - **delta-generator-tool runs as a subprocess** (D3). Tool is officially SNOMED-supported; subprocess gives clean OOM isolation and avoids dragging its full dependency tree into TermX's classpath.
+- **Resource naming: `uploads`, not `backfill`.** What was called the "backfill" endpoint in the first draft is modeled as an `/imports/uploads` sub-resource: `POST /snomed/imports/uploads` (and `/loinc/imports/uploads`) to store, `GET /snomed/imports/uploads` to list, `DELETE …/{id}` to remove. Matches the existing `SnomedRF2Upload` entity name in the codebase. Better than "backfill" because it isn't an awkward verb-as-noun and naturally supports list/get/delete operations for the new UI component.
+- **Q6 — Backfill source: admin re-uploads the original archive.** The admin always has the source file (they imported it once already), so a re-upload through `POST /snomed/imports/uploads` is universal, predictable, and requires zero migration code on the server. The alternative (reading from `SnomedRF2UploadCacheService` DB-blob cache) only covers archives uploaded in the last 7 days, can't be relied on, and would block on database I/O — rejected.
 
 ## Open questions
 
@@ -142,7 +144,6 @@ Reference: `snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java:15
 | Q3 | Should `SnomedRF2UploadCacheService` (DB-blob cache for the dry-run scan) move to Minio too? | Probably yes for consistency, but out-of-scope for this redesign. Track separately. |
 | Q4 | Authorization on the Minio bucket | Read/write from TermX server only, or also presigned URLs for direct browser → Minio uploads (would skip TermX as proxy entirely)? Presigned is more work but eliminates one more "JVM holds the file" path. Deferred to Phase 4. |
 | Q5 | What happens if delta-generator fails / produces empty delta? | If empty → no-op, mark Lorque complete with "no changes". If failure → fail Lorque with the subprocess stderr captured. |
-| Q6 | Where do existing-but-unstored-in-Minio versions come from for the backfill? | Realistic options: (a) admin uploads the original archive from their own filesystem through the same upload endpoint with a `skipImport=true` flag; (b) read from the existing `SnomedRF2UploadCacheService` DB blobs where available. (a) is simpler and covers every case (admin always has the source); recommend (a). |
 
 ## Phased delivery
 
@@ -163,17 +164,22 @@ Per-terminology changes:
 
 Acceptance: International SNOMED edition (~1 GB) imports successfully on dev-server with current `-Xmx1800m`; LOINC release-bundle imports the same way; heap usage stays bounded; failure cases (Snowstorm down, malformed archive) surface as `lorqueProcessService.fail` instead of HTTP 500.
 
-### Phase 2 — Backfill API: store existing previously-imported versions in Minio
+### Phase 2 — Uploads API + UI list
 
-Small, depends only on Phase 1's `TerminologyArchiveService` + `terminology_import` table. Useful in its own right (recovery / audit) and a prerequisite for Phase 3 to be effective — delta-generator needs a baseline.
+Small, depends only on Phase 1's `TerminologyArchiveService` + `terminology_import` table. Useful in its own right (recovery / audit / manual baseline seeding) and a prerequisite for Phase 3 to be effective — delta-generator needs a baseline already in Minio.
 
-Two endpoints (one per terminology, same shape):
-- `POST /snomed/imports/backfill` — accepts the same multipart payload as a regular import, plus form fields `edition`, `effectiveTime`. Stores in Minio, records a `terminology_import` row with `status=BACKFILLED`. Does **not** push anything to Snowstorm.
-- `POST /loinc/imports/backfill` — analogous.
+**Server endpoints** (one set per terminology, same shape):
+- `POST /snomed/imports/uploads` — multipart file + form fields `edition`, `effectiveTime`. Streams the upload to Minio, records a `terminology_import` row with `status=UPLOADED`. Does **not** push anything to Snowstorm.
+- `GET /snomed/imports/uploads` — list stored archives for the terminology. Supports query params `?edition=…&effectiveTime=…&status=…` for filtering. Returns one entry per `terminology_import` row (id, terminology, edition, effective time, filename, minio key, status, created at, optional Lorque process id).
+- `GET /snomed/imports/uploads/{id}` — single archive metadata.
+- `DELETE /snomed/imports/uploads/{id}` — soft-delete the `terminology_import` row and remove the Minio object. Used to free up baseline slots before the retention job runs.
+- Same four endpoints under `/loinc/imports/uploads`.
 
-Implementation is mostly reuse of Phase 1's streamed-upload + `TerminologyArchiveService.store` plumbing, just without the Lorque/Snowstorm step at the end.
+Implementation reuses Phase 1's streamed-upload + `TerminologyArchiveService.store` plumbing; the only difference vs. a normal import is that the controller stops after the Minio store, never starts a Lorque job, and never calls Snowstorm.
 
-Acceptance: admin uploads the SNOMED archive that matches what is already in Snowstorm/TermX today; row appears in `terminology_import`; subsequent normal import for the next release sees it as the baseline (after Phase 3).
+**UI — Stored uploads list view.** A new Angular component (`stored-uploads-list`) renders the result of `GET …/uploads` as a table with columns *Edition*, *Effective time*, *Filename*, *Status*, *Size*, *Stored at*, *Actions*. Filters on terminology (SNOMED / LOINC), edition, status. Per-row actions: `Delete`, `Trigger import from this archive` (calls a new `POST /snomed/imports?fromUploadId={id}` shortcut that skips the upload step and starts the Lorque job directly against the stored Minio object). An *Upload archive (no import)* button on the page hits the `POST …/uploads` endpoint, useful for seeding baselines.
+
+Acceptance: admin uploads the SNOMED archive that matches what is already in Snowstorm/TermX today via the UI; the row appears in the stored-uploads list with `status=UPLOADED`; subsequent normal import for the next release sees it as the baseline (after Phase 3). Deleting an entry removes the Minio object.
 
 ### Phase 3 — SNOMED delta-generator-tool integration
 
@@ -207,7 +213,7 @@ UI requests a presigned PUT URL from TermX, browser uploads directly to Minio, T
 1. **Phase 1 — SNOMED.** Local: `JAVA_OPTS=-Xmx1800m` (current dev-server) + International edition import → completes without OOM, peak RSS stays under 2 GB.
 2. **Phase 1 — LOINC.** Same: a full LOINC release-bundle import via the new endpoint completes without OOM under the same heap limits.
 3. **Phase 1 — failure mode.** Kill Snowstorm mid-import → Lorque process moves to FAILED with the connection error in `result_text`; UI shows it. No process holding onto a stale `byte[]` in heap.
-4. **Phase 2 — backfill.** Admin uploads the SNOMED archive that matches what's already in TermX today via `/snomed/imports/backfill` → row appears in `terminology_import` with `status=BACKFILLED`; nothing pushed to Snowstorm; archive readable from Minio.
+4. **Phase 2 — stored uploads.** Admin uploads the SNOMED archive that matches what's already in TermX today via `POST /snomed/imports/uploads` → row appears in `terminology_import` with `status=UPLOADED`; nothing pushed to Snowstorm; archive readable from Minio; `GET /snomed/imports/uploads` returns the row; UI list shows it; `DELETE …/{id}` removes both the row (soft-delete) and the Minio object.
 5. **Phase 3 — delta path.** With a baseline present from Phase 2, a normal import of the next release produces a delta archive dramatically smaller than the source ZIP; Snowstorm shows only the expected diff applied.
 6. **Phase 3 — empty delta.** Re-import an identical archive → delta-generator produces an empty delta → Lorque marked complete with "no changes" message; nothing pushed to Snowstorm.
 7. **Phase 3 — failure mode.** Feed delta-generator a corrupted ZIP → subprocess exits non-zero; Lorque captures stderr and marks FAILED; TermX JVM heap unaffected.


### PR DESCRIPTION
## Summary

Design doc — no code changes. Proposes the architecture for fixing the `OutOfMemoryError` that fires when a user uploads a full SNOMED International edition through the UI ("Import from RF2"). Requesting review before implementation begins.

**The doc lives at [`docs/snomed-rf2-import-redesign.md`](../blob/docs/snomed-rf2-import-redesign/docs/snomed-rf2-import-redesign.md).**

## Key proposals

1. **Stream uploads to Minio**, not into JVM heap. The current controller does `FileUtil.readBytes(Flowable.fromPublisher(file).firstOrError().blockingGet())` — a ~1 GB `byte[]` allocation in the request thread. Replace with multipart-streamed temp-file + `MinioService.store(...)` (Minio is already wired in `bob/`).
2. **Run the import as a Lorque async job**, mirroring the existing pattern in `SnomedRF2ScanService`. The HTTP request returns a `LorqueProcess` immediately and the UI polls `/lorque-processes/{id}/status` — already a supported endpoint.
3. **Integrate [IHTSDO delta-generator-tool](https://github.com/IHTSDO/delta-generator-tool)** as a subprocess so we push the delta between editions to Snowstorm, not the full snapshot. Dramatically reduces both TermX-side memory pressure and Snowstorm import time.

## Three phases, deployable independently

- **Phase 1** (foundation): streaming upload + Lorque async. **This phase alone eliminates the OOM** even before delta-generator lands.
- **Phase 2**: delta-generator-tool integration. Builds on Phase 1's job framework.
- **Phase 3** (optional): presigned-URL uploads — browser writes directly to Minio, TermX never proxies the bytes.

## Open questions called out in the doc

- Q1: Dedicated `snomed_import` table or extend `lorque_process`? *(Recommend new table.)*
- Q2: Confirm the exact `delta-generator-tool` CLI shape against its README.
- Q3: Should the dry-run scan cache migrate from DB-blob to Minio too?
- Q4: Authorization model on the Minio bucket (presigned URLs vs. server-side only).
- Q5: Handling of empty / failed delta-generator runs.

## What this PR does NOT do

- No code changes whatsoever — pure design doc.
- Does not touch the existing dry-run scan path (already async via Lorque, just uses DB-blob caching).
- Does not refactor `SnomedRF2ZipParser`'s in-memory accumulators (once delta-generator does the heavy lifting on disk, those accumulators stop mattering for the import path).

## What I'd like reviewers to focus on

- Is the **Minio + Lorque + delta-generator** shape what we want, or is there a simpler approach worth considering?
- Are the three phase boundaries the right size? Phase 1 is sized to fit one focused PR; happy to split further if needed.
- Open questions Q1, Q3, Q4 in particular — they have downstream implications.