### PR TITLE
feat(bob,snomed,loinc): streaming uploads + SNOMED from-archive import (Phase 1b/1c)

### DIFF
--- a/bob/build.gradle.kts
+++ b/bob/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     implementation("io.micronaut:micronaut-runtime")
     implementation("io.micronaut:micronaut-http-server-netty")
+    implementation("io.projectreactor:reactor-core")
     implementation("io.micronaut.spring:micronaut-spring")
     implementation("io.micronaut:micronaut-management")
     implementation("io.micronaut.micrometer:micronaut-micrometer-registry-prometheus")

--- a/bob/src/main/java/org/termx/bob/BobObjectController.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectController.java
@@ -3,14 +3,13 @@ package org.termx.bob;
 import com.kodality.commons.exception.ApiClientException;
 import com.kodality.commons.exception.ForbiddenException;
 import com.kodality.commons.exception.NotFoundException;
-import com.kodality.commons.micronaut.rest.MultipartBodyReader;
-import com.kodality.commons.micronaut.rest.MultipartBodyReader.Attachment;
 import com.kodality.commons.model.Issue;
 import com.kodality.commons.model.QueryResult;
 import com.kodality.commons.util.JsonUtil;
 import org.termx.core.auth.Authorized;
 import org.termx.core.auth.SessionInfo;
 import org.termx.core.auth.SessionStore;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
@@ -18,16 +17,22 @@ import io.micronaut.http.annotation.Delete;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Patch;
 import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Part;
 import io.micronaut.http.annotation.Post;
-import io.micronaut.http.server.multipart.MultipartBody;
+import io.micronaut.http.multipart.StreamingFileUpload;
 import io.micronaut.http.server.types.files.StreamedFile;
 import jakarta.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Mono;
 
 /**
  * Generic REST surface for the Binary Object Bank ({@code bob.object}).
@@ -77,33 +82,65 @@ public class BobObjectController {
     return objectService.loadContent(object);
   }
 
+  /**
+   * Multipart upload. The {@code file} part is streamed to a temp file on disk and then to Minio,
+   * so the JVM heap holds at most a small buffer regardless of file size. Other parts ({@code
+   * container}, {@code meta}, {@code description}, {@code path}, {@code contentType}) are
+   * received as normal form fields.
+   */
   @Authorized
   @Post(consumes = MediaType.MULTIPART_FORM_DATA)
