### PR TITLE
feat(bob): /bob/objects REST API with per-container authz plugin (Phase 1a)

### DIFF
--- a/bob/src/main/java/org/termx/bob/BobContainerAuthorizer.java
+++ b/bob/src/main/java/org/termx/bob/BobContainerAuthorizer.java
@@ -1,0 +1,42 @@
+package org.termx.bob;
+
+import org.termx.core.auth.SessionInfo;
+
+/**
+ * Plugin contract that lets each owning module declare which Bob container it owns
+ * and what authorisation the generic {@code /bob/objects} REST endpoints must enforce
+ * for operations on that container.
+ *
+ * <p>One bean per container value (e.g. {@code "wiki"}, {@code "snomed"}, {@code "loinc"}).
+ * The {@link BobObjectController} collects every {@code BobContainerAuthorizer} bean
+ * via Micronaut multi-bean injection and dispatches by {@link #getContainer()}.</p>
+ *
+ * <p>If no authorizer is registered for a container value, the controller treats it as
+ * forbidden. This is intentional — a new bucket never becomes reachable through the
+ * generic REST API without an explicit authz declaration.</p>
+ */
+public interface BobContainerAuthorizer {
+
+  /** The Bob container value this authorizer governs (matches {@code BobStorage.container}). */
+  String getContainer();
+
+  /**
+   * Verify the session may read an object in this container, throwing
+   * {@link com.kodality.commons.exception.ForbiddenException} otherwise.
+   *
+   * @param session the authenticated session
+   * @param object  the object being read; {@code null} on list/query operations (so authorizers
+   *                that need to scope by {@link BobObject#getMeta() meta} should require the
+   *                broadest privilege when {@code object} is {@code null})
+   */
+  void checkRead(SessionInfo session, BobObject object);
+
+  /**
+   * Verify the session may create / update / delete an object in this container, throwing
+   * {@link com.kodality.commons.exception.ForbiddenException} otherwise.
+   *
+   * @param session the authenticated session
+   * @param object  the object being mutated; on create the id and uuid are not yet populated
+   */
+  void checkWrite(SessionInfo session, BobObject object);
+}

