### PR TITLE
fix(snomed): unique per-delta Minio path + dated filename + latest-scan-result endpoint

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -376,6 +376,27 @@ public class SnomedController {
     return JsonUtil.fromJson(json, SnomedRF2ScanEnvelope.class);
   }
 
+  /**
+   * Most-recent scan envelope for a Bob archive, keyed by Bob uuid (the path) rather than by
+   * lorqueId. The archive-detail / scan-result Angular pages used to carry the envelope
+   * across navigations via router state, but that's per-history-entry and lost on refresh /
+   * back-forward cache restore — so two different archive URLs could end up showing whichever
+   * envelope was still cached in router state. With this endpoint the client fetches fresh
+   * by archive uuid every time and same URL always returns same data.
+   *
+   * <p>Returns {@code null} (HTTP 200 with empty body) when no scan has been recorded yet for
+   * this archive — the client treats that as "click Analyze on the archive page".</p>
+   */
+  @Authorized(Privilege.SNOMED_READ)
+  @Get("/archives/{uuid}/latest-scan-result")
+  public SnomedRF2ScanEnvelope latestScanResult(@PathVariable String uuid) {
+    Long lorqueId = snomedRF2UploadCacheService.findLatestScanLorqueIdByBobObjectUuid(uuid);
+    if (lorqueId == null) {
+      return null;
+    }
+    return loadScanResult(lorqueId);
+  }
+
   @Authorized(Privilege.SNOMED_READ)
   @Post("/concept-usage")
   public List<SnomedConceptUsage> findConceptUsage(@Body SnomedConceptUsageRequest request) {

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
@@ -212,14 +212,28 @@ public class SnomedDeltaCalculateService {
       desc.append(" — ").append(result.getRowsExported()).append(" rows");
     }
 
+    // Critical: route every delta to its own Minio key. The delta-generator-tool always
+    // writes its output to a fixed name ("Delta.zip"), so if we forward that name unchanged
+    // every delta upload writes to `snomed:/Delta.zip` and overwrites whatever the previous
+    // calculation produced. The Bob DB then has multiple rows pointing at the same physical
+    // zip — scans report identical stats because they're parsing the same bytes — reported
+    // live as "two different scan-result URLs show exactly the same information".
+    //
+    // Per-upload random path keeps each delta isolated and reuses the existing Minio cleanup
+    // semantics (delete by Bob uuid removes only that one Minio object). The date suffix on
+    // the filename is purely cosmetic — admins downloading the delta zip from the UI get a
+    // human-readable name like Delta-2026-05-20.zip rather than the upstream "Delta.zip".
+    String storagePath = "/delta-" + java.util.UUID.randomUUID() + "/";
+    String dateSuffix = java.time.LocalDate.now().toString(); // YYYY-MM-DD per ISO-8601
+    String storageFilename = "Delta-" + dateSuffix + ".zip";
     BobObject draft = new BobObject()
         .setContentType("application/zip")
         .setDescription(desc.toString())
         .setMeta(meta)
         .setStorage(new BobStorage()
             .setContainer(SnomedBobContainerAuthorizer.CONTAINER)
-            .setPath("/")
-            .setFilename(result.getDeltaZip().getFileName().toString()));
+            .setPath(storagePath)
+            .setFilename(storageFilename));
     return bobObjectService.store(draft, result.getDeltaZip());
   }
 

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheRepository.java
@@ -45,6 +45,25 @@ public class SnomedRF2UploadCacheRepository extends BaseRepository {
     jdbcTemplate.update(sql, lorqueId, id);
   }
 
