### PR TITLE
feat(loinc): GET /loinc/archives/{uuid}/files + optional fileMap on import-from-archive

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincController.java
@@ -5,6 +5,7 @@ import org.termx.core.auth.Authorized;
 import org.termx.core.sys.job.logger.ImportLogger;
 import org.termx.core.utils.FileUtil;
 import org.termx.editionint.Privilege;
+import org.termx.editionint.loinc.utils.LoincArchiveContents;
 import org.termx.editionint.loinc.utils.LoincImportFromArchiveRequest;
 import org.termx.editionint.loinc.utils.LoincImportRequest;
 import org.termx.sys.job.JobLogResponse;
@@ -12,8 +13,11 @@ import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Part;
 import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
@@ -71,6 +75,19 @@ public class LoincController {
   @Post(value = "/import/from-archive")
   public JobLogResponse processFromArchive(@Body LoincImportFromArchiveRequest request) {
     return loincImportFromArchiveService.startImport(request);
+  }
+
+  /**
+   * Lists every {@code .csv} entry inside a Bob-stored LOINC archive plus the slot the
+   * auto-dispatch would assign each one. Drives the per-slot select boxes on the import
+   * page — admins see what's in the chosen zip, the recommended mapping is preselected,
+   * and they can override before clicking Import.
+   */
+  @Authorized(Privilege.CS_WRITE)
+  @Get(value = "/archives/{uuid}/files")
+  public LoincArchiveContents listArchiveFiles(@PathVariable String uuid,
+                                               @Nullable @QueryValue String language) {
+    return loincImportFromArchiveService.listArchiveContents(uuid, language);
   }
 
   private static byte[] getBytes(Publisher<CompletedFileUpload> file) {

--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincImportFromArchiveService.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincImportFromArchiveService.java
@@ -14,9 +14,11 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.termx.bob.BobObject;
 import org.termx.bob.BobObjectService;
 import org.termx.core.sys.job.logger.ImportLogger;
+import org.termx.editionint.loinc.utils.LoincArchiveContents;
 import org.termx.editionint.loinc.utils.LoincImportFromArchiveRequest;
 import org.termx.editionint.loinc.utils.LoincZipReader;
 import org.termx.sys.job.JobLogResponse;
+import java.util.ArrayList;
 
 /**
  * Drives LOINC release import against an archive already stored in the {@code "loinc"} Bob
@@ -46,9 +48,10 @@ public class LoincImportFromArchiveService {
       Files.copy(is, tempFile, StandardCopyOption.REPLACE_EXISTING);
       // Unpack from the temp file — the LOINC pipeline still needs byte[] per CSV, but each
       // CSV is small (tens of MB) compared to the full zip, so peak heap is one CSV at a time
-      // rather than the whole archive.
+      // rather than the whole archive. When the admin provided an explicit fileMap from the
+      // import page (overriding the auto-dispatch), it flows straight through to the reader.
       try (InputStream unpackIn = Files.newInputStream(tempFile)) {
-        files = new LoincZipReader().unpack(unpackIn, req.getLanguage());
+        files = new LoincZipReader().unpack(unpackIn, req.getLanguage(), req.getFileMap());
       }
     } catch (Exception e) {
       try {
@@ -67,6 +70,29 @@ public class LoincImportFromArchiveService {
 
     Map<String, Object> params = Map.of("request", req.toImportRequest(), "files", files);
     return importLogger.runJob(LoincController.JOB_TYPE, params, loincService::importLoinc);
+  }
+
+  /**
+   * Walks the LOINC archive's zip directory and returns each {@code .csv} entry plus its
+   * auto-dispatch slot suggestion. Powers the LOINC import page's per-slot select boxes —
+   * admins see what CSVs are inside the chosen zip and the recommended mapping is preselected
+   * for each known slot. Doesn't buffer any entry body.
+   */
+  public LoincArchiveContents listArchiveContents(String archiveUuid, String language) {
+    BobObject archive = requireArchive(archiveUuid);
+    List<Pair<String, String>> raw;
+    try (InputStream is = bobObjectService.loadContentStream(archive)) {
+      raw = new LoincZipReader().describe(is, language);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read LOINC archive '" + archiveUuid + "': " + e.getMessage(), e);
+    }
+    List<LoincArchiveContents.Entry> entries = new ArrayList<>();
+    for (Pair<String, String> p : raw) {
+      entries.add(new LoincArchiveContents.Entry()
+          .setName(p.getLeft())
+          .setSuggestedSlot(p.getRight()));
+    }
+    return new LoincArchiveContents().setEntries(entries);
   }
 
   private BobObject requireArchive(String uuid) {

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincArchiveContents.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincArchiveContents.java
@@ -1,0 +1,35 @@
+package org.termx.editionint.loinc.utils;
+
+import io.micronaut.core.annotation.Introspected;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Response shape for {@code GET /loinc/archives/{uuid}/files} — drives the per-slot select
+ * boxes on the LOINC import page. Each entry is a {@code .csv} file inside the zip; the
+ * {@code suggestedSlot} is what the auto-dispatch (basename match in {@link LoincZipReader})
+ * would assign — {@code null} means "not a known LOINC file, admin can still pick it
+ * manually for any slot but it's not pre-selected anywhere".
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class LoincArchiveContents {
+  private List<Entry> entries;
+
+  @Getter
+  @Setter
+  @Accessors(chain = true)
+  @Introspected
+  public static class Entry {
+    /** Full entry name inside the zip (normalised with forward slashes). */
+    private String name;
+    /** {@code parts | terminology | supplementary-properties | panels | answer-list |
+     *  answer-list-link | order-observation | translations}, or {@code null} when the auto-
+     *  dispatch couldn't classify this entry. */
+    private String suggestedSlot;
+  }
+}

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincImportFromArchiveRequest.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincImportFromArchiveRequest.java
@@ -1,5 +1,6 @@
 package org.termx.editionint.loinc.utils;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -20,6 +21,18 @@ public class LoincImportFromArchiveRequest {
   private String version;
   /** ISO 639 lowercase language code; selects {@code <lang>LinguisticVariant.csv}. Optional. */
   private String language;
+  /**
+   * Optional explicit slot → entry-name map. When the admin overrides which CSV inside the
+   * archive maps to which import slot (via the per-slot selects on the LOINC import page),
+   * this carries the picks. Keys are {@code parts}, {@code terminology}, {@code panels},
+   * {@code answer-list}, {@code answer-list-link}, {@code supplementary-properties},
+   * {@code order-observation}, {@code translations}. Values are the full zip entry names
+   * (e.g. {@code AccessoryFiles/PartFile/Part.csv}).
+   *
+   * <p>When {@code null} or empty, the server falls back to the basename-match
+   * auto-dispatch — same behaviour as before this field existed.</p>
+   */
+  private Map<String, String> fileMap;
 
   public LoincImportRequest toImportRequest() {
     return new LoincImportRequest().setVersion(version).setLanguage(language);

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincZipReader.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincZipReader.java
@@ -43,11 +43,32 @@ public class LoincZipReader {
   }
 
   public List<Pair<String, byte[]>> unpack(InputStream zipStream, String language) {
+    return unpack(zipStream, language, null);
+  }
+
+  /**
+   * Unpack the LOINC archive using an explicit slot → entry-name map. When the caller
+   * supplies a {@code fileMap}, the basename-match heuristic is bypassed entirely and the
+   * provided entry names are used verbatim. The map shape mirrors the keys
+   * {@link LoincService} consumes — {@code parts}, {@code terminology}, …, {@code translations}.
+   *
+   * <p>Entries listed in the map but missing from the zip silently produce no output for
+   * that slot. Entries not in the map are ignored, even if they would have been picked up
+   * by the auto-dispatch. A {@code null} or empty map falls back to the auto-dispatch path
+   * (preserves the previous behaviour for /loinc/import/from-archive callers that don't yet
+   * pass a fileMap).</p>
+   */
+  public List<Pair<String, byte[]>> unpack(InputStream zipStream, String language, Map<String, String> fileMap) {
     List<Pair<String, byte[]>> files = new ArrayList<>();
     String translationsName = (language == null || language.isBlank()) ? null
         : (language.toLowerCase() + "LinguisticVariant");
+    // Invert the optional override: entryName -> slotKey. Normalise the same way matchKey
+    // does so the lookup can succeed regardless of which path-separator / case the caller
+    // sends.
+    Map<String, String> entryToSlot = (fileMap == null || fileMap.isEmpty()) ? null
+        : invertFileMap(fileMap);
 
-    log.info("Unpacking LOINC ZIP (lang={})", language);
+    log.info("Unpacking LOINC ZIP (lang={}, fileMap={})", language, entryToSlot != null ? "override" : "auto");
     try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
       ZipEntry entry;
       while ((entry = zipIn.getNextEntry()) != null) {
@@ -55,7 +76,14 @@ public class LoincZipReader {
           zipIn.closeEntry();
           continue;
         }
-        String key = matchKey(entry.getName(), translationsName);
+        String key;
+        if (entryToSlot != null) {
+          // Explicit override path — exact entry-name match (normalised).
+          String normalised = entry.getName().replace('\\', '/');
+          key = entryToSlot.get(normalised);
+        } else {
+          key = matchKey(entry.getName(), translationsName);
+        }
         if (key != null) {
           files.add(Pair.of(key, IOUtils.toByteArray(zipIn)));
         }
@@ -66,6 +94,51 @@ public class LoincZipReader {
       throw new RuntimeException(e);
     }
     return files;
+  }
+
+  /**
+   * Returns the entries the auto-dispatch *would* pick from this archive, with slot keys
+   * assigned per {@link #matchKey} — the "suggested mapping" surfaced on the import page so
+   * the admin can preview / override before kicking off the import. Stream-walks; never
+   * materialises any entry body.
+   */
+  public List<Pair<String, String>> describe(InputStream zipStream, String language) {
+    List<Pair<String, String>> entries = new ArrayList<>();
+    String translationsName = (language == null || language.isBlank()) ? null
+        : (language.toLowerCase() + "LinguisticVariant");
+    try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
+      ZipEntry entry;
+      while ((entry = zipIn.getNextEntry()) != null) {
+        if (entry.isDirectory()) {
+          zipIn.closeEntry();
+          continue;
+        }
+        String normalised = entry.getName().replace('\\', '/');
+        if (!normalised.toLowerCase().endsWith(".csv")) {
+          zipIn.closeEntry();
+          continue;
+        }
+        String key = matchKey(entry.getName(), translationsName);
+        entries.add(Pair.of(normalised, key)); // key may be null — UI shows entry as "Unmapped"
+        zipIn.closeEntry();
+      }
+    } catch (IOException | RuntimeException e) {
+      log.error("Error while describing LOINC pack", e);
+      throw new RuntimeException(e);
+    }
+    return entries;
+  }
+
+  private static Map<String, String> invertFileMap(Map<String, String> fileMap) {
+    Map<String, String> inverted = new java.util.HashMap<>();
+    for (Map.Entry<String, String> e : fileMap.entrySet()) {
+      if (e.getValue() == null || e.getValue().isBlank()) {
+        continue;
+      }
+      String entryName = e.getValue().replace('\\', '/');
+      inverted.put(entryName, e.getKey());
+    }
+    return inverted;
   }
 
   private static String matchKey(String entryName, String translationsBaseName) {


### PR DESCRIPTION
Two server-side primitives the LOINC import page (web change in a follow-up PR) needs to replace the eight manual file inputs with a single archive picker + per-slot select boxes preselected to the auto-dispatch suggestion.

## 1. `GET /loinc/archives/{uuid}/files?language=<lang>`

```json
{
  "entries": [
    {"name": "AccessoryFiles/PartFile/Part.csv",                "suggestedSlot": "parts"},
    {"name": "AccessoryFiles/PartFile/LoincPartLink_Primary.csv","suggestedSlot": "terminology"},
    {"name": "AccessoryFiles/PartFile/LoincPartLink_Supplementary.csv","suggestedSlot": "supplementary-properties"},
    {"name": "AccessoryFiles/PanelsAndForms/PanelsAndForms.csv","suggestedSlot": "panels"},
    {"name": "AccessoryFiles/AnswerFile/AnswerList.csv",        "suggestedSlot": "answer-list"},
    {"name": "AccessoryFiles/AnswerFile/LoincAnswerListLink.csv","suggestedSlot": "answer-list-link"},
    {"name": "AccessoryFiles/UniversalLabOrdersValueSet/LoincUniversalLabOrdersValueSet.csv","suggestedSlot": "order-observation"},
    {"name": "AccessoryFiles/LinguisticVariants/etLinguisticVariant.csv","suggestedSlot": "translations"},
    {"name": "LoincTable/Loinc.csv",                            "suggestedSlot": null},
    …
  ]
}
```

Stream-only — walks the zip directory via `ZipInputStream` without buffering any entry body. Fast on full LOINC releases.

## 2. Optional `fileMap` on `POST /loinc/import/from-archive`

```json
{
  "archiveUuid": "<uuid>",
  "version": "2.78",
  "language": "et",
  "fileMap": {
    "parts": "AccessoryFiles/PartFile/Part.csv",
    "terminology": "AccessoryFiles/PartFile/LoincPartLink_Primary.csv",
    "translations": "AccessoryFiles/LinguisticVariants/etLinguisticVariant.csv"
  }
}
```

When provided, `LoincZipReader.unpack(stream, lang, map)` uses the explicit entry-name overrides instead of the basename match. Admins can pick a different CSV per slot via the new UI selects. When `fileMap` is `null`/empty, the legacy auto-dispatch runs unchanged.

## Test plan
- [ ] `GET /loinc/archives/<uuid>/files?language=et` on a Bob LOINC archive returns one entry per `.csv`, with `suggestedSlot` populated for the 7 well-known files + the matching `etLinguisticVariant.csv`.
- [ ] Without `language`, `translations` is never suggested (no entry can match).
- [ ] `POST /loinc/import/from-archive` with no `fileMap` still imports correctly (auto-dispatch path unchanged).
- [ ] `POST /loinc/import/from-archive` with an explicit `fileMap` mapping a non-default entry name to a slot uses that file (e.g. point `parts` at a custom `MyCustomParts.csv` and the import logs reflect it).
- [ ] `fileMap` with an entry name that doesn't exist in the zip silently produces no rows for that slot (still attempts the others).