--- a/bob/src/main/java/org/termx/bob/BobObjectController.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectController.java
@@ -1,0 +1,176 @@
+package org.termx.bob;
+
+import com.kodality.commons.exception.ApiClientException;
+import com.kodality.commons.exception.ForbiddenException;
+import com.kodality.commons.exception.NotFoundException;
+import com.kodality.commons.micronaut.rest.MultipartBodyReader;
+import com.kodality.commons.micronaut.rest.MultipartBodyReader.Attachment;
+import com.kodality.commons.model.Issue;
+import com.kodality.commons.model.QueryResult;
+import com.kodality.commons.util.JsonUtil;
+import org.termx.core.auth.Authorized;
+import org.termx.core.auth.SessionInfo;
+import org.termx.core.auth.SessionStore;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Delete;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Patch;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.server.multipart.MultipartBody;
+import io.micronaut.http.server.types.files.StreamedFile;
+import jakarta.inject.Singleton;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Generic REST surface for the Binary Object Bank ({@code bob.object}).
+ *
+ * <p>Every endpoint dispatches to a per-container {@link BobContainerAuthorizer}, looked up
+ * by the object's (or query's) container value. Containers without a registered authorizer
+ * are inaccessible — a new bucket only becomes reachable once its owning module declares
+ * a {@link BobContainerAuthorizer} bean. The {@link Authorized} annotation is intentionally
+ * left empty so the {@link org.termx.core.auth.AuthorizationFilter} allows authenticated
+ * users past the static check, and the dynamic per-container authz runs inside each handler.</p>
+ */
+@Singleton
+@Controller("/bob/objects")
+public class BobObjectController {
+  private final BobObjectService objectService;
+  private final Map<String, BobContainerAuthorizer> authorizers;
+
+  public BobObjectController(BobObjectService objectService, List<BobContainerAuthorizer> authorizers) {
+    this.objectService = objectService;
+    this.authorizers = authorizers.stream().collect(Collectors.toMap(BobContainerAuthorizer::getContainer, a -> a));
+  }
+
+  @Authorized
+  @Get
+  public QueryResult<BobObject> query(BobObjectQueryParams params) {
+    if (params.getContainer() == null || params.getContainer().isBlank()) {
+      throw new ApiClientException(Issue.error("BOB001", "container query parameter is required"));
+    }
+    BobContainerAuthorizer authorizer = requireAuthorizer(params.getContainer());
+    authorizer.checkRead(session(), null);
+    return objectService.query(params);
+  }
+
+  @Authorized
+  @Get("/{uuid}")
+  public BobObject load(@PathVariable String uuid) {
+    BobObject object = requireExisting(uuid);
+    requireAuthorizer(object.getStorage().getContainer()).checkRead(session(), object);
+    return object;
+  }
+
+  @Authorized
+  @Get(value = "/{uuid}/content", produces = MediaType.APPLICATION_OCTET_STREAM)
+  public StreamedFile loadContent(@PathVariable String uuid) {
+    BobObject object = requireExisting(uuid);
+    requireAuthorizer(object.getStorage().getContainer()).checkRead(session(), object);
+    return objectService.loadContent(object);
+  }
+
+  @Authorized
+  @Post(consumes = MediaType.MULTIPART_FORM_DATA)
+  public BobObject create(@Body MultipartBody partz) {
+    MultipartBodyReader.MultipartBody body = MultipartBodyReader.readMultipart(partz);
+
+    String container = require(body.getTextParts().get("container"), "container");
+    Attachment file = body.getAttachments().get("file");
+    if (file == null) {
+      throw new ApiClientException(Issue.error("BOB002", "file part is required"));
+    }
+    String path = body.getTextParts().getOrDefault("path", "/");
+    Map<String, Object> meta = parseJsonMap(body.getTextParts().get("meta"));
+    String description = body.getTextParts().get("description");
+    String contentType = body.getTextParts().getOrDefault("contentType", file.getContentType());
+
+    BobObject draft = new BobObject()
+        .setContentType(contentType)
+        .setMeta(meta)
+        .setDescription(description)
+        .setStorage(new BobStorage()
+            .setContainer(container)
+            .setPath(path)
+            .setFilename(file.getFileName()));
+    requireAuthorizer(container).checkWrite(session(), draft);
+
+    String uuid = objectService.store(draft, file.getContent());
+    return objectService.load(uuid);
+  }
+
+  @Authorized
+  @Patch("/{uuid}")
+  public BobObject update(@PathVariable String uuid, @Body BobObjectPatch patch) {
+    BobObject existing = requireExisting(uuid);
+    BobContainerAuthorizer authorizer = requireAuthorizer(existing.getStorage().getContainer());
+    authorizer.checkWrite(session(), existing);
+    BobObject patchObj = new BobObject()
+        .setMeta(patch.getMeta())
+        .setDescription(patch.getDescription());
+    return objectService.update(uuid, patchObj);
+  }
+
+  @Authorized
+  @Delete("/{uuid}")
+  public void delete(@PathVariable String uuid) {
+    BobObject existing = requireExisting(uuid);
+    requireAuthorizer(existing.getStorage().getContainer()).checkWrite(session(), existing);
+    objectService.delete(uuid);
+  }
+
+  private BobObject requireExisting(String uuid) {
+    BobObject object = objectService.load(uuid);
+    if (object == null) {
+      throw new NotFoundException("BobObject '" + uuid + "' does not exist");
+    }
+    return object;
+  }
+
+  private BobContainerAuthorizer requireAuthorizer(String container) {
+    BobContainerAuthorizer a = authorizers.get(container);
+    if (a == null) {
+      // No authorizer registered → treat as forbidden. We use ForbiddenException rather than
+      // 404 to avoid leaking whether the container exists in storage.
+      throw new ForbiddenException("forbidden");
+    }
+    return a;
+  }
+
+  private SessionInfo session() {
+    return SessionStore.require();
+  }
+
+  private static String require(String value, String name) {
+    if (value == null || value.isBlank()) {
+      throw new ApiClientException(Issue.error("BOB003", "{{name}} is required", Map.of("name", name)));
+    }
+    return value;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> parseJsonMap(String json) {
+    if (json == null || json.isBlank()) {
+      return new HashMap<>();
+    }
+    try {
+      return JsonUtil.fromJson(json, Map.class);
+    } catch (Exception e) {
+      throw new ApiClientException(Issue.error("BOB004", "meta is not valid JSON"));
+    }
+  }
+
+  @Getter
+  @Setter
+  public static class BobObjectPatch {
+    private Map<String, Object> meta;
+    private String description;
+  }
+}

--- a/bob/src/main/java/org/termx/bob/BobObjectQueryParams.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectQueryParams.java
@@ -9,5 +9,6 @@ import lombok.experimental.Accessors;
 @Setter
 @Accessors(chain = true)
 public class BobObjectQueryParams extends QueryParams {
+  private String container;
   private String meta;
 }

--- a/bob/src/main/java/org/termx/bob/BobObjectRepository.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectRepository.java
@@ -42,6 +42,7 @@ public class BobObjectRepository extends BaseRepository {
 
   private SqlBuilder filter(BobObjectQueryParams params) {
     SqlBuilder sb = new SqlBuilder("where o.sys_status = 'A'");
+    sb.appendIfNotNull(params.getContainer(), (sql, p) -> sql.and("os.container = ?", p));
     sb.appendIfNotNull(params.getMeta(), (sql, p) -> sql.and("o.meta @> ?::jsonb", p));
     return sb;
   }
@@ -90,6 +91,19 @@ public class BobObjectRepository extends BaseRepository {
       throw new IllegalStateException("Failed to create BobStorage");
     }
     return result;
+  }
+
+  public void update(Long objectId, BobObject obj) {
+    SaveSqlBuilder ssb = new SaveSqlBuilder();
+    ssb.property("id", objectId);
+    ssb.jsonProperty("meta", obj.getMeta());
+    ssb.property("description", obj.getDescription());
+
+    SqlBuilder sb = ssb.buildUpdate("bob.object", "id");
+    if (jdbcTemplate == null) {
+      throw new IllegalStateException("jdbcTemplate is not initialized");
+    }
+    jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());
   }
 
   public void deleteStorage(Long objectId) {

--- a/bob/src/main/java/org/termx/bob/BobObjectService.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectService.java
@@ -41,6 +41,20 @@ public class BobObjectService {
   }
 
   @Transactional
+  public BobObject update(String uuid, BobObject patch) {
+    BobObject existing = load(uuid);
+    if (existing == null) {
+      throw new RuntimeException("BobObject not found: " + uuid);
+    }
+    BobObject merged = new BobObject()
+        .setId(existing.getId())
+        .setMeta(patch.getMeta() != null ? patch.getMeta() : existing.getMeta())
+        .setDescription(patch.getDescription() != null ? patch.getDescription() : existing.getDescription());
+    objectRepository.update(existing.getId(), merged);
+    return load(uuid);
+  }
+
+  @Transactional
   public void delete(String uuid) {
     BobObject object = load(uuid);
     getMinio().delete(object);

--- a/wiki/src/main/java/org/termx/wiki/WikiBobContainerAuthorizer.java
+++ b/wiki/src/main/java/org/termx/wiki/WikiBobContainerAuthorizer.java
@@ -1,0 +1,36 @@
+package org.termx.wiki;
+
+import org.termx.bob.BobContainerAuthorizer;
+import org.termx.bob.BobObject;
+import org.termx.core.auth.SessionInfo;
+import jakarta.inject.Singleton;
+
+/**
+ * Authorizes access to Wiki attachments stored under the {@code "wiki"} Bob container
+ * when reached via the generic {@code /bob/objects} REST API.
+ *
+ * <p>The fine-grained per-space checks still live on the {@code /pages/{id}/files}
+ * endpoints; this authorizer only governs the cross-cutting Bob API and therefore
+ * requires the broad {@code *.Wiki.read} / {@code *.Wiki.write} privileges — i.e. only
+ * an admin-style user (with permission on any space) can list, fetch, or mutate Wiki
+ * attachments through {@code /bob/objects}. Per-space callers should continue using the
+ * existing {@code PageController} endpoints.</p>
+ */
+@Singleton
+public class WikiBobContainerAuthorizer implements BobContainerAuthorizer {
+
+  @Override
+  public String getContainer() {
+    return "wiki";
+  }
+
+  @Override
+  public void checkRead(SessionInfo session, BobObject object) {
+    session.checkPermitted("*", Privilege.W_READ);
+  }
+
+  @Override
+  public void checkWrite(SessionInfo session, BobObject object) {
+    session.checkPermitted("*", Privilege.W_WRITE);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1a of the SNOMED / LOINC large-archive import redesign (see [`docs/snomed-rf2-import-redesign.md`](docs/snomed-rf2-import-redesign.md)). Foundation only — no SNOMED / LOINC controller changes yet.

- Generic `/bob/objects` REST surface over the existing `BobObjectService` (POST multipart, GET list / one / content, PATCH meta+description, DELETE).
- `BobContainerAuthorizer` plugin: one bean per container. Controller dispatches each request to the matching authorizer; containers with no registered authorizer are forbidden by design, so adding a new bucket never silently bypasses authz.
- `WikiBobContainerAuthorizer` registers the existing `"wiki"` container (no regression — fine-grained per-space checks on `/pages/{id}/files` continue unchanged).
- `BobObjectQueryParams.container` filter (required on the list endpoint) and a `BobObject.update()` path for meta / description patches.

The follow-up PRs will register `snomed` / `loinc` authorizers and refactor those controllers to stream uploads through this surface.

## Test plan
- [ ] `GET /bob/objects?container=wiki` returns the existing wiki attachments for a user with `*.Wiki.read`; forbidden without it.
- [ ] `GET /bob/objects?container=wiki` filtered by `meta={"page": N}` returns just that page's attachments.
- [ ] `POST /bob/objects` multipart with `container=wiki`, file, optional `meta` / `description` / `path` creates the object and forwards bytes to Minio.
- [ ] `GET /bob/objects/{uuid}` returns metadata, `GET /bob/objects/{uuid}/content` streams the file.
- [ ] `PATCH /bob/objects/{uuid}` with `{description, meta}` updates only those fields; content untouched.
- [ ] `DELETE /bob/objects/{uuid}` deletes both the Minio object and the row.
- [ ] `GET /bob/objects?container=does-not-exist` → 403 (no authorizer registered).
- [ ] Existing `POST /pages/{id}/files` Wiki upload continues to work.