### PR TITLE
fix(bob): bind query params on GET /bob/objects via {?params*}

### DIFF
--- a/bob/src/main/java/org/termx/bob/BobObjectController.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectController.java
@@ -56,7 +56,7 @@ public class BobObjectController {
   }
 
   @Authorized
-  @Get
+  @Get("{?params*}")
   public QueryResult<BobObject> query(BobObjectQueryParams params) {
     if (params.getContainer() == null || params.getContainer().isBlank()) {
       throw new ApiClientException(Issue.error("BOB001", "container query parameter is required"));


### PR DESCRIPTION
Without the matrix syntax, Micronaut can't resolve the `BobObjectQueryParams` parameter from query-string values and rejects every GET with:

> Required argument [BobObjectQueryParams params] not specified

That broke the **Stored archives** card on the SNOMED CodeSystem edit page (and equivalently on the LOINC import page) — every page load made a `GET /bob/objects?container=…` that returned 400.

Switch the annotation to `@Get("{?params*}")` to match the convention used by `PageController.queryPages` / `CodeSystemController` and Micronaut maps the query string onto the POJO again.

## Reproduction (against current main, pre-fix)

```
$ curl 'http://localhost:8200/bob/objects?container=snomed&limit=10' -H 'Authorization: Bearer yupi'
[{"severity":"ERROR","code":"400","message":"Required argument [BobObjectQueryParams params] not specified"}]
```

## Test plan
- [ ] Restart `./scripts/run-backend.sh`, navigate to `/integration/snomed/codesystems/<SHORTNAME>/edit` — Stored archives card loads without 400.
- [ ] `curl 'http://localhost:8200/bob/objects?container=snomed&limit=10' -H 'Authorization: Bearer yupi'` returns the QueryResult JSON.
- [ ] Filter by `meta`: `curl 'http://localhost:8200/bob/objects?container=wiki&meta=%7B%22page%22%3A1%7D' …` returns the page-scoped attachments.