### PR TITLE
fix(snomed): tag delta archive with shortName so Stored archives card lists it

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
@@ -95,6 +95,14 @@ public class SnomedDeltaCalculateService {
     if (currentBranch != null && baselineBranch != null && !currentBranch.equals(baselineBranch)) {
       throw new IllegalArgumentException("Baseline branchPath (" + baselineBranch + ") differs from current (" + currentBranch + ")");
     }
+    // The Stored archives card filters by JSONB containment on {shortName, branchPath}, so
+    // the delta has to carry both keys or it disappears from the card it should appear in.
+    // Take shortName from the current archive (the new state, which has the meta tags
+    // assigned by the modal upload), falling back to baseline if the current is missing it.
+    // Assigned in a single expression so it stays effectively-final for the async lambda.
+    final String currentShortName = metaString(current, "shortName") != null
+        ? metaString(current, "shortName")
+        : metaString(baseline, "shortName");
 
     LorqueProcess process = lorqueProcessService.start(new LorqueProcess().setProcessName(PROCESS_NAME));
     Long pid = process.getId();
@@ -118,7 +126,7 @@ public class SnomedDeltaCalculateService {
         SnomedDeltaGeneratorRuntime.Result result = runtime.run(baselineTemp, currentTemp, workDir, latestState);
 
         lorqueProcessService.reportProgress(pid, 80, "uploading delta archive to Bob");
-        String deltaUuid = persistDelta(currentUuid, req.getBaselineUuid(), currentBranch, result, latestState);
+        String deltaUuid = persistDelta(currentUuid, req.getBaselineUuid(), currentShortName, currentBranch, result, latestState);
 
         Map<String, Object> resultPayload = new LinkedHashMap<>();
         resultPayload.put("deltaUuid", deltaUuid);
@@ -151,10 +159,15 @@ public class SnomedDeltaCalculateService {
     }
   }
 
-  private String persistDelta(String sourceUuid, String baselineUuid, String branchPath,
+  private String persistDelta(String sourceUuid, String baselineUuid, String shortName, String branchPath,
                               SnomedDeltaGeneratorRuntime.Result result, boolean latestState) {
     Map<String, Object> meta = new LinkedHashMap<>();
     meta.put("kind", "delta");
+    // shortName must be present for the per-CS Stored archives card's JSONB @> filter to
+    // include this delta. Same for branchPath — both are inherited from the source archive.
+    if (shortName != null) {
+      meta.put("shortName", shortName);
+    }
     if (branchPath != null) {
       meta.put("branchPath", branchPath);
     }


### PR DESCRIPTION
**Reported live:** "the delta also not visible in /integration/snomed/codesystems/SNOMEDCT/edit".

## Root cause

`SnomedDeltaCalculateService.persistDelta` only set `meta.branchPath`. The SNOMED CodeSystem edit page's Stored archives card filters by JSONB containment on `{shortName, branchPath}`:

```typescript
<tw-bob-archives container="snomed"
                 [meta]="{shortName: snomedCodeSystem?.shortName,
                          branchPath: snomedCodeSystem?.branchPath}" …/>
```

So newly-generated deltas matched `branchPath` but missed `shortName` and disappeared from the card — admins could only reach them via the Lorque process result URL or by remembering the uuid.

## Fix

Inherit `shortName` from the current archive's `meta` (the new state, which the modal upload tags with the full `{shortName, branchPath, rf2Type}` triple). Fall back to the baseline's `shortName` if the current archive predates meta scoping.

```java
final String currentShortName = metaString(current, "shortName") != null
    ? metaString(current, "shortName")
    : metaString(baseline, "shortName");
```

The `final` is required because the value is captured by the async lambda; the original single-conditional `if` form left it non-effectively-final.

## Backfill

Patched the three existing deltas in this dev's Bob via `PATCH /bob/objects/{uuid}`:

| uuid | shortName after |
|---|---|
| `49d696df-…` | SNOMEDCT |
| `2c935b88-…` | SNOMEDCT |
| `b982bcfe-…` | SNOMEDCT |

Verified the card now lists all 5 SNOMED-on-MAIN archives (2 source editions + 3 deltas).

## Test plan
- [ ] Calculate a new delta → reload the SNOMED edit page → the new delta appears in the Stored archives card alongside its source / baseline.
- [ ] Click the delta row → archive detail page (Phase 2c + #71 summary panel) renders correctly.
- [ ] An edit page for a *different* CodeSystem (e.g. SNOMEDCT-ES) doesn't show the SNOMEDCT-tagged deltas — meta scoping is still strict.