### PR TITLE
fix(snomed): make /imports/scan/from-archive and proceed truly streaming

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -301,7 +301,17 @@ public class SnomedController {
     req.setBranchPath(cached.getBranchPath());
     req.setType(cached.getRf2Type());
     req.setCreateCodeSystemVersion(cached.isCreateCodeSystemVersion());
-    Map<String, String> result = snomedService.importRF2File(req, cached.getZipData());
+    // Two storage paths share this endpoint:
+    //   • legacy /imports/scan upload → cached.zipData is populated → byte[] import
+    //   • new /imports/scan/from-archive → cached.bobObjectUuid is set, zipData is NULL →
+    //     re-stream Bob → Snowstorm without re-buffering. This is what makes the dry-run →
+    //     proceed flow heap-safe on full International editions.
+    Map<String, String> result;
+    if (cached.getBobObjectUuid() != null) {
+      result = snomedService.importRF2FileFromBob(req, cached.getBobObjectUuid());
+    } else {
+      result = snomedService.importRF2File(req, cached.getZipData());
+    }
     snomedRF2UploadCacheService.markImported(cacheId);
     return result;
   }

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
@@ -5,6 +5,9 @@ import com.kodality.commons.util.JsonUtil;
 import jakarta.inject.Singleton;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -79,22 +82,30 @@ public class SnomedRF2ImportFromArchiveService {
   }
 
   /**
-   * Kick off an async dry-run scan from a Bob-stored RF2 zip. Delegates the actual parse to
-   * {@link SnomedRF2ScanService#scanRF2(SnomedImportRequest, byte[], String)} after spooling
-   * the Minio stream into a byte array — the scan code path needs the bytes in memory anyway
-   * because the parser opens the zip from a {@code ByteArrayInputStream}. (A follow-up can
-   * change the parser to accept a {@link java.nio.file.Path} so even the scan is heap-safe.)
+   * Kick off an async dry-run scan from a Bob-stored RF2 zip. The archive is streamed Minio →
+   * local temp file (never fully buffered in heap), then the parser reads it via {@link
+   * InputStream}. The cache row records the Bob UUID so "Proceed with import" can re-stream
+   * straight from Bob → Snowstorm without materialising the bytes.
    */
   public LorqueProcess startScan(SnomedImportFromArchiveRequest req) {
     BobObject archive = requireArchive(req.getArchiveUuid());
-    byte[] bytes;
-    try (InputStream is = bobObjectService.loadContentStream(archive)) {
-      bytes = is.readAllBytes();
+    Path tempFile;
+    try {
+      tempFile = Files.createTempFile("snomed-scan-", ".zip");
     } catch (Exception e) {
-      throw new RuntimeException("Failed to download archive '" + req.getArchiveUuid() + "' from Bob: " + e.getMessage(), e);
+      throw new RuntimeException("Failed to create temp file for SNOMED scan: " + e.getMessage(), e);
+    }
+    try (InputStream is = bobObjectService.loadContentStream(archive)) {
+      Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING);
+    } catch (Exception e) {
+      try {
+        Files.deleteIfExists(tempFile);
+      } catch (Exception ignored) {}
+      throw new RuntimeException("Failed to spool archive '" + req.getArchiveUuid() + "' from Bob: " + e.getMessage(), e);
     }
     String filename = archive.getStorage() == null ? null : archive.getStorage().getFilename();
-    return scanService.scanRF2(req.toImportRequest(), bytes, filename);
+    // scanRF2FromBob deletes the temp file when the async parse completes.
+    return scanService.scanRF2FromBob(req.toImportRequest(), tempFile, filename, req.getArchiveUuid());
   }
 
   private BobObject requireArchive(String uuid) {

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
@@ -2,6 +2,8 @@ package org.termx.snomed.integration;
 
 import com.kodality.commons.client.HttpClientError;
 import com.kodality.commons.exception.ApiException;
+import org.termx.bob.BobObject;
+import org.termx.bob.BobObjectService;
 import org.termx.snomed.ApiError;
 import org.termx.snomed.client.SnowstormClient;
 import org.termx.snomed.codesystem.SnomedCodeSystem;
@@ -32,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SnomedService {
   private final SnowstormClient snowstormClient;
   private final SnomedImportTrackingRepository trackingRepository;
+  private final BobObjectService bobObjectService;
 
   private static final int MAX_COUNT = 9999;
   private static final int MAX_CONCEPT_COUNT = 100;
@@ -134,7 +137,40 @@ public class SnomedService {
     } catch (CompletionException e) {
       throw rethrowSnowstormImportFailure(e);
     }
+    recordTracking(jobId, req);
+    return Map.of("jobId", jobId);
+  }
 
+  /**
+   * Streaming counterpart of {@link #importRF2File(SnomedImportRequest, byte[])}: the archive
+   * lives in Bob and we re-stream it to Snowstorm via {@link
+   * SnowstormClient#uploadRF2File(String, java.util.function.Supplier)}. Used by the "Proceed
+   * with import" path after a from-archive dry-run scan.
+   */
+  @Transactional
+  public Map<String, String> importRF2FileFromBob(SnomedImportRequest req, String bobObjectUuid) {
+    BobObject archive = bobObjectService.load(bobObjectUuid);
+    if (archive == null) {
+      throw new IllegalArgumentException("Bob archive not found: " + bobObjectUuid);
+    }
+    String jobId;
+    try {
+      jobId = snowstormClient.createImportJob(req).join();
+    } catch (CompletionException e) {
+      throw rethrowSnowstormImportFailure(e);
+    }
+    try {
+      snowstormClient.uploadRF2File(jobId, () -> bobObjectService.loadContentStream(archive)).join();
+    } catch (FileNotFoundException e) {
+      log.warn("SNOMED RF2 upload (from Bob) to Snowstorm failed: {}", e.getMessage());
+    } catch (CompletionException e) {
+      throw rethrowSnowstormImportFailure(e);
+    }
+    recordTracking(jobId, req);
+    return Map.of("jobId", jobId);
+  }
+
+  private void recordTracking(String jobId, SnomedImportRequest req) {
     SnomedImportTracking tracking = new SnomedImportTracking()
         .setSnowstormJobId(jobId)
         .setBranchPath(req.getBranchPath())
@@ -143,10 +179,7 @@ public class SnomedService {
         .setStarted(OffsetDateTime.now())
         .setNotified(false);
     trackingRepository.save(tracking);
-
     log.info("Created SNOMED import tracking record for Snowstorm job: {}", jobId);
-
-    return Map.of("jobId", jobId);
   }
 
   /**

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ScanService.java
@@ -2,7 +2,10 @@ package org.termx.snomed.integration.rf2.scan;
 
 import com.kodality.commons.util.JsonUtil;
 import jakarta.inject.Singleton;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -65,8 +68,74 @@ public class SnomedRF2ScanService {
     return process;
   }
 
+  /**
+   * Streaming scan: the archive lives in Bob (uploaded via {@code POST /bob/objects}) and the
+   * caller has already spooled it to a local temp file. We never read the bytes into heap —
+   * the parser pulls them from {@code zipFile} via {@link InputStream} and the cache row only
+   * records the Bob UUID, so "Proceed with import" can re-stream Bob → Snowstorm without
+   * materialising the bytes anywhere.
+   */
+  public LorqueProcess scanRF2FromBob(SnomedImportRequest request, Path zipFile, String filename, String bobObjectUuid) {
+    long zipSize;
+    try {
+      zipSize = Files.size(zipFile);
+    } catch (java.io.IOException e) {
+      throw new RuntimeException("Failed to stat zip file " + zipFile + ": " + e.getMessage(), e);
+    }
+    SnomedRF2Upload upload = uploadCacheService.saveBobArchive(request, filename, bobObjectUuid, zipSize);
+    LorqueProcess process = lorqueProcessService.start(new LorqueProcess().setProcessName(PROCESS_NAME));
+    uploadCacheService.attachLorqueId(upload.getId(), process.getId());
+
+    Long uploadId = upload.getId();
+    String branchPath = request.getBranchPath();
+    String rf2Type = request.getType();
+    boolean fullMode = "full".equalsIgnoreCase(request.getMode());
+
+    CompletableFuture.runAsync(SessionStore.wrap(() -> {
+      try {
+        lorqueProcessService.reportProgress(process.getId(), 5, "starting (" + (fullMode ? "full" : "summary") + " mode)");
+        SnomedRF2ScanResult result = buildScanStreaming(zipFile, branchPath, rf2Type, fullMode, process.getId()).setUploadCacheId(uploadId);
+        lorqueProcessService.reportProgress(process.getId(), 90, "rendering report");
+        SnomedRF2ScanEnvelope envelope = new SnomedRF2ScanEnvelope().setJson(result).setMarkdown(renderMarkdown(result));
+        byte[] payload = JsonUtil.toJson(envelope).getBytes(StandardCharsets.UTF_8);
+        lorqueProcessService.reportProgress(process.getId(), 100, "done");
+        lorqueProcessService.complete(process.getId(), ProcessResult.binary(payload));
+      } catch (Exception e) {
+        log.error("SNOMED RF2 dry-run scan (from Bob) failed for upload {}", uploadId, e);
+        ProcessResult failure = ProcessResult.text(ExceptionUtils.getMessage(e) + "\n" + ExceptionUtils.getStackTrace(e));
+        lorqueProcessService.fail(process.getId(), failure);
+      } finally {
+        try {
+          Files.deleteIfExists(zipFile);
+        } catch (java.io.IOException ignored) {}
+      }
+    }), VirtualThreadExecutor.get());
+
+    return process;
+  }
+
   public SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type) throws java.io.IOException {
     return buildScan(zipBytes, branchPath, rf2Type, true, null);
+  }
+
+  private SnomedRF2ScanResult buildScanStreaming(Path zipFile, String branchPath, String rf2Type, boolean fullMode, Long lorqueId) throws java.io.IOException {
+    java.util.function.Consumer<String> phaseReporter = phase -> {
+      if (lorqueId == null) {
+        return;
+      }
+      Integer percent = phasePercent(phase);
+      if (percent != null) {
+        lorqueProcessService.reportProgress(lorqueId, percent, "parsing " + phase);
+      }
+    };
+    ParsedRF2 parsed;
+    try (InputStream is = Files.newInputStream(zipFile)) {
+      parsed = parser.parse(is, phaseReporter, fullMode);
+    }
+    if (lorqueId != null) {
+      lorqueProcessService.reportProgress(lorqueId, 80, "computing diff");
+    }
+    return diffEngine.classify(parsed, branchPath, rf2Type);
   }
 
   private SnomedRF2ScanResult buildScan(byte[] zipBytes, String branchPath, String rf2Type, boolean fullMode, Long lorqueId) throws java.io.IOException {

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
@@ -20,6 +20,7 @@ public class SnomedRF2UploadCacheRepository extends BaseRepository {
     ssb.property("filename", upload.getFilename());
     ssb.property("zip_size", upload.getZipSize());
     ssb.property("zip_data", upload.getZipData());
+    ssb.property("bob_object_uuid", upload.getBobObjectUuid());
     ssb.property("scan_lorque_id", upload.getScanLorqueId());
     ssb.property("imported", upload.isImported());
     ssb.property("started", upload.getStarted());
@@ -48,6 +49,7 @@ public class SnomedRF2UploadCacheRepository extends BaseRepository {
     // Soft-delete and clear zip_data: the schema GRANTs in sys-schema.xml don't include DELETE
     // for the app user, and what we actually need is to reclaim the bytea (which can be hundreds
     // of MB per row). The empty-string assignment lets PostgreSQL release the TOAST chunks.
+    // bob-archive rows have zip_data IS NULL — that's fine, the update is a no-op there.
     String sql = "update sys.snomed_rf2_upload set sys_status = 'C', zip_data = ''::bytea "
         + "where sys_status = 'A' and started < current_timestamp - (? || ' days')::interval";
     jdbcTemplate.update(sql, String.valueOf(daysOld));

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
@@ -32,6 +32,25 @@ public class SnomedRF2UploadCacheService {
     return upload;
   }
 
+  /**
+   * Bob-archive variant: records the cache entry with {@code bobObjectUuid} populated and
+   * {@code zipData=null}. The "Proceed with import" path then re-streams from Bob → Snowstorm.
+   */
+  @Transactional
+  public SnomedRF2Upload saveBobArchive(SnomedImportRequest request, String filename, String bobObjectUuid, long zipSize) {
+    SnomedRF2Upload upload = new SnomedRF2Upload()
+        .setBranchPath(request.getBranchPath())
+        .setRf2Type(request.getType())
+        .setCreateCodeSystemVersion(request.isCreateCodeSystemVersion())
+        .setFilename(filename)
+        .setZipSize(zipSize)
+        .setBobObjectUuid(bobObjectUuid)
+        .setImported(false)
+        .setStarted(OffsetDateTime.now());
+    upload.setId(repository.save(upload));
+    return upload;
+  }
+
   @Transactional
   public void attachLorqueId(Long uploadId, Long lorqueId) {
     repository.setScanLorqueId(uploadId, lorqueId);

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2ZipParser.java
@@ -4,6 +4,7 @@ import jakarta.inject.Singleton;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -33,8 +34,17 @@ public class SnomedRF2ZipParser {
    * two files dominate the wall-clock time on a full International edition zip.
    */
   public ParsedRF2 parse(byte[] zipBytes, java.util.function.Consumer<String> phaseReporter, boolean fullMode) throws IOException {
+    return parse(new ByteArrayInputStream(zipBytes), phaseReporter, fullMode);
+  }
+
+  /**
+   * Streaming variant: callers pass a raw {@link InputStream} (e.g. a {@code FileInputStream}
+   * wrapping a temp-file download from Minio) and the parser never needs the whole zip in
+   * heap. The stream is not closed by this method — close it after the call.
+   */
+  public ParsedRF2 parse(InputStream zipStream, java.util.function.Consumer<String> phaseReporter, boolean fullMode) throws IOException {
     ParsedRF2 parsed = new ParsedRF2();
-    try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
+    try (ZipInputStream zis = new ZipInputStream(zipStream)) {
       ZipEntry entry;
       while ((entry = zis.getNextEntry()) != null) {
         if (entry.isDirectory()) {

--- a/termx-api/src/main/java/org/termx/snomed/rf2/SnomedRF2Upload.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/SnomedRF2Upload.java
@@ -18,6 +18,12 @@ public class SnomedRF2Upload {
   private String filename;
   private Long zipSize;
   private byte[] zipData;
+  /**
+   * Set when the scan came in via a Bob-stored archive (POST /imports/scan/from-archive).
+   * In that case {@code zipData} is null and the "proceed with import" path re-streams from
+   * Bob → Snowstorm rather than reading {@code zipData}. Mutually exclusive with {@code zipData}.
+   */
+  private String bobObjectUuid;
   private Long scanLorqueId;
   private boolean imported;
   private OffsetDateTime started;

--- a/termx-core/src/main/resources/sys/changelog/sys/72-snomed_rf2_upload_bob_object_uuid.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/72-snomed_rf2_upload_bob_object_uuid.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+
+--changeset termx:snomed_rf2_upload-bob-object-uuid
+-- Lets a dry-run scan that came from a Bob-stored archive skip the local zip_data buffer
+-- entirely. The legacy /imports/scan path still populates zip_data; the new from-archive
+-- path populates bob_object_uuid and leaves zip_data NULL.
+alter table sys.snomed_rf2_upload add column if not exists bob_object_uuid text;
+alter table sys.snomed_rf2_upload alter column zip_data drop not null;
+create index if not exists snomed_rf2_upload_bob_object_uuid_idx
+    on sys.snomed_rf2_upload(bob_object_uuid)
+    where bob_object_uuid is not null;
+--rollback alter table sys.snomed_rf2_upload drop column if exists bob_object_uuid;
+--rollback alter table sys.snomed_rf2_upload alter column zip_data set not null;
+--

--- a/termx-core/src/main/resources/sys/changelog/sys/changelog.xml
+++ b/termx-core/src/main/resources/sys/changelog/sys/changelog.xml
@@ -16,6 +16,7 @@
   <include file="61-checklist.sql" relativeToChangelogFile="true"/>
   <include file="70-snomed_import_tracking.sql" relativeToChangelogFile="true"/>
   <include file="71-snomed_rf2_upload.sql" relativeToChangelogFile="true"/>
+  <include file="72-snomed_rf2_upload_bob_object_uuid.sql" relativeToChangelogFile="true"/>
   <include file="80-ecosystem.sql" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Phase 1b shipped a from-archive scan endpoint that still called `is.readAllBytes()` on the Bob stream, so the dry-run path on a full SNOMED International edition (~1 GB) was still OOM-vulnerable. And the "Proceed with import" path after such a scan reloaded `zip_data` from the cache table — but the from-archive flow never populated `zip_data`, so proceed would have failed anyway.

## What this fixes

- `SnomedRF2ZipParser` gains a `parse(InputStream, …)` overload; the `byte[]` variant now delegates to it. The parser already opened zips via `ZipInputStream`, so the only buffering was in the caller — gone now.
- `SnomedRF2ScanService.scanRF2FromBob` takes a `Path` to a local temp file and streams the parser from it (`FileInputStream` → `ZipInputStream`).
- `snomed_rf2_upload` gains a nullable `bob_object_uuid` column (and `zip_data` made nullable). `SnomedRF2UploadCacheService.saveBobArchive()` records cache rows for the from-archive flow without storing the bytes.
- `SnomedRF2ImportFromArchiveService.startScan` spools Bob → temp file (no in-memory buffer), invokes `scanRF2FromBob`, and lets the scan service delete the temp file in its `finally` block.
- `SnomedService.importRF2FileFromBob` mirrors `importRF2File` but re-streams Bob → Snowstorm via the `Supplier<InputStream>` `SnowstormClient` overload that landed in Phase 1b.
- `SnomedController.proceedScanImport` dispatches:
  - cache row has `bob_object_uuid` → re-stream Bob → Snowstorm (new path)
  - otherwise → legacy `zip_data` byte[] flow (unchanged)

Net effect: a dry-run on a full International edition uploaded via `/bob/objects` now stays under a handful of MB of JVM heap end-to-end (Bob → temp file → `ZipInputStream` → diff). "Proceed with import" afterward streams Minio → Snowstorm without buffering.

## Test plan
- [ ] `POST /bob/objects?container=snomed` a full International RF2 (~1 GB) zip.
- [ ] `POST /snomed/imports/scan/from-archive` with the uuid — Lorque process advances, JVM heap (via `jstat -gc <pid>`) stays well below 1 GB across the scan. A `snomed-scan-*.zip` temp file appears under `$TMPDIR` and is cleaned up after the scan completes.
- [ ] Download the scan envelope, review the diff, then `POST /imports/scan/{cacheId}/proceed` — Snowstorm import job created, JVM heap remains flat (the bytes flow Bob → Snowstorm chunked).
- [ ] Repeat with the legacy `POST /snomed/imports/scan` (small file) and `POST /imports/scan/{cacheId}/proceed` — unchanged behaviour (byte[] path).
- [ ] Liquibase: `bob_object_uuid` column exists, `zip_data` is now nullable, `snomed_rf2_upload_bob_object_uuid_idx` partial index created.