### PR TITLE
feat(loinc): prefix-match translations + detect version from DifferenceReport.pdf

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincImportFromArchiveService.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincImportFromArchiveService.java
@@ -81,10 +81,21 @@ public class LoincImportFromArchiveService {
   public LoincArchiveContents listArchiveContents(String archiveUuid, String language) {
     BobObject archive = requireArchive(archiveUuid);
     List<Pair<String, String>> raw;
+    String detectedVersion;
+    // Two passes over the archive — one for the CSV listing (describe), one for the
+    // DifferenceReport.pdf-based version detection. Each is a streaming walk of the central
+    // directory + a single InputStream read per entry header; the second pass is cheap
+    // enough that bundling both into one walk would be a premature optimisation.
     try (InputStream is = bobObjectService.loadContentStream(archive)) {
       raw = new LoincZipReader().describe(is, language);
     } catch (Exception e) {
       throw new RuntimeException("Failed to read LOINC archive '" + archiveUuid + "': " + e.getMessage(), e);
+    }
+    try (InputStream is = bobObjectService.loadContentStream(archive)) {
+      detectedVersion = new LoincZipReader().detectVersion(is);
+    } catch (Exception e) {
+      log.warn("Version detection from LOINC archive '{}' failed: {}", archiveUuid, e.getMessage());
+      detectedVersion = null;
     }
     List<LoincArchiveContents.Entry> entries = new ArrayList<>();
     for (Pair<String, String> p : raw) {
@@ -92,7 +103,9 @@ public class LoincImportFromArchiveService {
           .setName(p.getLeft())
           .setSuggestedSlot(p.getRight()));
     }
-    return new LoincArchiveContents().setEntries(entries);
+    return new LoincArchiveContents()
+        .setEntries(entries)
+        .setDetectedVersion(detectedVersion);
   }
 
   private BobObject requireArchive(String uuid) {

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincArchiveContents.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincArchiveContents.java
@@ -19,6 +19,13 @@ import lombok.experimental.Accessors;
 @Introspected
 public class LoincArchiveContents {
   private List<Entry> entries;
+  /**
+   * Version string extracted from the {@code Loinc_<version>_DifferenceReport.pdf} entry
+   * the LOINC release zips ship at their root. {@code null} when the archive doesn't
+   * follow that convention. Used by the import page as a fallback when the archive's
+   * outer filename / {@code meta.version} doesn't already carry the version.
+   */
+  private String detectedVersion;
 
   @Getter
   @Setter

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincZipReader.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincZipReader.java
@@ -60,8 +60,6 @@ public class LoincZipReader {
    */
   public List<Pair<String, byte[]>> unpack(InputStream zipStream, String language, Map<String, String> fileMap) {
     List<Pair<String, byte[]>> files = new ArrayList<>();
-    String translationsName = (language == null || language.isBlank()) ? null
-        : (language.toLowerCase() + "LinguisticVariant");
     // Invert the optional override: entryName -> slotKey. Normalise the same way matchKey
     // does so the lookup can succeed regardless of which path-separator / case the caller
     // sends.
@@ -82,7 +80,7 @@ public class LoincZipReader {
           String normalised = entry.getName().replace('\\', '/');
           key = entryToSlot.get(normalised);
         } else {
-          key = matchKey(entry.getName(), translationsName);
+          key = matchKey(entry.getName(), language);
         }
         if (key != null) {
           files.add(Pair.of(key, IOUtils.toByteArray(zipIn)));
@@ -104,8 +102,6 @@ public class LoincZipReader {
    */
   public List<Pair<String, String>> describe(InputStream zipStream, String language) {
     List<Pair<String, String>> entries = new ArrayList<>();
-    String translationsName = (language == null || language.isBlank()) ? null
-        : (language.toLowerCase() + "LinguisticVariant");
     try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
       ZipEntry entry;
       while ((entry = zipIn.getNextEntry()) != null) {
@@ -118,7 +114,7 @@ public class LoincZipReader {
           zipIn.closeEntry();
           continue;
         }
-        String key = matchKey(entry.getName(), translationsName);
+        String key = matchKey(entry.getName(), language);
         entries.add(Pair.of(normalised, key)); // key may be null — UI shows entry as "Unmapped"
         zipIn.closeEntry();
       }
@@ -127,6 +123,41 @@ public class LoincZipReader {
       throw new RuntimeException(e);
     }
     return entries;
+  }
+
+  /**
+   * Scan the archive for the {@code Loinc_<version>_DifferenceReport.pdf} entry shipped by
+   * LOINC releases (typically directly under the {@code Loinc_<version>/} root). Returns
+   * the detected version string (e.g. {@code "2.82"}) or {@code null} when the archive
+   * doesn't follow this convention. Used as a fallback so the import page can suggest a
+   * version even when the uploaded archive's outer filename didn't carry it (e.g. renamed
+   * to {@code release.zip}).
+   */
+  public String detectVersion(InputStream zipStream) {
+    java.util.regex.Pattern pat =
+        java.util.regex.Pattern.compile("Loinc[_-]([\\d.]+)_DifferenceReport\\.pdf$", java.util.regex.Pattern.CASE_INSENSITIVE);
+    try (ZipInputStream zipIn = new ZipInputStream(zipStream)) {
+      ZipEntry entry;
+      while ((entry = zipIn.getNextEntry()) != null) {
+        if (entry.isDirectory()) {
+          zipIn.closeEntry();
+          continue;
+        }
+        String basename = entry.getName().replace('\\', '/');
+        int slash = basename.lastIndexOf('/');
+        if (slash >= 0) {
+          basename = basename.substring(slash + 1);
+        }
+        java.util.regex.Matcher m = pat.matcher(basename);
+        if (m.find()) {
+          return m.group(1).replaceAll("\\.+$", "");
+        }
+        zipIn.closeEntry();
+      }
+    } catch (IOException | RuntimeException e) {
+      log.warn("Failed to detect version from LOINC pack: {}", e.getMessage());
+    }
+    return null;
   }
 
   private static Map<String, String> invertFileMap(Map<String, String> fileMap) {
@@ -141,7 +172,24 @@ public class LoincZipReader {
     return inverted;
   }
 
-  private static String matchKey(String entryName, String translationsBaseName) {
+  /**
+   * Maps a zip entry name to a LoincService slot key.
+   *
+   * <p>Auto-dispatch is by file <em>basename</em> (case-insensitive, path separators
+   * normalised) so the wrapper directory in real LOINC releases — {@code Loinc_2.82/} above
+   * each entry — doesn't break the match.</p>
+   *
+   * <p>Translations: LOINC distributes translation files as
+   * {@code <lang><Country><variantId>LinguisticVariant.csv} (e.g. {@code etEE25Linguistic
+   * Variant.csv}, {@code elGR17LinguisticVariant.csv}). The admin only picks an ISO-639
+   * code from the language dropdown ({@code et}, {@code en}, …), so we match any file
+   * whose basename starts with that code (case-insensitive) AND ends with
+   * {@code LinguisticVariant} — prefix-matched, not exact.</p>
+   *
+   * @param language raw language code as entered by the admin (e.g. {@code "et"}), or
+   *                 {@code null} when no language is set
+   */
+  private static String matchKey(String entryName, String language) {
     String normalised = entryName.replace('\\', '/');
     int slash = normalised.lastIndexOf('/');
     String basename = slash < 0 ? normalised : normalised.substring(slash + 1);
@@ -161,7 +209,10 @@ public class LoincZipReader {
         return e.getValue();
       }
     }
-    if (translationsBaseName != null && translationsBaseName.equalsIgnoreCase(basename)) {
+    // Translations: prefix-match on the language code + suffix LinguisticVariant.
+    if (language != null && !language.isBlank()
+        && basename.toLowerCase().startsWith(language.toLowerCase())
+        && basename.endsWith("LinguisticVariant")) {
       return "translations";
     }
     return null;


### PR DESCRIPTION
Two improvements to the LOINC archive auto-dispatch, both visible on the import page's per-slot selects and the version dropdown.

## 1. Translations file: prefix-match by language code

LOINC distributes per-language files as `<lang><COUNTRY><variantId>LinguisticVariant.csv` — e.g.

```
etEE25LinguisticVariant.csv      (Estonian-Estonia, variant 25)
elGR17LinguisticVariant.csv      (Greek-Greece, 17)
enUS1LinguisticVariant.csv       (English-US, 1)
zhCN5LinguisticVariant.csv       (Chinese-China, 5)
…
```

The admin only picks an ISO-639 code from the language dropdown (`et`, `en`, …). The previous `matchKey` path did an exact equality check against `<lang>LinguisticVariant` — so `et` **never matched** `etEE25LinguisticVariant`, and the Translations slot ended up with no suggestion despite a perfectly good file sitting in the archive.

**Fix:** prefix match.
```java
basename.toLowerCase().startsWith(language)
    && basename.endsWith("LinguisticVariant")
```
keys the slot. Refactor `matchKey` to take the raw language code so both `unpack()` and `describe()` paths share one source of truth (no more pre-computed `<lang>LinguisticVariant` glue string).

## 2. Version detection from `Loinc_<version>_DifferenceReport.pdf`

LOINC releases ship a `Loinc_<version>_DifferenceReport.pdf` (e.g. `Loinc_2.82_DifferenceReport.pdf`) at the archive's root. Add `LoincZipReader.detectVersion()` — scans for that filename, extracts the version via regex.

`LoincImportFromArchiveService.listArchiveContents` does a second stream-pass over the archive, surfaces the result as `LoincArchiveContents.detectedVersion`. The web import page can use it as a fallback when the BobObject's `meta.version` is empty — e.g. legacy archives uploaded before the filename-detection feature ([termx-web #79](https://github.com/termx-health/termx-web/pull/79)) landed.

## Test plan
- [ ] Upload a LOINC release zip with `etEE25LinguisticVariant.csv` inside, pick language=`et` on the import page → Translations slot's `<m-select>` has the file preselected with "(suggested)".
- [ ] Pick language=`en` on a release that has both `enUS1LinguisticVariant.csv` and `enAU3LinguisticVariant.csv` → both appear as candidates, one of them is suggested. Admin can switch.
- [ ] `GET /loinc/archives/<uuid>/files?language=et` on an archive whose outer filename was renamed to `release.zip` (so `meta.version` is empty) → response includes `"detectedVersion": "2.82"` from the bundled DifferenceReport pdf.
- [ ] Archive with no `*_DifferenceReport.pdf` → response has `detectedVersion: null`, no error.
- [ ] Existing non-translation slot suggestions (`Part.csv`, `LoincPartLink_Primary.csv`, etc.) still preselect correctly.