### PR TITLE
chore(scripts): kill stale process on :8200 before starting backend

### DIFF
--- a/scripts/run-backend.sh
+++ b/scripts/run-backend.sh
@@ -5,6 +5,8 @@
 # - Enables dev authentication (Bearer token: yupi)
 # - Loads application-dev.yml and application-local.yml configurations
 # - Runs on port 8200 by default
+# - Kills any process already bound to that port so consecutive starts don't
+#   fall back to a different port or wedge gradle on "Address already in use"
 
 set -e
 
@@ -12,11 +14,30 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
+PORT="${TERMX_SERVER_PORT:-8200}"
+
+# Helper: kill any process listening on a given TCP port. Pattern lifted from
+# ~/source/emr/repo/scripts/run-backend.sh so termx and emr behave the same way
+# when an old run was Ctrl-Z'd or a gradle daemon held the port.
+kill_port() {
+  local port=$1
+  local pid
+  pid=$(lsof -ti:"$port" 2>/dev/null || true)
+  if [ -n "$pid" ]; then
+    echo "Killing existing process on port $port (PID $pid)..."
+    kill -9 $pid 2>/dev/null || true
+    # Give the kernel a moment to release the socket before gradle binds it.
+    sleep 1
+  fi
+}
+
+kill_port "$PORT"
+
 echo "=========================================="
 echo "Starting TermX Server (Local Dev Mode)"
 echo "=========================================="
 echo "Profile: dev,local"
-echo "Port: 8200"
+echo "Port:    ${PORT}"
 echo "Dev Token: yupi"
 echo ""
 


### PR DESCRIPTION
Mirrors the `kill_port` helper from `~/source/emr/repo/scripts/run-backend.sh` so both repos handle the same recurring annoyance the same way.

## Why

Back-to-back `./scripts/run-backend.sh` invocations could otherwise:
- fail with `Address already in use` if a gradle daemon held :8200
- fall back to an ephemeral port that the frontend isn't pointing at
- silently coexist with a stale JVM bound to the same port

So the second instance was effectively invisible — exactly the failure mode I hit twice this afternoon while iterating on Bob fixes.

## What

```bash
kill_port() {
  local port=$1
  local pid
  pid=$(lsof -ti:"$port" 2>/dev/null || true)
  if [ -n "$pid" ]; then
    echo "Killing existing process on port $port (PID $pid)..."
    kill -9 $pid 2>/dev/null || true
    sleep 1
  fi
}

kill_port "$PORT"
```

The port is configurable via `TERMX_SERVER_PORT` (defaults to 8200) so running two backends on different ports for A/B comparison stays trivial.

## Verified
- Old backend on :8200 (PID 71624), ran the script — log starts with `Killing existing process on port 8200 (PID 71624)...`, new JVM bound :8200 cleanly, `Startup completed in 3959ms`, `POST /bob/objects → 200`.
- Old PID was reaped (`ps -p 71624` returned `(dead)`).
- Run with no stale process — kill_port noops, normal startup path.