-  public BobObject create(@Body MultipartBody partz) {
-    MultipartBodyReader.MultipartBody body = MultipartBodyReader.readMultipart(partz);
-
-    String container = require(body.getTextParts().get("container"), "container");
-    Attachment file = body.getAttachments().get("file");
-    if (file == null) {
-      throw new ApiClientException(Issue.error("BOB002", "file part is required"));
+  public Mono<BobObject> create(
+      StreamingFileUpload file,
+      @Part("container") String container,
+      @Nullable @Part("meta") String meta,
+      @Nullable @Part("description") String description,
+      @Nullable @Part("path") String path,
+      @Nullable @Part("contentType") String contentType
+  ) {
+    if (container == null || container.isBlank()) {
+      throw new ApiClientException(Issue.error("BOB001", "container query parameter is required"));
     }
-    String path = body.getTextParts().getOrDefault("path", "/");
-    Map<String, Object> meta = parseJsonMap(body.getTextParts().get("meta"));
-    String description = body.getTextParts().get("description");
-    String contentType = body.getTextParts().getOrDefault("contentType", file.getContentType());
-
     BobObject draft = new BobObject()
-        .setContentType(contentType)
-        .setMeta(meta)
+        .setContentType(contentType != null ? contentType : (file.getContentType().isPresent() ? file.getContentType().get().getName() : null))
+        .setMeta(parseJsonMap(meta))
         .setDescription(description)
         .setStorage(new BobStorage()
             .setContainer(container)
-            .setPath(path)
-            .setFilename(file.getFileName()));
+            .setPath(path != null ? path : "/")
+            .setFilename(file.getFilename()));
     requireAuthorizer(container).checkWrite(session(), draft);
 
-    String uuid = objectService.store(draft, file.getContent());
-    return objectService.load(uuid);
+    // Capture the session up-front; the streaming completion runs on a Netty event loop with
+    // no servlet thread-local, so SessionStore.require() inside the lambda would fail.
+    SessionInfo capturedSession = session();
+
+    Path temp;
+    try {
+      temp = Files.createTempFile("bob-", ".upload");
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to create temp file for upload", e);
+    }
+
+    Publisher<Boolean> transfer = file.transferTo(temp.toFile());
+    return Mono.from(transfer).map(ok -> {
+      if (!Boolean.TRUE.equals(ok)) {
+        try {
+          Files.deleteIfExists(temp);
+        } catch (IOException ignored) {}
+        throw new RuntimeException("Failed to spool upload to disk");
+      }
+      try {
+        SessionStore.setLocal(capturedSession);
+        String uuid = objectService.store(draft, temp);
+        return objectService.load(uuid);
+      } finally {
+        SessionStore.clearLocal();
+        try {
+          Files.deleteIfExists(temp);
+        } catch (IOException ignored) {}
+      }
+    });
   }
 
   @Authorized
@@ -146,13 +183,6 @@ public class BobObjectController {
 
   private SessionInfo session() {
     return SessionStore.require();
-  }
-
-  private static String require(String value, String name) {
-    if (value == null || value.isBlank()) {
-      throw new ApiClientException(Issue.error("BOB003", "{{name}} is required", Map.of("name", name)));
-    }
-    return value;
   }
 
   @SuppressWarnings("unchecked")

--- a/bob/src/main/java/org/termx/bob/BobObjectService.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectService.java
@@ -4,6 +4,10 @@ package org.termx.bob;
 import com.kodality.commons.model.QueryResult;
 import org.termx.bob.minio.MinioService;
 import io.micronaut.http.server.types.files.StreamedFile;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +35,14 @@ public class BobObjectService {
     return getMinio().retrieve(object);
   }
 
+  /**
+   * Raw {@link InputStream} for server-side consumers (re-uploading to Snowstorm, spooling
+   * to a temp file). Caller closes it.
+   */
+  public InputStream loadContentStream(BobObject object) {
+    return getMinio().retrieveStream(object);
+  }
+
 
   @Transactional
   public String store(BobObject object, byte[] content) {
@@ -38,6 +50,32 @@ public class BobObjectService {
     object.setId(id);
     persistContent(object, content);
     return objectRepository.getUuid(id);
+  }
+
+  /**
+   * Streaming variant: bytes from {@code filePath} flow to Minio without being buffered in
+   * the JVM heap. Use this for large uploads (SNOMED RF2, LOINC) — typically the controller
+   * has already spooled the multipart body to a temp file on disk and just passes the path.
+   */
+  @Transactional
+  public String store(BobObject object, Path filePath) {
+    Long id = objectRepository.create(object);
+    object.setId(id);
+    persistContent(object, filePath);
+    return objectRepository.getUuid(id);
+  }
+
+  private void persistContent(BobObject object, Path filePath) {
+    BobStorage storage = object.getStorage();
+    prepareTypeAndPath(storage);
+    try (InputStream in = Files.newInputStream(filePath)) {
+      long size = Files.size(filePath);
+      getMinio().store(object, in, size);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to stream file '" + filePath + "' to Minio: " + e.getMessage(), e);
+    }
+    Long storageId = objectRepository.createStorage(object.getId(), storage);
+    storage.setId(storageId);
   }
 
   @Transactional

--- a/bob/src/main/java/org/termx/bob/minio/MinioService.java
+++ b/bob/src/main/java/org/termx/bob/minio/MinioService.java
@@ -19,6 +19,7 @@ import io.minio.StatObjectResponse;
 import io.minio.errors.ErrorResponseException;
 import jakarta.inject.Singleton;
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Headers;
@@ -33,6 +34,14 @@ public class MinioService {
   private final MinioClient minioClient;
 
   public void store(BobObject object, byte[] content) {
+    store(object, new ByteArrayInputStream(content), content.length);
+  }
+
+  /**
+   * Streaming upload: the bytes flow Netty/HTTP → temp file → this method → Minio without ever
+   * being held entirely in JVM heap. Use this overload for large archives (SNOMED RF2, LOINC).
+   */
+  public void store(BobObject object, InputStream content, long contentLength) {
     BobStorage storage = object.getStorage();
     checkBucketExists(storage.getContainer());
     String fullPath = storage.getFullPath();
@@ -48,7 +57,7 @@ public class MinioService {
       try (var r = e.response()) {
         if (r.code() == 404) {
           log.info("File '{}' does not exist in bucket '{}', uploading it.", fullPath, storage.getContainer());
-          uploadFile(object, content);
+          uploadFile(object, content, contentLength);
         }
       }
     } catch (Exception e) {
@@ -69,6 +78,24 @@ public class MinioService {
     }
   }
 
+  /**
+   * Returns a raw {@link InputStream} for the object's content — for server-side consumers
+   * (re-uploading to Snowstorm, spooling to a temp file) that don't want the HTTP-response
+   * wrapping from {@link #retrieve(BobObject)}. The caller is responsible for closing it.
+   */
+  public InputStream retrieveStream(BobObject object) {
+    BobStorage storage = object.getStorage();
+    try {
+      return minioClient.getObject(
+          GetObjectArgs.builder()
+              .bucket(storage.getContainer())
+              .object(storage.getFullPath())
+              .build());
+    } catch (Exception e) {
+      throw new RuntimeException(format("Failed to retrieve object '%s' from bucket '%s", storage.getFullPath(), storage.getContainer()), e);
+    }
+  }
+
 
   private void checkBucketExists(String bucket) {
     try {
@@ -81,15 +108,20 @@ public class MinioService {
     }
   }
 
-  private void uploadFile(BobObject object, byte[] content) {
+  private void uploadFile(BobObject object, InputStream content, long contentLength) {
     try {
-      PutObjectArgs req = PutObjectArgs.builder()
+      PutObjectArgs.Builder b = PutObjectArgs.builder()
           .bucket(object.getStorage().getContainer())
           .object(object.getStorage().getFullPath())
-          .contentType(object.getContentType())
-          .stream(new ByteArrayInputStream(content), content.length, -1)
-          .build();
-      minioClient.putObject(req);
+          .contentType(object.getContentType());
+      // contentLength<0 → use multipart with 5MB part size (Minio's smallest part). Lets us
+      // accept truly unknown-size streams; the upper bound -1 means "until EOF".
+      if (contentLength >= 0) {
+        b.stream(content, contentLength, -1);
+      } else {
+        b.stream(content, -1, 5L * 1024 * 1024);
+      }
+      minioClient.putObject(b.build());
     } catch (Exception e) {
       throw new RuntimeException("Failed to upload file '" + object.getStorage().getFilename() + "': " + e.getMessage());
     }

--- a/edition-int/build.gradle.kts
+++ b/edition-int/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
 
     implementation(project(":termx-api"))
     implementation(project(":termx-core"))
+    implementation(project(":bob"))
 
     implementation("com.kodality.commons:commons-util:${rootProject.extra["commonsVersion"]}")
     implementation("com.kodality.commons:commons-db:${rootProject.extra["commonsVersion"]}")

--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincBobContainerAuthorizer.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincBobContainerAuthorizer.java
@@ -1,0 +1,34 @@
+package org.termx.editionint.loinc;
+
+import org.termx.bob.BobContainerAuthorizer;
+import org.termx.bob.BobObject;
+import org.termx.core.auth.SessionInfo;
+import jakarta.inject.Singleton;
+
+/**
+ * Authorizes access to LOINC release archives stored in the {@code "loinc"} Bob container.
+ *
+ * <p>The LOINC import is gated by {@code *.CodeSystem.write} (same as the existing
+ * {@code /loinc/import} endpoint), so we use the same privilege string here. Read goes against
+ * a {@code loinc.CodeSystem.read} convention to allow admins listing archives in the UI without
+ * needing global write.</p>
+ */
+@Singleton
+public class LoincBobContainerAuthorizer implements BobContainerAuthorizer {
+  public static final String CONTAINER = "loinc";
+
+  @Override
+  public String getContainer() {
+    return CONTAINER;
+  }
+
+  @Override
+  public void checkRead(SessionInfo session, BobObject object) {
+    session.checkPermitted("loinc", "CodeSystem", "read");
+  }
+
+  @Override
+  public void checkWrite(SessionInfo session, BobObject object) {
+    session.checkPermitted("loinc", "CodeSystem", "write");
+  }
+}

--- a/snomed/build.gradle.kts
+++ b/snomed/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation(project(":termx-api"))
     implementation(project(":termx-core"))
     implementation(project(":task"))
+    implementation(project(":bob"))
 
     implementation("com.kodality.commons:commons-util:${rootProject.extra["commonsVersion"]}")
     implementation("com.kodality.commons:commons-db:${rootProject.extra["commonsVersion"]}")

--- a/snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java
+++ b/snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java
@@ -28,12 +28,14 @@ import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MediaType;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -166,8 +168,17 @@ public class SnowstormClient {
   }
 
   public CompletableFuture<HttpResponse<String>> uploadRF2File(String jobId, byte[] file) throws FileNotFoundException {
+    return uploadRF2File(jobId, () -> new ByteArrayInputStream(file));
+  }
+
+  /**
+   * Streaming variant of {@link #uploadRF2File(String, byte[])}. The {@link Supplier} is invoked
+   * lazily by the multipart publisher when bytes are pushed to Snowstorm, so callers can pass a
+   * Minio / file InputStream and the JVM never holds the whole archive in heap.
+   */
+  public CompletableFuture<HttpResponse<String>> uploadRF2File(String jobId, Supplier<InputStream> file) throws FileNotFoundException {
     MultipartBodyPublisher publisher = new MultipartBodyPublisher()
-        .addPart("file", () -> new ByteArrayInputStream(file), "file", MediaType.APPLICATION_OCTET_STREAM);
+        .addPart("file", file, "file", MediaType.APPLICATION_OCTET_STREAM);
     HttpRequest request = client.builder("imports/" + jobId + "/archive").POST(publisher.build())
         .header("Content-Type", "multipart/form-data; boundary=" + publisher.getBoundary())
         .build();

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedBobContainerAuthorizer.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedBobContainerAuthorizer.java
@@ -1,0 +1,35 @@
+package org.termx.snomed.integration;
+
+import org.termx.bob.BobContainerAuthorizer;
+import org.termx.bob.BobObject;
+import org.termx.core.auth.SessionInfo;
+import org.termx.snomed.Privilege;
+import jakarta.inject.Singleton;
+
+/**
+ * Authorizes access to SNOMED RF2 archives stored in the {@code "snomed"} Bob container.
+ *
+ * <p>Read requires {@link Privilege#SNOMED_READ}, write / delete requires {@link
+ * Privilege#SNOMED_WRITE} — matching the existing {@code SnomedController} endpoints. Without
+ * this bean, {@code /bob/objects?container=snomed} would be forbidden by the controller's
+ * default-deny dispatch.</p>
+ */
+@Singleton
+public class SnomedBobContainerAuthorizer implements BobContainerAuthorizer {
+  public static final String CONTAINER = "snomed";
+
+  @Override
+  public String getContainer() {
+    return CONTAINER;
+  }
+
+  @Override
+  public void checkRead(SessionInfo session, BobObject object) {
+    session.checkPermitted("snomed-ct", "CodeSystem", "read");
+  }
+
+  @Override
+  public void checkWrite(SessionInfo session, BobObject object) {
+    session.checkPermitted("snomed-ct", "CodeSystem", "write");
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -24,6 +24,7 @@ import org.termx.snomed.refset.SnomedRefsetResponse;
 import org.termx.snomed.refset.SnomedRefsetSearchParams;
 import org.termx.snomed.rf2.SnomedExportJob;
 import org.termx.snomed.rf2.SnomedExportRequest;
+import org.termx.snomed.rf2.SnomedImportFromArchiveRequest;
 import org.termx.snomed.rf2.SnomedImportJob;
 import org.termx.snomed.rf2.SnomedImportRequest;
 import org.termx.snomed.rf2.SnomedRF2Upload;
@@ -86,6 +87,7 @@ public class SnomedController {
   private final SnomedRF2ScanService snomedRF2ScanService;
   private final SnomedRF2UploadCacheService snomedRF2UploadCacheService;
   private final SnomedConceptUsageService snomedConceptUsageService;
+  private final SnomedRF2ImportFromArchiveService snomedRF2ImportFromArchiveService;
 
 
   //----------------CodeSystems----------------
@@ -264,6 +266,28 @@ public class SnomedController {
     byte[] importFile = FileUtil.readBytes(upload);
     String filename = upload == null ? null : upload.getFilename();
     return snomedRF2ScanService.scanRF2(req, importFile, filename);
+  }
+
+  /**
+   * Streaming counterpart of {@link #createImportJob}: the archive already lives in the
+   * {@code "snomed"} Bob container (uploaded via {@code POST /bob/objects?container=snomed}),
+   * so we never buffer the zip in JVM heap. Runs asynchronously via Lorque; the response is
+   * a process the UI can poll.
+   */
+  @Authorized(Privilege.SNOMED_WRITE)
+  @Post(value = "/imports/from-archive")
+  public LorqueProcess createImportJobFromArchive(@Body SnomedImportFromArchiveRequest request) {
+    return snomedRF2ImportFromArchiveService.startImport(request);
+  }
+
+  /**
+   * Streaming counterpart of {@link #scanImport}: the archive already lives in the
+   * {@code "snomed"} Bob container, so re-running a dry-run scan does not require re-upload.
+   */
+  @Authorized(Privilege.SNOMED_READ)
+  @Post(value = "/imports/scan/from-archive")
+  public LorqueProcess scanImportFromArchive(@Body SnomedImportFromArchiveRequest request) {
+    return snomedRF2ImportFromArchiveService.startScan(request);
   }
 
   @Authorized(Privilege.SNOMED_WRITE)

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
@@ -1,0 +1,113 @@
+package org.termx.snomed.integration;
+
+import com.kodality.commons.exception.NotFoundException;
+import com.kodality.commons.util.JsonUtil;
+import jakarta.inject.Singleton;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.termx.bob.BobObject;
+import org.termx.bob.BobObjectService;
+import org.termx.core.auth.SessionStore;
+import org.termx.core.sys.lorque.LorqueProcessService;
+import org.termx.core.utils.VirtualThreadExecutor;
+import org.termx.snomed.client.SnowstormClient;
+import org.termx.snomed.integration.rf2.scan.SnomedRF2ScanService;
+import org.termx.snomed.rf2.SnomedImportFromArchiveRequest;
+import org.termx.snomed.rf2.SnomedImportRequest;
+import org.termx.snomed.rf2.SnomedImportTracking;
+import org.termx.sys.lorque.LorqueProcess;
+import org.termx.sys.lorque.ProcessResult;
+
+/**
+ * Drives the SNOMED RF2 import / dry-run-scan flow against an archive that already lives in the
+ * {@code "snomed"} Bob container. The archive bytes are streamed Minio → Snowstorm (or Minio →
+ * temp file for the scan), so the JVM never holds the whole zip — the customer-reported OOM on
+ * full International editions does not apply to this path.
+ */
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class SnomedRF2ImportFromArchiveService {
+  private static final String PROCESS_NAME_IMPORT = "snomed-rf2-import";
+  private static final String PROCESS_NAME_SCAN = "snomed-rf2-scan";
+
+  private final BobObjectService bobObjectService;
+  private final SnowstormClient snowstormClient;
+  private final SnomedImportTrackingRepository trackingRepository;
+  private final LorqueProcessService lorqueProcessService;
+  private final SnomedRF2ScanService scanService;
+
+  /**
+   * Kick off an async import from a Bob-stored RF2 zip. Returns immediately with a {@link
+   * LorqueProcess} the UI can poll; the actual work runs on a virtual thread.
+   */
+  public LorqueProcess startImport(SnomedImportFromArchiveRequest req) {
+    BobObject archive = requireArchive(req.getArchiveUuid());
+    LorqueProcess process = lorqueProcessService.start(new LorqueProcess().setProcessName(PROCESS_NAME_IMPORT));
+
+    SnomedImportRequest importRequest = req.toImportRequest();
+    Long processId = process.getId();
+
+    CompletableFuture.runAsync(SessionStore.wrap(() -> {
+      try {
+        lorqueProcessService.reportProgress(processId, 5, "creating Snowstorm import job");
+        String jobId = snowstormClient.createImportJob(importRequest).join();
+        lorqueProcessService.reportProgress(processId, 20, "uploading archive (streaming)");
+        snowstormClient.uploadRF2File(jobId, () -> bobObjectService.loadContentStream(archive)).join();
+        trackingRepository.save(new SnomedImportTracking()
+            .setSnowstormJobId(jobId)
+            .setBranchPath(importRequest.getBranchPath())
+            .setType(importRequest.getType())
+            .setStatus("RUNNING")
+            .setStarted(OffsetDateTime.now())
+            .setNotified(false));
+        lorqueProcessService.reportProgress(processId, 100, "Snowstorm job " + jobId);
+        lorqueProcessService.complete(processId, ProcessResult.text(JsonUtil.toJson(Map.of("jobId", jobId))));
+      } catch (Exception e) {
+        log.error("SNOMED RF2 from-archive import failed for archive {}", req.getArchiveUuid(), e);
+        lorqueProcessService.fail(processId, ProcessResult.text(ExceptionUtils.getMessage(e) + "\n" + ExceptionUtils.getStackTrace(e)));
+      }
+    }), VirtualThreadExecutor.get());
+
+    return process;
+  }
+
+  /**
+   * Kick off an async dry-run scan from a Bob-stored RF2 zip. Delegates the actual parse to
+   * {@link SnomedRF2ScanService#scanRF2(SnomedImportRequest, byte[], String)} after spooling
+   * the Minio stream into a byte array — the scan code path needs the bytes in memory anyway
+   * because the parser opens the zip from a {@code ByteArrayInputStream}. (A follow-up can
+   * change the parser to accept a {@link java.nio.file.Path} so even the scan is heap-safe.)
+   */
+  public LorqueProcess startScan(SnomedImportFromArchiveRequest req) {
+    BobObject archive = requireArchive(req.getArchiveUuid());
+    byte[] bytes;
+    try (InputStream is = bobObjectService.loadContentStream(archive)) {
+      bytes = is.readAllBytes();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to download archive '" + req.getArchiveUuid() + "' from Bob: " + e.getMessage(), e);
+    }
+    String filename = archive.getStorage() == null ? null : archive.getStorage().getFilename();
+    return scanService.scanRF2(req.toImportRequest(), bytes, filename);
+  }
+
+  private BobObject requireArchive(String uuid) {
+    if (uuid == null || uuid.isBlank()) {
+      throw new IllegalArgumentException("archiveUuid is required");
+    }
+    BobObject archive = bobObjectService.load(uuid);
+    if (archive == null) {
+      throw new NotFoundException("Archive '" + uuid + "' not found in Bob");
+    }
+    if (archive.getStorage() == null || !SnomedBobContainerAuthorizer.CONTAINER.equals(archive.getStorage().getContainer())) {
+      throw new IllegalArgumentException("Archive '" + uuid + "' is not in the SNOMED container");
+    }
+    return archive;
+  }
+}

--- a/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportFromArchiveRequest.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportFromArchiveRequest.java
@@ -1,0 +1,31 @@
+package org.termx.snomed.rf2;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Trigger SNOMED RF2 import or dry-run scan against an archive that already lives in the
+ * {@code "snomed"} Bob container (uploaded earlier via {@code POST /bob/objects}). The archive
+ * bytes never have to be re-uploaded, and the JVM never holds the whole zip — the import
+ * service streams it from Minio.
+ */
+@Getter
+@Setter
+public class SnomedImportFromArchiveRequest {
+  /** UUID of the {@code bob.object} row that holds the RF2 archive. */
+  private String archiveUuid;
+  private String branchPath;
+  private String type;
+  private boolean createCodeSystemVersion;
+  /** Scan-only: "summary" (default) or "full". Ignored on the real import endpoint. */
+  private String mode;
+
+  public SnomedImportRequest toImportRequest() {
+    SnomedImportRequest r = new SnomedImportRequest();
+    r.setBranchPath(branchPath);
+    r.setType(type);
+    r.setCreateCodeSystemVersion(createCodeSystemVersion);
+    r.setMode(mode);
+    return r;
+  }
+}


### PR DESCRIPTION
Phase 1b/1c of the SNOMED / LOINC large-archive import redesign ([`docs/snomed-rf2-import-redesign.md`](docs/snomed-rf2-import-redesign.md)) — replaces the JVM-heap-buffered RF2 ingest that OOMed on full SNOMED International editions with a streaming flow. Follows the Phase 1a foundation that landed in #120.

## Bob (foundation streaming)
- `MinioService.store(BobObject, InputStream, long)` — true streaming upload to Minio.
- `BobObjectService.store(BobObject, Path)` — pipes a temp file straight to Minio without heap buffering.
- `BobObjectController.POST` now uses `StreamingFileUpload` and `transferTo()` into a temp file before storing — so the multipart upload bytes never live entirely in heap.
- `BobObjectService.loadContentStream()` + `MinioService.retrieveStream()` — raw `InputStream` variant of `retrieve()` for server-side consumers (re-uploading to Snowstorm without buffering).

## SNOMED (Phase 1b)
- `SnowstormClient.uploadRF2File(jobId, Supplier<InputStream>)` — streaming variant; the existing `byte[]` overload now delegates to it.
- `SnomedBobContainerAuthorizer` registers the `"snomed"` container with `snomed-ct.CodeSystem.read / .write`.
- `SnomedRF2ImportFromArchiveService` — async Lorque-backed job that loads a previously-uploaded archive from Bob and streams it to Snowstorm.
- New endpoints on `SnomedController`:
  - `POST /snomed/imports/from-archive` — real import, streaming.
  - `POST /snomed/imports/scan/from-archive` — dry-run scan.

  Body: `{ archiveUuid, branchPath, type, createCodeSystemVersion, mode }`.

## LOINC (Phase 1c)
- `LoincBobContainerAuthorizer` registers the `"loinc"` container with `loinc.CodeSystem.read / .write` so admins can list / upload / delete LOINC releases via `/bob/objects`.
- Refactoring the multi-file `POST /loinc/import` to consume a single stored archive is deferred — it requires zip-entry dispatching by LOINC release file convention and deserves its own iteration.

## Compatibility
The legacy multipart endpoints (`POST /snomed/imports`, `POST /snomed/imports/scan`, `POST /loinc/import`) are left in place for backward compatibility. The web UI will migrate to the new from-archive flow in Phase 1d.

## Test plan
- [ ] `POST /bob/objects?container=snomed` with a multi-hundred-MB RF2 zip — JVM heap stays flat (verify via `jstat`).
- [ ] `POST /snomed/imports/from-archive` with the stored archive's uuid — Lorque process advances 5 → 20 → 100, Snowstorm receives the upload, `SnomedImportTracking` row created.
- [ ] `POST /snomed/imports/scan/from-archive` — scan completes, result downloadable via existing `/imports/scan/result/{lorqueId}`.
- [ ] `POST /bob/objects?container=loinc` upload works (streaming); `GET /bob/objects?container=loinc` lists archives.
- [ ] Old `POST /snomed/imports` and `POST /loinc/import` continue to function (regression).
- [ ] `POST /bob/objects?container=snomed` without `snomed-ct.CodeSystem.write` → 403.