+  /**
+   * Most-recent scan lorqueId for a given Bob archive uuid, or {@code null} if no scan has
+   * been recorded yet. Backs {@code GET /snomed/archives/{uuid}/latest-scan-result} — the
+   * archive-detail / scan-result pages used to rely on Angular router state to carry the
+   * envelope across navigations, but that's brittle (state is per-history-entry and lost on
+   * refresh / back-forward cache restore), so the client now fetches by archive uuid
+   * server-side and we just need to know which lorque process produced the latest result.
+   */
+  public Long findLatestScanLorqueIdByBobObjectUuid(String bobObjectUuid) {
+    String sql = "select scan_lorque_id from sys.snomed_rf2_upload "
+        + "where sys_status = 'A' and bob_object_uuid = ? and scan_lorque_id is not null "
+        + "order by started desc limit 1";
+    try {
+      return jdbcTemplate.queryForObject(sql, Long.class, bobObjectUuid);
+    } catch (org.springframework.dao.EmptyResultDataAccessException e) {
+      return null;
+    }
+  }
+
   public void cleanup(int daysOld) {
     // Soft-delete and clear zip_data: the schema GRANTs in sys-schema.xml don't include DELETE
     // for the app user, and what we actually need is to reclaim the bytea (which can be hundreds

--- a/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/rf2/scan/SnomedRF2UploadCacheService.java
@@ -60,6 +60,15 @@ public class SnomedRF2UploadCacheService {
     return repository.load(id);
   }
 
+  /**
+   * Latest scan lorqueId for a Bob archive uuid, or {@code null} if no scan has been
+   * recorded. Drives {@code GET /snomed/archives/{uuid}/latest-scan-result} on the
+   * controller — same-URL → same-data semantics for the scan-result page.
+   */
+  public Long findLatestScanLorqueIdByBobObjectUuid(String bobObjectUuid) {
+    return repository.findLatestScanLorqueIdByBobObjectUuid(bobObjectUuid);
+  }
+
   @Transactional
   public void markImported(Long id) {
     repository.markImported(id);


### PR DESCRIPTION
Two distinct bugs both presenting as **"two different scan-result URLs show exactly the same information"**, tracked down live in this session.

## 1. Delta uploads collided in Minio (the real cause)

`SnomedDeltaCalculateService.persistDelta` wrote every delta to the same Minio key:

```
storage.path     = "/"
storage.filename = <delta-generator's output = always "Delta.zip">
                 ⇒ Minio key  "/Delta.zip"
```

The Bob DB inserted a fresh row per delta (different UUIDs), but every upload **overwrote** the previous delta's bytes in storage. So:

| BobObject | meta says | Minio bytes after upload |
|---|---|---|
| `c03074f6` (SNOMEDCT International, `rowsExported=1,179,399`) — 1st upload | — | International delta zip |
| `78145ecd` (SNOMEDCT-EE, `rowsExported=4,596`) — 2nd upload | — | **EE delta zip (overwrites)** |

Both objects' `storage.path + storage.filename` resolved to `/Delta.zip`. Whichever upload was last became the content the scan engine read for *every* delta archive — which is exactly why `/latest-scan-result` and `/file-stats` returned identical numbers (443K AttributeValueDelta, 265K RelationshipDelta, …) regardless of which delta the admin clicked.

### Fix

`persistDelta` now uses a unique per-upload random subdirectory:

```java
storage.path     = "/delta-<random-uuid>/"
storage.filename = "Delta-YYYY-MM-DD.zip"
```

- The path-prefix guarantees Minio-key uniqueness — collision-free across concurrent runs *and* same-day regenerates.
- The date suffix is cosmetic — admins downloading the zip get a human-readable filename instead of every delta showing up as plain `Delta.zip`.

### Verified live

Fresh EE delta after the fix:
```
storage.path     = /delta-25734a12-1405-4f30-8774-f1e6583b128a/
storage.filename = Delta-2026-05-20.zip
```
and its `file-stats` correctly reports 4,596 total rows with `EE1000181_20251130` filenames — not the previously-overwritten International 20260501 content.

## 2. Scan-result envelope was carried via Angular router state

`SnomedRF2ScanResultComponent` used to read the envelope from `history.state` / `lastSuccessfulNavigation.extras.state`. Router state is per-history-entry, lost on refresh / back-forward-cache restore, and can return stale entries when the same route config matches a new URL. So "same URL ⇒ same data" wasn't actually true in practice.

Add a server-side lookup so the client can fetch the latest envelope by archive UUID:

```
GET /snomed/archives/{uuid}/latest-scan-result
  → SnomedRF2ScanEnvelope (or null when never scanned)
```

Implementation:
- `SnomedRF2UploadCacheRepository.findLatestScanLorqueIdByBobObjectUuid` — order-by-`started`-desc against `sys.snomed_rf2_upload`
- `SnomedRF2UploadCacheService` passthrough
- `SnomedController.latestScanResult` — looks up the lorqueId, delegates to existing `loadScanResult(lorqueId)`

A follow-up web PR will rewire `SnomedRF2ScanResultComponent` to call this endpoint on each `paramMap` fire instead of trusting router state.

## Migration note

The 7+ delta BobObjects already in dev Bob predate the path fix — they all point at `/Delta.zip` and will continue to show whatever was uploaded last. To clean up: `DELETE /bob/objects/<uuid>` for the old delta uuids, then re-run Calculate Delta on each pair. New deltas land at unique paths from this commit forward.

## Test plan
- [ ] Run Calculate Delta on two different (source, baseline) pairs → both new BobObjects have distinct `storage.path` values (no `/Delta.zip` collision).
- [ ] Downloaded filename in browser is `Delta-2026-05-20.zip` (or current date).
- [ ] `GET /snomed/archives/<delta-uuid>/file-stats` on each new delta returns the correct per-entry counts matching its actual content.
- [ ] `GET /snomed/archives/<archive-uuid>/latest-scan-result` returns the envelope for the most recent scan of THAT archive, returning `null` for archives never scanned.
- [ ] No regression on source archives (file-stats still works).