### PR TITLE
fix(bob): escape minio URL default with backticks so colons aren't eaten

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,20 @@ After installation add properties `snowstorm.url`, `snowstorm.user`, `snowstorm.
 
 ## MinIO
 
+The Binary Object Bank (BOB) — `/bob/objects`, Wiki attachments, SNOMED / LOINC archive uploads — stores blobs in MinIO. For local dev, the bundled helper script starts a `tx-minio` container with the same credentials that `application.yml` defaults to:
+
 ```shell
-docker run \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  --name termx-minio \
-  -e "MINIO_ROOT_USER=minio" \
-  -e "MINIO_ROOT_PASSWORD=supersecretpass" \
-  -d \
-  quay.io/minio/minio server /data --console-address ":9001"
+./scripts/run-minio.sh
 ```
+
+That starts MinIO on `:9000` (S3 API) and `:9001` (web console) with `minio` / `minio123`. The defaults in [`termx-app/src/main/resources/application.yml`](termx-app/src/main/resources/application.yml) (`bob.minio.url=http://localhost:9000`, `access-key=minio`, `secret-key=minio123`) line up out of the box, so `./scripts/run-backend.sh` after `./scripts/run-minio.sh` "just works".
+
+For production, override via env vars on the JVM:
+
+```
+MINIO_URL=https://minio.example.com
+MINIO_ACCESS_KEY=...
+MINIO_SECRET_KEY=...
+```
+
+If `MINIO_URL` is unset and there's no `bob.minio.url` override, the application starts but every `/bob/*` write returns a structured `BOB101 Object storage (Minio) is not configured` error — see [`BobObjectService.getMinio`](bob/src/main/java/org/termx/bob/BobObjectService.java).

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -91,7 +91,12 @@ auth:
 # (handled in BobObjectService.getMinio).
 bob:
   minio:
-    url: ${MINIO_URL:http://localhost:9000}
+    # Backticks around the default — Micronaut treats `:` as the var/default delimiter,
+    # so `${MINIO_URL:http://…}` parses the default as just `http`, the URL is then
+    # malformed and the okhttp client inside the Minio SDK fails with
+    # NoRouteToHostException. Same backtick pattern as the `datasources.default.url`
+    # line at the top of this file.
+    url: ${MINIO_URL:`http://localhost:9000`}
     access-key: ${MINIO_ACCESS_KEY:minio}
     secret-key: ${MINIO_SECRET_KEY:minio123}
 


### PR DESCRIPTION
Reproduced on macOS + Docker Desktop after #125 merged to main:

```
POST /bob/objects
500 XX100 System error
  java.lang.RuntimeException: Failed to check bucket existence
  Caused by: java.net.NoRouteToHostException: No route to host
    at okhttp3.internal.platform.Platform.connectSocket(Platform.kt:128)
```

## Root cause

Micronaut parses the first `:` in `${VAR:default}` as the variable/default delimiter, so

```yaml
url: ${MINIO_URL:http://localhost:9000}
```

is parsed as variable `MINIO_URL`, default `http` — the rest of the string is silently discarded. With no `MINIO_URL` env var set (the documented "Local dev: just works" case from #125), `MinioClient.endpoint` receives literally `"http"` and the okhttp connect attempt against the resulting malformed URL surfaces as `NoRouteToHostException`. Setting `MINIO_URL` explicitly (e.g. `http://127.0.0.1:9000`) masked the bug because the env value bypasses the default-parsing path entirely — that's why my earlier smoke-test "passed" with the env override.

The same project already escapes JDBC URLs this way 60 lines above:

```yaml
url: ${DB_URL:`jdbc:postgresql://localhost:5432/termx`}
```

Apply the same backtick escape to `bob.minio.url`.

## Verification

Bounced backend on this branch with **no** `MINIO_URL` env var:

```
$ curl -X POST http://localhost:8200/bob/objects \
       -H 'Authorization: Bearer yupi' \
       -F 'file=@tiny.txt' -F 'container=snomed'

HTTP/1.1 200
{"uuid":"9295fb21-…","storage":{"container":"snomed","filename":"tiny.txt",…}}
```

## Test plan
- [ ] `./scripts/run-minio.sh` (if not already running), then `./scripts/run-backend.sh` — no `MINIO_URL` env var set, no `application-local.yml` override.
- [ ] Hit the SNOMED CodeSystem edit page; upload a file via the Stored archives card — succeeds without XX100.
- [ ] `curl -X POST http://localhost:8200/bob/objects -H 'Authorization: Bearer yupi' -F 'file=@…' -F 'container=snomed'` → 200.
- [ ] Existing operators who had `MINIO_URL=…` set explicitly continue working (unchanged path).