### PR TITLE
feat(loinc): POST /loinc/import/from-archive — import from Bob-stored release zip

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java
@@ -5,10 +5,12 @@ import org.termx.core.auth.Authorized;
 import org.termx.core.sys.job.logger.ImportLogger;
 import org.termx.core.utils.FileUtil;
 import org.termx.editionint.Privilege;
+import org.termx.editionint.loinc.utils.LoincImportFromArchiveRequest;
 import org.termx.editionint.loinc.utils.LoincImportRequest;
 import org.termx.sys.job.JobLogResponse;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Part;
 import io.micronaut.http.annotation.Post;
@@ -29,6 +31,7 @@ public class LoincController {
 
   private final LoincService loincService;
   private final ImportLogger importLogger;
+  private final LoincImportFromArchiveService loincImportFromArchiveService;
 
   @Authorized(Privilege.CS_WRITE)
   @Post(value = "/import", consumes = MediaType.MULTIPART_FORM_DATA)
@@ -55,6 +58,19 @@ public class LoincController {
 
     Map<String, Object> params = Map.of("request", req, "files", files);
     return importLogger.runJob(JOB_TYPE, params, loincService::importLoinc);
+  }
+
+  /**
+   * Streaming counterpart of {@link #process}: the LOINC release zip already lives in the
+   * {@code "loinc"} Bob container (uploaded via {@code POST /bob/objects?container=loinc}). The
+   * server spools it to a local temp file, unpacks the eight known CSVs by basename, and feeds
+   * the existing {@link LoincService#importLoinc} pipeline as an async {@code ImportLogger}
+   * job. The browser never has to re-upload a multi-hundred-MB release for retries.
+   */
+  @Authorized(Privilege.CS_WRITE)
+  @Post(value = "/import/from-archive")
+  public JobLogResponse processFromArchive(@Body LoincImportFromArchiveRequest request) {
+    return loincImportFromArchiveService.startImport(request);
   }
 
   private static byte[] getBytes(Publisher<CompletedFileUpload> file) {

--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincImportFromArchiveService.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincImportFromArchiveService.java
@@ -1,0 +1,85 @@
+package org.termx.editionint.loinc;
+
+import com.kodality.commons.exception.NotFoundException;
+import jakarta.inject.Singleton;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.termx.bob.BobObject;
+import org.termx.bob.BobObjectService;
+import org.termx.core.sys.job.logger.ImportLogger;
+import org.termx.editionint.loinc.utils.LoincImportFromArchiveRequest;
+import org.termx.editionint.loinc.utils.LoincZipReader;
+import org.termx.sys.job.JobLogResponse;
+
+/**
+ * Drives LOINC release import against an archive already stored in the {@code "loinc"} Bob
+ * container. The release zip is streamed Minio → local temp file (heap-safe even on large
+ * releases); we then unpack the eight known CSV entries by basename via {@link LoincZipReader}
+ * and feed the existing {@link LoincService#importLoinc(Map)} pipeline as a background job.
+ */
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class LoincImportFromArchiveService {
+  private final BobObjectService bobObjectService;
+  private final LoincService loincService;
+  private final ImportLogger importLogger;
+
+  public JobLogResponse startImport(LoincImportFromArchiveRequest req) {
+    BobObject archive = requireArchive(req.getArchiveUuid());
+
+    Path tempFile;
+    try {
+      tempFile = Files.createTempFile("loinc-import-", ".zip");
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create temp file for LOINC import: " + e.getMessage(), e);
+    }
+    List<Pair<String, byte[]>> files;
+    try (InputStream is = bobObjectService.loadContentStream(archive)) {
+      Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING);
+      // Unpack from the temp file — the LOINC pipeline still needs byte[] per CSV, but each
+      // CSV is small (tens of MB) compared to the full zip, so peak heap is one CSV at a time
+      // rather than the whole archive.
+      try (InputStream unpackIn = Files.newInputStream(tempFile)) {
+        files = new LoincZipReader().unpack(unpackIn, req.getLanguage());
+      }
+    } catch (Exception e) {
+      try {
+        Files.deleteIfExists(tempFile);
+      } catch (Exception ignored) {}
+      throw new RuntimeException("Failed to download / unpack LOINC archive '" + req.getArchiveUuid() + "': " + e.getMessage(), e);
+    } finally {
+      try {
+        Files.deleteIfExists(tempFile);
+      } catch (Exception ignored) {}
+    }
+
+    if (files.isEmpty()) {
+      throw new IllegalArgumentException("LOINC archive '" + req.getArchiveUuid() + "' does not contain any recognised CSV files (expected Part.csv, LoincPartLink_Primary.csv, etc.)");
+    }
+
+    Map<String, Object> params = Map.of("request", req.toImportRequest(), "files", files);
+    return importLogger.runJob(LoincController.JOB_TYPE, params, loincService::importLoinc);
+  }
+
+  private BobObject requireArchive(String uuid) {
+    if (uuid == null || uuid.isBlank()) {
+      throw new IllegalArgumentException("archiveUuid is required");
+    }
+    BobObject archive = bobObjectService.load(uuid);
+    if (archive == null) {
+      throw new NotFoundException("Archive '" + uuid + "' not found in Bob");
+    }
+    if (archive.getStorage() == null || !LoincBobContainerAuthorizer.CONTAINER.equals(archive.getStorage().getContainer())) {
+      throw new IllegalArgumentException("Archive '" + uuid + "' is not in the LOINC container");
+    }
+    return archive;
+  }
+}

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincImportFromArchiveRequest.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincImportFromArchiveRequest.java
@@ -1,0 +1,27 @@
+package org.termx.editionint.loinc.utils;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Trigger a LOINC import against a release archive that already lives in the
+ * {@code "loinc"} Bob container (uploaded via {@code POST /bob/objects}). The server unpacks
+ * the zip by basename ({@code Part.csv}, {@code LoincPartLink_Primary.csv}, etc.) and feeds the
+ * normal {@link org.termx.editionint.loinc.LoincService#importLoinc(java.util.Map)} pipeline.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+public class LoincImportFromArchiveRequest {
+  /** UUID of the {@code bob.object} row holding the LOINC release zip. */
+  private String archiveUuid;
+  /** LOINC release version label (passed through as {@link LoincImportRequest#getVersion()}). */
+  private String version;
+  /** ISO 639 lowercase language code; selects {@code <lang>LinguisticVariant.csv}. Optional. */
+  private String language;
+
+  public LoincImportRequest toImportRequest() {
+    return new LoincImportRequest().setVersion(version).setLanguage(language);
+  }
+}

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincZipReader.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincZipReader.java
@@ -2,6 +2,7 @@ package org.termx.editionint.loinc.utils;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -12,9 +13,19 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 
+/**
+ * Walks a LOINC release zip and extracts the CSV files the {@code LoincService} pipeline knows
+ * about, keyed by the import-step name. Matching is by file <em>basename</em> (case-insensitive,
+ * any path separator normalised) so both modern releases (where CSVs live under
+ * {@code AccessoryFiles/…/Part.csv}, {@code LoincTable/…}, etc.) and older flat layouts work.
+ *
+ * <p>Translation files use a per-language naming convention ({@code <lang>LinguisticVariant.csv})
+ * — pass the requested language to {@link #unpack(InputStream, String)} so only that variant is
+ * extracted. {@code null} or empty {@code language} skips translation entries.</p>
+ */
 @Slf4j
 public class LoincZipReader {
-  private static final Map<String, String> fileNameMap = Map.of(
+  private static final Map<String, String> BASENAME_TO_KEY = Map.of(
       "Part", "parts",
       "LoincPartLink_Primary", "terminology",
       "LoincPartLink_Supplementary", "supplementary-properties",
@@ -23,25 +34,63 @@ public class LoincZipReader {
       "LoincAnswerListLink", "answer-list-link",
       "LoincUniversalLabOrdersValueSet", "order-observation");
 
+  /**
+   * Legacy entry point — buffers the whole zip in memory. New callers should prefer
+   * {@link #unpack(InputStream, String)} with a {@code FileInputStream} from a local temp file.
+   */
   public List<Pair<String, byte[]>> handleZipPack(byte[] bytes) {
-    List<Pair<String, byte[]>> files = new ArrayList<>();
+    return unpack(new ByteArrayInputStream(bytes), null);
+  }
 
-    log.info("Unpacking LOINC ZIP");
-    ZipInputStream zipIn = new ZipInputStream(new ByteArrayInputStream(bytes));
-    ZipEntry entry;
-    try {
+  public List<Pair<String, byte[]>> unpack(InputStream zipStream, String language) {
+    List<Pair<String, byte[]>> files = new ArrayList<>();
+    String translationsName = (language == null || language.isBlank()) ? null
+        : (language.toLowerCase() + "LinguisticVariant");
+
+    log.info("Unpacking LOINC ZIP (lang={})", language);
+    try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
+      ZipEntry entry;
       while ((entry = zipIn.getNextEntry()) != null) {
-        System.out.println(entry.getName());
-        if (fileNameMap.containsKey(entry.getName())) {
-          files.add(Pair.of(fileNameMap.get(entry.getName()), IOUtils.toByteArray(zipIn)));
+        if (entry.isDirectory()) {
+          zipIn.closeEntry();
+          continue;
+        }
+        String key = matchKey(entry.getName(), translationsName);
+        if (key != null) {
+          files.add(Pair.of(key, IOUtils.toByteArray(zipIn)));
         }
         zipIn.closeEntry();
       }
-
     } catch (IOException | RuntimeException e) {
       log.error("Error while reading LOINC pack", e);
       throw new RuntimeException(e);
     }
     return files;
+  }
+
+  private static String matchKey(String entryName, String translationsBaseName) {
+    String normalised = entryName.replace('\\', '/');
+    int slash = normalised.lastIndexOf('/');
+    String basename = slash < 0 ? normalised : normalised.substring(slash + 1);
+    int dot = basename.lastIndexOf('.');
+    if (dot >= 0) {
+      // Only match .csv (or no-extension) entries — Loinc release zips also ship .txt READMEs,
+      // .xml, .docx etc. that we never want to feed to the CSV parser.
+      String ext = basename.substring(dot + 1).toLowerCase();
+      if (!"csv".equals(ext)) {
+        return null;
+      }
+      basename = basename.substring(0, dot);
+    }
+    // Case-insensitive lookup against the small static map.
+    for (Map.Entry<String, String> e : BASENAME_TO_KEY.entrySet()) {
+      if (e.getKey().equalsIgnoreCase(basename)) {
+        return e.getValue();
+      }
+    }
+    if (translationsBaseName != null && translationsBaseName.equalsIgnoreCase(basename)) {
+      return "translations";
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Completes the LOINC half of the Bob streaming-import design (Phase 1c backend follow-up). LOINC release archives can now be uploaded to the `"loinc"` Bob container via streaming `/bob/objects`, then imported by uuid: the server spools Minio → local temp file, unpacks the eight known CSVs by basename via the refactored `LoincZipReader`, and feeds the existing `LoincService.importLoinc` pipeline as an async `ImportLogger` job.

## Changes

- **`LoincZipReader`** — match by file *basename* (case-insensitive, normalised path separators) instead of exact entry-name. Real LOINC release zips ship files under nested paths like `AccessoryFiles/PartFile/Part.csv` — the old exact-name dispatch would have skipped all of them. Also adds a `<lang>LinguisticVariant.csv` selector for the `translations` key, and a new `unpack(InputStream, language)` overload so callers can stream from a temp file without buffering the whole zip in heap.
- **`LoincImportFromArchiveRequest`** carries the uuid + version + language pulled from the JSON body (replaces the legacy multi-part request).
- **`LoincImportFromArchiveService`** validates the archive belongs to the `"loinc"` container, spools it to a temp file, unpacks into the `Pair<key, byte[]>` list the existing pipeline expects, and runs the import asynchronously via `ImportLogger` (same `JobLogResponse` polling pattern as the legacy endpoint).
- **`POST /loinc/import/from-archive`** on `LoincController` returns `JobLogResponse` — the UI polls `jobService.pollFinishedJobLog` exactly like the legacy endpoint.

The legacy `POST /loinc/import` remains for backward-compat callers but the UI now has a single-uuid alternative that works on full LOINC releases without re-uploading every retry.

## Test plan
- [ ] `POST /bob/objects?container=loinc` with a LOINC release zip → archive appears in the stored-archives list.
- [ ] `POST /loinc/import/from-archive` with `{archiveUuid, version, language: "en"}` → returns `{jobId}`, the import succeeds, and `code-system: loinc-part` / `loinc` are populated.
- [ ] Repeat with `language: "et"` — the `etLinguisticVariant.csv` entry is extracted and translations are imported.
- [ ] Archive without recognised CSVs → 400 with a clear error message.
- [ ] Legacy `POST /loinc/import` continues to work (regression).