### PR TITLE
perf(loinc): faster import + chunk entity insert + surface stack traces

### DIFF
--- a/docs/features/loinc-import-management.md
+++ b/docs/features/loinc-import-management.md
@@ -1,0 +1,109 @@
+# LOINC Release Import and Management
+
+## Description
+
+This feature lets terminology managers upload LOINC release zips once, then re-run imports against the stored archive without re-uploading the file — typically a 100 MB+ download from Regenstrief. Each archive carries its release version (`2.82`, `2.81`, …) and translation language as Bob metadata, so the import page surfaces them as a version picker rather than a free-text input. Per-CSV slot mapping is preselected from the archive's actual contents, and the heavy parse + persistence runs as a background Lorque job.
+
+It replaces the previous flow where admins had to re-upload the eight raw CSV files (Parts, LoincPartLink_Primary, LoincPartLink_Supplementary, PanelsAndForms, AnswerList, LoincAnswerListLink, LoincUniversalLabOrdersValueSet, language-specific LinguisticVariant) every time they wanted to retry or change a single mapping.
+
+**Key capabilities**
+
+- **Archive storage** in the existing Bob (`bob.object` / `bob.object_storage`) layer under container `loinc`, with `meta.version` and `meta.language` tags. Multi-hundred-MB zips stream straight to Minio; the JVM never holds the full file in heap.
+- **Version select** on the import page — populated from the distinct `meta.version` values across stored archives. Picking a version auto-resolves the most-recently-uploaded archive for that version; admins can override via a secondary "LOINC archive" picker when more than one archive shares a version.
+- **Auto version detection on upload** — pulled from the filename pattern `Loinc_<version>.zip` (frontend regex) with a server-side fallback that scans the archive for `Loinc_<version>_DifferenceReport.pdf` so archives whose outer filename doesn't reveal the version still get tagged.
+- **Per-slot file mapping** — listing endpoint walks the zip's central directory and returns every `.csv` entry plus an auto-dispatched slot suggestion (Parts / Terminology / Supplementary properties / Panels and forms / Answer list / Answer list link / Order-observation / Translations). The translations slot's suggestion is keyed off the requested language: any entry whose basename starts with the language code and ends with `LinguisticVariant` matches (e.g. `etEE10LinguisticVariant.csv` for Estonian).
+- **Override before import** — every slot is preselected from the suggestion but the admin can swap in a custom CSV from any other zip entry, or leave it on "(none — use server default)" to let the auto-dispatch fall through.
+- **Streaming import** — the server spools the chosen Bob archive to a local temp file, unpacks each CSV by name via `LoincZipReader`, and feeds the existing `LoincService.importLoinc` pipeline as a Lorque job. Each CSV is decompressed into byte arrays one at a time, never the whole archive.
+- **Per-phase progress logging** under the `loinc-import:` prefix — admins (or grep) can see wall-clock for each parse step (answer-list, parts, concepts+associations+answer-list-link+order-observation, linguistic variants) and each persistence step (answer-list code-system, map-set, parts, concepts).
+- **Independent code systems** — answer-lists, parts, and the core LOINC concept set are saved as three distinct code systems (`loinc-answer-list`, `loinc-part`, `loinc`) so consumers can subscribe to or version each one separately.
+
+## Configuration
+
+### Properties
+
+LOINC piggy-backs on the existing Bob + multipart limits; no LOINC-specific knobs.
+
+| Property | Default | Description |
+|---|---|---|
+| `bob.minio.url` / `bob.minio.access-key` / `bob.minio.secret-key` | (deployment) | Minio endpoint + credentials for archive storage. |
+| `micronaut.server.max-request-size` | 600 MB | Hard cap on multipart upload size — LOINC release zips are ~100 MB. |
+| `micronaut.server.multipart.max-file-size` | 600 MB | Same. |
+
+### Privileges
+
+| Privilege | Used for |
+|---|---|
+| `loinc.CodeSystem.read` | View the LOINC import page, list stored archives, fetch slot mappings. |
+| `loinc.CodeSystem.write` | Upload a new archive, delete one, trigger an import, open a code system after a successful run. |
+
+## Use-Cases
+
+### Scenario 1: First-time import of a new LOINC release
+
+A new LOINC release ships (`Loinc_2.82.zip`). The terminology manager opens the LOINC import page, picks Estonian as the language, clicks "Choose file" in the Stored Archives card, and selects the downloaded zip. The frontend immediately detects the version from the filename and pre-fills the version field. After clicking Upload, the archive streams to Minio with `meta = { version: "2.82", language: "et" }`. The version dropdown above refreshes, the new "2.82" entry appears and is auto-selected, the archive's slot mapping is fetched, and all eight per-slot selects pre-populate with the suggested CSVs (including `etEE10LinguisticVariant.csv` for Translations). The admin reviews, clicks Import, and the background job runs end-to-end. The success notification links straight to the imported code system.
+
+### Scenario 2: Retry a failed import without re-uploading
+
+A previous import failed mid-way (e.g. a transient DB issue). The admin returns to the import page, opens the version dropdown, picks 2.82, and clicks Import again — the same Bob-stored archive is reused, no second upload of a 100 MB file.
+
+### Scenario 3: Override a single CSV with a corrected file
+
+The admin needs to test a corrected `Part.csv` Regenstrief sent out-of-band. They re-zip the corrected file into the original archive, upload it, and on the import page the Parts slot stays preselected to `Loinc_2.82/AccessoryFiles/PartFile/Part.csv` — but they could equally pick a different file from the same zip via the dropdown.
+
+### Scenario 4: Multi-version coexistence
+
+The team archives historical versions (2.76, 2.79, 2.82) by uploading each one. The version dropdown lists all three; picking any one switches the form to that version's archive, slot mapping, and language-specific translation file. The Stored archives card lists all uploads with their version tags and a per-row Open action to load that specific archive into the form.
+
+## Implementation Highlights
+
+### Backend
+
+| File | Purpose |
+|---|---|
+| `edition-int/.../loinc/LoincController.java` | Endpoints: `POST /loinc/import/from-archive`, `GET /loinc/archives/{uuid}/files`, legacy `POST /loinc/import`. |
+| `edition-int/.../loinc/LoincImportFromArchiveService.java` | Spools archive Bob → temp file, unpacks CSVs via `LoincZipReader`, hands off to `LoincService.importLoinc`. |
+| `edition-int/.../loinc/utils/LoincZipReader.java` | Streams a LOINC zip — `unpack(stream, language, fileMap)` returns the eight CSVs by slot; `describe(stream, language)` lists all `.csv` entries with auto-dispatch slot suggestion (prefix-match for translations: `<lang>...LinguisticVariant`); `detectVersion(stream)` extracts the version from `Loinc_<version>_DifferenceReport.pdf`. |
+| `edition-int/.../loinc/utils/LoincArchiveContents.java` | Response DTO for the listing endpoint — entries + detectedVersion. |
+| `edition-int/.../loinc/LoincBobContainerAuthorizer.java` | Per-container Bob authz: maps `loinc` container CRUD to `loinc.CodeSystem.*` privileges. |
+| `edition-int/.../loinc/LoincService.java` | Parses each CSV, builds in-memory part/concept models, delegates to `CodeSystemImportProvider`. Each phase logs wall-clock under the `loinc-import:` prefix. |
+| `terminology/.../codesystem/entity/CodeSystemEntityRepository.java` | `batchUpsert` chunks `INSERT … VALUES (?,?),(?,?),…` at 25 000 rows per query so the LOINC answer-list step (~33 k entities) doesn't exceed PostgreSQL's 65 535-parameter `PreparedStatement` limit. |
+
+### Frontend
+
+| File | Purpose |
+|---|---|
+| `app/src/app/integration/import/loinc/loinc-import.component.ts` / `.html` | The import page. Drives the version select, the per-slot file picks, and posts to `/loinc/import/from-archive`. |
+| `app/src/app/sys/_lib/bob/components/bob-archives.component.ts` | Reusable "Stored archives" card embedded on the import page. `(fileSelected)` fires on file pick (used to auto-detect version from filename); `(uploaded)` fires after a successful upload so the version dropdown can refresh and auto-select the new entry. |
+
+### Parsing optimisations
+
+The CSV-to-model parsing has been tuned to keep the Java-side work to a few seconds even on full LOINC releases:
+
+- Column-name → index resolved **once per CSV** (small `Idx` helper). Replaces the previous per-row `headers.indexOf("X")` linear scans (~10 million scans on `LoincPartLink_Primary.csv` + `_Supplementary.csv` alone).
+- Incoming `Pair<String, byte[]>` file list indexed into a `Map<slot, bytes>` once at the top of `importLoinc` so each phase doesn't re-walk eight pairs.
+- Single-pass concept building (no `groupingBy` → entrySet → map) and single-pass answer-list building (folds three independent collectors into one row walk).
+- Linguistic-variants phase builds a per-concept `partName → partCode` map on first hit (cached for the row) so the seven part-name lookups become `O(1)`. A small `Set<partCode|lang>` de-dupes redundant `HashMap.put` calls when the same part code recurs across thousands of concepts.
+
+### Measured timings (LOINC 2.82, Estonian, fresh import on local dev DB)
+
+```
+loinc-import: parsed answer-list (22 146 answers, 4 955 lists, 456 SNOMED mappings) in 71 ms
+loinc-import: parsed 74 087 parts in 52 ms
+loinc-import: parsed 109 325 concepts (terminology + associations + answer-list-link + order-observation) in 1 863 ms
+loinc-import: applied linguistic variants in 121 ms
+loinc-import: saved answer-list code-system in 24 970 ms
+loinc-import: saved answer-list map-set (456 mappings) in 151 ms
+loinc-import: saved 74 087 parts in 62 510 ms
+loinc-import: saved 109 325 concepts in 279 620 ms
+loinc-import: total 369 359 ms
+```
+
+Java-side parse + transform: **~2.1 s** for ~320 k input rows. End-to-end import: **~6.2 minutes** dominated by the DB writes of 1.4 M property values across 109 k concepts.
+
+## Operational Notes
+
+- **Idempotent re-runs** — re-importing the same archive against an existing code-system goes through the same `CodeSystemImportProvider.importCodeSystem` path which upserts by code; safe to retry.
+- **No automatic concept-property refresh** — references inside other code-systems' property values (e.g. `LOINC-CODE` properties on EHR concepts) still carry the LOINC version they were saved with. See `coding-value-refresh` feature for the per-concept / per-CS-version refresh button.
+- **Cache retention** — Bob archives are kept indefinitely; cleanup is manual via the Stored archives card's Delete action.
+- **Translation files** — only the slot matching the requested language gets ingested; other `<lang>...LinguisticVariant.csv` entries inside the same zip are listed in the dropdown but not preselected.
+- **Pre-existing latent fix** — `LoincMapper.toProperties` was rebuilding the property list via `Stream.toList()` (unmodifiable in Java 16+) then calling `.add(DISPLAY)` / `.add(KEY_WORDS)` on it. Previously masked by the upstream parameter-limit crash in `CodeSystemEntityRepository.batchUpsert`; now collects into a mutable `ArrayList`.

--- a/docs/features/snomed-import-management.md
+++ b/docs/features/snomed-import-management.md
@@ -1,0 +1,103 @@
+# SNOMED CT RF2 Import and Management
+
+## Description
+
+This feature lets terminology managers upload, scan, diff, and import SNOMED CT RF2 release archives (full International edition, national extensions, deltas) from the TermX UI without the heap-OOM risk of buffering ~549 MB zips in memory. Heavy work runs as background Lorque jobs and reports progress; archives live in Minio (via the `bob` storage layer) so retries, deltas, and cross-edition comparisons reuse the same upload.
+
+It pairs three flows:
+
+1. **Dry-run scan** — uploads or selects an RF2 zip, parses it, and produces a structured report of new / modified / invalidated concepts (with designations and optionally relationships+attributes) plus aggregate stats. The same upload can be pushed to Snowstorm in one click without re-uploading the file.
+2. **Delta calculation** — picks a baseline archive on the same `branchPath` and runs the IHTSDO `delta-generator-tool` against the current archive; the produced delta zip lands back in Bob (tagged `meta.kind = "delta"`) and can itself be imported or scanned later.
+3. **Snowstorm push** — submits a stored or just-uploaded archive to Snowstorm, streaming bytes from Minio rather than re-uploading from the browser.
+
+A complementary **concept-usage lookup** answers "which TermX-managed CodeSystem supplements, ValueSet rules, and stored expansions still reference these SNOMED codes?" — useful when triaging the inactivated-concept list from a scan.
+
+**Key capabilities**
+
+- **Archive storage** in Bob (`bob.object` / `bob.object_storage`) under container `snomed`, tagged with `meta.branchPath`, `meta.shortName`, `meta.effectiveTime`, and `meta.kind` ("delta" for tool output).
+- **Streamed multipart upload** — bytes go straight from network → temp file → Minio; nothing buffered in heap.
+- **Per-archive scan** via `POST /snomed/imports/scan/from-archive`, async via Lorque, two modes (`summary` — concepts + descriptions + text definitions only, default; `full` — also relationships + language-refset acceptability + attributes). `summary` is roughly 3–4× faster than `full` on the International edition.
+- **Streamed Snowstorm push** via `POST /snomed/imports/from-archive` — `snowstormClient.uploadRF2File(jobId, () -> bobObjectService.loadContentStream(archive))` re-streams from Bob, never re-buffers.
+- **Delta-against-baseline** via `POST /snomed/archives/{uuid}/delta` — spools both archives Bob → temp files, invokes the vendored `DeltaGeneratorTool-3.0.0.jar` subprocess, uploads the produced delta zip back into Bob.
+- **Archive detail page** with: per-file row stats (`GET /snomed/archives/{uuid}/file-stats`), diff candidates (`GET /snomed/archives/{uuid}/diff-candidates` — same `branchPath`, excludes delta-kind archives), Calculate Delta action, and the latest scan result link.
+- **Concept-usage lookup** — accepts plain codes, a JSON array, or a full `SnomedRF2ScanResult` JSON (auto-extracts invalidated codes); returns every CodeSystem supplement / ValueSet rule / stored expansion that still references those codes, with links back to the affected resource edit pages.
+- **Cache + import tracking** — `sys.snomed_rf2_upload` caches scan/import zips (bytea or Bob UUID reference) with 7-day retention; `sys.snomed_import_tracking` records the Snowstorm jobId, branchPath, type, and status of every push.
+- **Standalone Python equivalents** under `termx-server/scripts/` for offline / batch / CI use of the scan and concept-usage logic.
+
+## Configuration
+
+### Properties
+
+| Property | Env variable | Default | Description |
+|---|---|---|---|
+| `bob.minio.url` / `bob.minio.access-key` / `bob.minio.secret-key` | `BOB_MINIO_*` | (deployment) | Minio endpoint + credentials — shared with all Bob containers. |
+| `snowstorm.url` | — | `https://snowstorm.termx.org/` | Snowstorm base URL — consulted on import push. |
+| `snowstorm.user` / `snowstorm.password` | — | (deployment) | Basic Auth. Empty values send no `Authorization` header. |
+| `micronaut.server.max-request-size` | — | `629145600` (600 MB) | Multipart upload cap — SNOMED International is ~549 MB. |
+| `micronaut.server.multipart.max-file-size` | — | `629145600` (600 MB) | Same. |
+| `termx.snomed.delta-generator.timeout-seconds` | — | `1800` (30 min) | Hard cap on the `DeltaGeneratorTool` subprocess. |
+
+### Cache retention
+
+`sys.snomed_rf2_upload` rows older than **7 days** are soft-deleted and their `data` column nulled by a scheduled cleanup task (`SnomedRF2UploadCacheService.scheduledCleanup`, every 6 h, 10-min initial delay). Retention is hard-coded in `RETENTION_DAYS`.
+
+### Privileges
+
+| Privilege | Used for |
+|---|---|
+| `snomed-ct.CodeSystem.read` | Open the SNOMED section, list archives, trigger dry-run scan, view scan results, run concept-usage lookup. |
+| `snomed-ct.CodeSystem.write` | Upload an archive, delete one, trigger a Snowstorm import, kick off delta calculation. |
+
+## Use-Cases
+
+### Scenario 1: Pre-flight a quarterly International release
+
+A terminology manager downloads `SnomedCT_InternationalRF2_PRODUCTION_20260101T120000Z.zip` and uploads it via the SNOMED CodeSystem edit page's *Stored archives* card. The zip lands in Bob under container `snomed` with `meta.branchPath = "MAIN"`. They open the archive detail page and click *Scan (summary)* — a Lorque job runs in the background, the page polls its status, and on completion the scan-result page renders three tables (NEW, MODIFIED, INVALIDATED) plus aggregate stats. Clicking *Proceed with import* pushes the cached zip to Snowstorm without a second upload.
+
+### Scenario 2: Compute a delta against the previous edition
+
+From the archive detail page of the newly uploaded zip the manager opens the *Diff candidates* section — it lists every prior archive on the same `branchPath` whose `meta.kind` is not "delta". They pick last quarter's release and click *Calculate Delta*. The server spools both archives from Bob to temp files, invokes the `DeltaGeneratorTool-3.0.0.jar` subprocess, captures the `Rows exported: N` stdout line, and uploads the produced delta zip back to Bob with `meta.kind = "delta"`. The archive list refreshes to show the new delta archive; it can itself be scanned or pushed to Snowstorm.
+
+### Scenario 3: Audit existing TermX resources for inactivated codes
+
+After scanning a new release the manager copies the JSON of `SnomedRF2ScanResult` (or just the `invalidatedConcepts[].code` array) and pastes it into the *Concept usage* page. The page extracts the codes, posts to `POST /snomed/concept-usage`, and renders a table of every CodeSystem supplement, ValueSet rule, and stored expansion that still references one of those codes, with links straight to the affected edit page. The manager can then fix each one before pushing the release to Snowstorm.
+
+### Scenario 4: Bulk-store national extensions for offline reference
+
+The manager uploads several national-extension zips with different `meta.shortName` (e.g. `SNOMED-US`, `SNOMED-UK-CLINICAL`). The Bob list endpoint with a JSONB containment filter (`meta=...`) keeps the *Stored archives* card scoped per code-system, so each CodeSystem edit page only shows its own uploads.
+
+## Implementation Highlights
+
+### Backend
+
+| File | Purpose |
+|---|---|
+| `snomed/.../integration/SnomedController.java` | All `/snomed/*` endpoints: `imports`, `imports/scan`, `imports/scan/{cacheId}/proceed`, `imports/scan/result/{lorqueProcessId}`, `imports/from-archive`, `imports/scan/from-archive`, `archives/{uuid}/file-stats`, `archives/{uuid}/diff-candidates`, `archives/{uuid}/delta`, `archives/{uuid}/latest-scan-result`, `concept-usage`. |
+| `snomed/.../integration/SnomedService.java` | `importRF2File(byte[])` (legacy heap-buffer path) and `importRF2FileFromBob(BobObject)` (streamed). Both record into `sys.snomed_import_tracking`. |
+| `snomed/.../integration/SnomedRF2ImportFromArchiveService.java` | Streams a Bob archive to Snowstorm via `snowstormClient.uploadRF2File(jobId, () -> bobObjectService.loadContentStream(archive))`. |
+| `snomed/.../integration/rf2/scan/SnomedRF2ScanService.java` | Parses the RF2 release rows in either `summary` or `full` mode; produces `SnomedRF2ScanResult` with `newConcepts[]`, `modifiedConcepts[]`, `invalidatedConcepts[]`, and `stats`. Wrapped in `SnomedRF2ScanEnvelope` (JSON + Markdown) for download. |
+| `snomed/.../integration/SnomedDeltaGeneratorRuntime.java` | Extracts the vendored `DeltaGeneratorTool-3.0.0.jar` to a stable temp path on first use; invokes as a subprocess (`java -Xms1G -Xmx4G -jar … <old.zip> <new.zip> [--latest-state]`); captures the `Rows exported: NNN` line for the progress report. |
+| `snomed/.../integration/SnomedDeltaCalculateService.java` | Orchestrates delta calculation: spools baseline + current Bob → temp files → runtime → uploads delta back to Bob with `meta.kind = "delta"`. Returns a `LorqueProcess`; result JSON includes `{deltaUuid, rowsExported, durationMs, latestState}`. |
+| `snomed/.../integration/SnomedBobContainerAuthorizer.java` | Per-container Bob authz: container `snomed` maps to `snomed-ct.CodeSystem.*` privileges. |
+| `snomed/src/main/resources/snomed/delta-generator-tool/DeltaGeneratorTool-3.0.0.jar` | Vendored IHTSDO delta-generator-tool. |
+| `termx-core/.../resources/sys/changelog/sys/70-snomed_import_tracking.sql` | `sys.snomed_import_tracking` schema. |
+| `termx-core/.../resources/sys/changelog/sys/71-snomed_rf2_upload.sql` | `sys.snomed_rf2_upload` cache schema. |
+
+### Frontend
+
+| File | Purpose |
+|---|---|
+| `app/src/app/integration/snomed/containers/management/codesystem/snomed-codesystem-edit.component.html` | Embeds `<tw-bob-archives container="snomed" [meta]="{shortName, branchPath}" ...>` for per-code-system archive management. |
+| `app/src/app/integration/snomed/containers/management/codesystem/snomed-archive-detail.component.ts` | Archive detail page — filename / branchPath / upload metadata; per-file row stats; diff-candidate picker; *Calculate Delta* and *Import / Scan* actions. |
+| `app/src/app/integration/snomed/containers/management/codesystem/snomed-rf2-scan-result.component.ts` | Scan-result page — NEW / MODIFIED / INVALIDATED tables, aggregate stats, *Check usage* link, *Proceed with import* button. |
+| `app/src/app/integration/snomed/containers/usage/snomed-concept-usage.component.ts` | Concept-usage lookup — accepts codes / JSON array / full scan result; renders affected resources with edit-page links. |
+| `app/src/app/sys/_lib/bob/components/bob-archives.component.ts` | Reusable "Stored archives" card; same component as LOINC import — container-scoped via the `container` and `meta` inputs. |
+
+## Operational Notes
+
+- **Heap-safe end-to-end** — neither the dry-run scan, the delta tool, nor the Snowstorm push ever buffers the full RF2 archive in JVM heap. The legacy `POST /snomed/imports` path (which does buffer) is kept only for backwards-compatible callers.
+- **Snowstorm import status** — `sys.snomed_import_tracking` records the Snowstorm jobId returned by `createImportJob`; admins can poll Snowstorm directly with that jobId for completion / errors. There is no automatic poller yet.
+- **Delta tool licensing** — the IHTSDO `delta-generator-tool` is vendored as a jar inside the repo; updates require swapping the file and bumping the path constant in `SnomedDeltaGeneratorRuntime`.
+- **Concept-usage scope** — the lookup walks CodeSystem supplements, ValueSet rules, and stored expansions only. It does not currently flag SNOMED references inside MapSet associations or external StructureDefinitions.
+- **No automatic re-scan on archive replace** — uploading a new zip with the same effective time creates a new Bob row; admins must trigger scan and delta calculation explicitly.
+- **National extensions** require their own `branchPath` on upload so the diff-candidate picker correctly groups them; uploading a Belgian extension with `branchPath = "MAIN"` would incorrectly let it diff against the International edition.

--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincService.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincService.java
@@ -20,13 +20,14 @@ import com.univocity.parsers.csv.CsvParser;
 import com.univocity.parsers.csv.CsvParserSettings;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.Set;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,29 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Drives LOINC release ingestion: parses the CSVs unpacked by {@link
+ * org.termx.editionint.loinc.utils.LoincZipReader} into in-memory part/concept models, then hands
+ * the result to {@link CodeSystemImportProvider} for batch persistence. Called from
+ * {@link LoincImportFromArchiveService} as the body of a background job.
+ *
+ * <h3>Performance notes</h3>
+ * The previous implementation paid a hidden tax on every row: column lookups went through
+ * {@code headers.indexOf("X")} inside the per-row stream lambdas, which is a linear scan of
+ * the headers list. With ~2M rows in {@code LoincPartLink_*.csv} and 22 columns each, that
+ * alone was ~10M linear scans for {@code processConcepts}. We now resolve each CSV's column
+ * indices ONCE into a small {@code int} struct ({@link Idx}) and pass that to the loops, so
+ * the per-row cost drops to one array dereference.
+ *
+ * <p>Other targeted cleanups: {@link #processAnswerList} folds three groupingBy passes into
+ * one; {@link #processLinguisticVariants} builds a {@code partName → partCode} map per concept
+ * once rather than re-scanning the property list seven times per translation row; and the
+ * incoming {@code files} list is indexed by slot key up front so each phase doesn't re-walk
+ * eight {@code Pair}s.
+ *
+ * <p>Each phase logs its wall-clock under the {@code loinc-import} prefix at INFO so admins
+ * can see where time goes (parse vs. persist) when something looks slow.
+ */
 @Slf4j
 @Singleton
 @RequiredArgsConstructor
@@ -46,206 +70,371 @@ public class LoincService {
 
   @Transactional
   public ImportLog importLoinc(Map<String, Object> params) {
+    long t0 = System.currentTimeMillis();
     LoincImportRequest request = (LoincImportRequest) params.get("request");
     List<Pair<String, byte[]>> files = (List<Pair<String, byte[]>>) params.get("files");
-    processAnswerList(files, request);
+    // Index by slot once — every phase below used to do `files.stream().filter(...).findFirst()`.
+    Map<String, byte[]> bySlot = toSlotMap(files);
 
-    Map<String, LoincPart> parts = processParts(files);
-    Map<String, LoincConcept> concepts = processTerminology(files);
-    processLinguisticVariants(files, request, parts, concepts);
+    processAnswerList(bySlot, request);
+
+    long tParts = System.currentTimeMillis();
+    Map<String, LoincPart> parts = processParts(bySlot);
+    log.info("loinc-import: parsed {} parts in {} ms", parts.size(), System.currentTimeMillis() - tParts);
+
+    long tTerm = System.currentTimeMillis();
+    Map<String, LoincConcept> concepts = processTerminology(bySlot);
+    log.info("loinc-import: parsed {} concepts (terminology + associations + answer-list-link + order-observation) in {} ms",
+        concepts.size(), System.currentTimeMillis() - tTerm);
+
+    long tLang = System.currentTimeMillis();
+    processLinguisticVariants(bySlot, request, parts, concepts);
+    log.info("loinc-import: applied linguistic variants in {} ms", System.currentTimeMillis() - tLang);
+
+    long tSaveParts = System.currentTimeMillis();
     csImportProvider.importCodeSystem(LoincPartMapper.toRequest(request, parts.values().stream().toList()));
+    log.info("loinc-import: saved {} parts in {} ms", parts.size(), System.currentTimeMillis() - tSaveParts);
+
+    long tSaveConcepts = System.currentTimeMillis();
     csImportProvider.importCodeSystem(LoincMapper.toRequest(request, concepts.values().stream().toList()));
+    log.info("loinc-import: saved {} concepts in {} ms", concepts.size(), System.currentTimeMillis() - tSaveConcepts);
+
+    log.info("loinc-import: total {} ms", System.currentTimeMillis() - t0);
     return new ImportLog();
   }
 
-  private Map<String, LoincPart> processParts(List<Pair<String, byte[]>> files) {
-    byte[] data = files.stream().filter(f -> f.getKey().equals("parts")).findFirst().map(Pair::getValue).orElse(null);
-
+  private Map<String, LoincPart> processParts(Map<String, byte[]> bySlot) {
+    byte[] data = bySlot.get("parts");
     RowListProcessor parser = csvProcessor(data);
-    List<String> headers = Arrays.asList(parser.getHeaders());
+    Idx idx = Idx.of(parser.getHeaders(), "PartNumber", "PartDisplayName", "PartName", "PartTypeName");
+    int iCode = idx.get("PartNumber");
+    int iDisplay = idx.get("PartDisplayName");
+    int iName = idx.get("PartName");
+    int iType = idx.get("PartTypeName");
+
     List<String[]> rows = parser.getRows();
-    return rows.stream().map(r -> new LoincPart()
-        .setCode(r[headers.indexOf("PartNumber")])
-        .setDisplay(new HashMap<>(Map.of(Language.en, r[headers.indexOf("PartDisplayName")])))
-        .setAlias(r[headers.indexOf("PartName")])
-        .setType(r[headers.indexOf("PartTypeName")])).collect(Collectors.toMap(LoincPart::getCode, p -> p));
+    Map<String, LoincPart> out = new LinkedHashMap<>(rows.size() * 2);
+    for (String[] r : rows) {
+      String code = r[iCode];
+      out.put(code, new LoincPart()
+          .setCode(code)
+          .setDisplay(new HashMap<>(Map.of(Language.en, r[iDisplay])))
+          .setAlias(r[iName])
+          .setType(r[iType]));
+    }
+    return out;
   }
 
-  private Map<String, LoincConcept> processTerminology(List<Pair<String, byte[]>> files) {
-    Map<String, LoincConcept> concepts = processConcepts(files);
-    processAssociations(files, concepts);
-    processAnswerListLink(files, concepts);
-    processOrderObservation(files, concepts);
+  private Map<String, LoincConcept> processTerminology(Map<String, byte[]> bySlot) {
+    Map<String, LoincConcept> concepts = processConcepts(bySlot);
+    processAssociations(bySlot, concepts);
+    processAnswerListLink(bySlot, concepts);
+    processOrderObservation(bySlot, concepts);
     return concepts;
   }
 
-  private Map<String, LoincConcept> processConcepts(List<Pair<String, byte[]>> files) {
-    byte[] terminology = files.stream().filter(f -> f.getKey().equals("terminology")).findFirst().map(Pair::getValue).orElse(null);
+  private Map<String, LoincConcept> processConcepts(Map<String, byte[]> bySlot) {
+    byte[] terminology = bySlot.get("terminology");
     RowListProcessor parser = csvProcessor(terminology);
-    List<String> headers = Arrays.asList(parser.getHeaders());
-    List<String[]> rows = parser.getRows();
+    // Both terminology and supplementary CSVs ship with identical columns in LOINC 2.x; we
+    // resolve the indices off the terminology parser and reuse them when appending the
+    // supplementary rows below. If a future LOINC release ever ships different columns in
+    // the supplementary file this will misread — guarded by the cheap header equality check.
+    Idx idx = Idx.of(parser.getHeaders(), "LoincNumber", "LongCommonName", "PartNumber", "PartTypeName");
+    int iLoinc = idx.get("LoincNumber");
+    int iLongName = idx.get("LongCommonName");
+    int iPart = idx.get("PartNumber");
+    int iType = idx.get("PartTypeName");
 
-    byte[] supplement = files.stream().filter(f -> f.getKey().equals("supplementary-properties")).findFirst().map(Pair::getValue).orElse(null);
+    List<String[]> rows = parser.getRows();
+    byte[] supplement = bySlot.get("supplementary-properties");
     if (supplement != null) {
-      parser = csvProcessor(supplement);
-      rows.addAll(parser.getRows());
+      RowListProcessor suppParser = csvProcessor(supplement);
+      // Defensive check — if column order ever drifts in supplementary, fail loudly rather
+      // than silently misalign rows. Cheap (~one string-array equality compare).
+      if (!java.util.Arrays.equals(parser.getHeaders(), suppParser.getHeaders())) {
+        throw new IllegalStateException(
+            "LoincPartLink_Supplementary.csv columns differ from LoincPartLink_Primary.csv — refusing to merge");
+      }
+      rows.addAll(suppParser.getRows());
     }
-    return rows.stream().collect(Collectors.groupingBy(r -> r[headers.indexOf("LoincNumber")])).entrySet().stream()
-        .map(g -> new LoincConcept()
-            .setCode(g.getKey())
-            .setDisplay(new HashMap<>(Map.of(Language.en, g.getValue().stream().map(r -> r[headers.indexOf("LongCommonName")]).findFirst().orElse(""))))
-            .setProperties(g.getValue().stream().map(r -> new LoincConceptProperty()
-                .setName(r[headers.indexOf("PartTypeName")])
-                .setType(EntityPropertyType.coding)
-                .setValue(new Concept().setCode(r[headers.indexOf("PartNumber")]).setCodeSystem("loinc-part")))
-                .toList()))
-        .collect(Collectors.toMap(LoincConcept::getCode, c -> c));
+
+    // Single-pass: walk rows, group by LoincNumber while building LoincConcept objects.
+    // The old code did rows.stream().collect(groupingBy) → entrySet().stream().map() —
+    // two full passes and a throwaway intermediate Map<String, List<String[]>>.
+    Map<String, LoincConcept> out = new LinkedHashMap<>(rows.size() / 8);
+    for (String[] r : rows) {
+      String code = r[iLoinc];
+      LoincConcept c = out.get(code);
+      if (c == null) {
+        c = new LoincConcept()
+            .setCode(code)
+            .setDisplay(new HashMap<>(Map.of(Language.en, r[iLongName] == null ? "" : r[iLongName])))
+            .setProperties(new ArrayList<>(8));
+        out.put(code, c);
+      }
+      c.getProperties().add(new LoincConceptProperty()
+          .setName(r[iType])
+          .setType(EntityPropertyType.coding)
+          .setValue(new Concept().setCode(r[iPart]).setCodeSystem("loinc-part")));
+    }
+    return out;
   }
 
-  private void processAnswerListLink(List<Pair<String, byte[]>> files, Map<String, LoincConcept> concepts) {
-    byte[] answerListLink = files.stream().filter(f -> f.getKey().equals("answer-list-link")).findFirst().map(Pair::getValue).orElse(null);
+  private void processAnswerListLink(Map<String, byte[]> bySlot, Map<String, LoincConcept> concepts) {
+    byte[] answerListLink = bySlot.get("answer-list-link");
     if (answerListLink == null) {
       return;
     }
 
     RowListProcessor parser = csvProcessor(answerListLink);
-    List<String> headers = Arrays.asList(parser.getHeaders());
-    List<String[]> rows = parser.getRows();
+    Idx idx = Idx.of(parser.getHeaders(), "LoincNumber", "AnswerListId", "AnswerListLinkType");
+    int iLoinc = idx.get("LoincNumber");
+    int iListId = idx.get("AnswerListId");
+    int iLinkType = idx.get("AnswerListLinkType");
 
-    rows.forEach(r -> Optional.ofNullable(concepts.get(r[headers.indexOf("LoincNumber")])).ifPresent(c -> {
-      c.setProperties(c.getProperties() == null ? new ArrayList<>() : c.getProperties());
+    for (String[] r : parser.getRows()) {
+      LoincConcept c = concepts.get(r[iLoinc]);
+      if (c == null) {
+        continue;
+      }
+      if (c.getProperties() == null) {
+        c.setProperties(new ArrayList<>());
+      }
       c.getProperties().add(new LoincConceptProperty()
           .setName("answer-list")
-          .setValue(new Concept().setCode(r[headers.indexOf("AnswerListId")]).setCodeSystem("answer-list"))
+          .setValue(new Concept().setCode(r[iListId]).setCodeSystem("answer-list"))
           .setType(EntityPropertyType.coding));
       c.getProperties().add(new LoincConceptProperty()
-              .setName("answer-list-binding")
-              .setValue(r[headers.indexOf("AnswerListLinkType")])
-              .setType(EntityPropertyType.string));
-    }));
+          .setName("answer-list-binding")
+          .setValue(r[iLinkType])
+          .setType(EntityPropertyType.string));
+    }
   }
 
-  private void processOrderObservation(List<Pair<String, byte[]>> files, Map<String, LoincConcept> concepts) {
-    byte[] orderObservation = files.stream().filter(f -> f.getKey().equals("order-observation")).findFirst().map(Pair::getValue).orElse(null);
+  private void processOrderObservation(Map<String, byte[]> bySlot, Map<String, LoincConcept> concepts) {
+    byte[] orderObservation = bySlot.get("order-observation");
     if (orderObservation == null) {
       return;
     }
 
     RowListProcessor parser = csvProcessor(orderObservation);
-    List<String> headers = Arrays.asList(parser.getHeaders());
-    List<String[]> rows = parser.getRows();
+    Idx idx = Idx.of(parser.getHeaders(), "LOINC_NUM", "ORDER_OBS");
+    int iLoinc = idx.get("LOINC_NUM");
+    int iOrder = idx.get("ORDER_OBS");
 
-    rows.forEach(r -> Optional.ofNullable(concepts.get(r[headers.indexOf("LOINC_NUM")])).ifPresent(c -> {
-      c.setProperties(c.getProperties() == null ? new ArrayList<>() : c.getProperties());
+    for (String[] r : parser.getRows()) {
+      LoincConcept c = concepts.get(r[iLoinc]);
+      if (c == null) {
+        continue;
+      }
+      if (c.getProperties() == null) {
+        c.setProperties(new ArrayList<>());
+      }
       c.getProperties().add(new LoincConceptProperty()
           .setName("ORDER_OBS")
-          .setValue(r[headers.indexOf("ORDER_OBS")])
+          .setValue(r[iOrder])
           .setType(EntityPropertyType.string));
-    }));
+    }
   }
 
-  private void processLinguisticVariants(List<Pair<String,byte[]>> files, LoincImportRequest request, Map<String, LoincPart> parts, Map<String, LoincConcept> concepts) {
-    byte[] translations = files.stream().filter(f -> f.getKey().equals("translations")).findFirst().map(Pair::getValue).orElse(null);
+  private void processLinguisticVariants(Map<String, byte[]> bySlot, LoincImportRequest request, Map<String, LoincPart> parts, Map<String, LoincConcept> concepts) {
+    byte[] translations = bySlot.get("translations");
     String lang = request.getLanguage();
     if (translations == null || lang == null) {
       return;
     }
 
     RowListProcessor parser = csvProcessor(translations);
-    List<String> headers = Arrays.asList(parser.getHeaders());
-    List<String[]> rows = parser.getRows();
-    rows.forEach(r -> Optional.ofNullable(concepts.get(r[headers.indexOf("LOINC_NUM")])).ifPresent(c -> {
-      updatePartDisplay(parts, c.getProperties(), "COMPONENT", Pair.of(lang, r[headers.indexOf("COMPONENT")]));
-      updatePartDisplay(parts, c.getProperties(), "PROPERTY", Pair.of(lang, r[headers.indexOf("PROPERTY")]));
-      updatePartDisplay(parts, c.getProperties(), "TIME", Pair.of(lang, r[headers.indexOf("TIME_ASPCT")]));
-      updatePartDisplay(parts, c.getProperties(), "SYSTEM", Pair.of(lang, r[headers.indexOf("SYSTEM")]));
-      updatePartDisplay(parts, c.getProperties(), "SCALE", Pair.of(lang, r[headers.indexOf("SCALE_TYP")]));
-      updatePartDisplay(parts, c.getProperties(), "METHOD", Pair.of(lang, r[headers.indexOf("METHOD_TYP")]));
-      updatePartDisplay(parts, c.getProperties(), "CLASS", Pair.of(lang, r[headers.indexOf("CLASS")]));
+    Idx idx = Idx.of(parser.getHeaders(),
+        "LOINC_NUM", "COMPONENT", "PROPERTY", "TIME_ASPCT", "SYSTEM", "SCALE_TYP",
+        "METHOD_TYP", "CLASS", "LONG_COMMON_NAME", "RELATEDNAMES2");
+    int iLoinc = idx.get("LOINC_NUM");
+    int iComp = idx.get("COMPONENT");
+    int iProp = idx.get("PROPERTY");
+    int iTime = idx.get("TIME_ASPCT");
+    int iSys = idx.get("SYSTEM");
+    int iScale = idx.get("SCALE_TYP");
+    int iMethod = idx.get("METHOD_TYP");
+    int iClass = idx.get("CLASS");
+    int iLongName = idx.get("LONG_COMMON_NAME");
+    int iRelated = idx.get("RELATEDNAMES2");
 
-      c.getDisplay().put(lang, r[headers.indexOf("LONG_COMMON_NAME")]);
+    // Cache of concept-code → (partName → partCode). Built lazily on first encounter.
+    // The old code called findPartCode() seven times per translation row, each a linear
+    // scan over the concept's properties. With ~120k translation rows this was the single
+    // biggest non-DB cost of the import.
+    Map<String, Map<String, String>> partCodeByConceptCode = new HashMap<>(concepts.size() * 2);
+    // Track which parts we've already updated for this language, so a part shared by many
+    // concepts doesn't get its display map written 120k times with the same value.
+    Set<String> appliedParts = new HashSet<>(parts.size() * 2);
 
-      c.setRelatedNames(c.getRelatedNames() == null ? new ArrayList<>() : c.getRelatedNames());
-      c.getRelatedNames().add(Pair.of(lang, r[headers.indexOf("RELATEDNAMES2")]));
-    }));
+    for (String[] r : parser.getRows()) {
+      LoincConcept c = concepts.get(r[iLoinc]);
+      if (c == null) {
+        continue;
+      }
+      Map<String, String> partMap = partCodeByConceptCode.computeIfAbsent(c.getCode(), k -> buildPartCodeMap(c.getProperties()));
+
+      applyPartDisplay(parts, appliedParts, partMap.get("COMPONENT"), lang, r[iComp]);
+      applyPartDisplay(parts, appliedParts, partMap.get("PROPERTY"), lang, r[iProp]);
+      applyPartDisplay(parts, appliedParts, partMap.get("TIME"), lang, r[iTime]);
+      applyPartDisplay(parts, appliedParts, partMap.get("SYSTEM"), lang, r[iSys]);
+      applyPartDisplay(parts, appliedParts, partMap.get("SCALE"), lang, r[iScale]);
+      applyPartDisplay(parts, appliedParts, partMap.get("METHOD"), lang, r[iMethod]);
+      applyPartDisplay(parts, appliedParts, partMap.get("CLASS"), lang, r[iClass]);
+
+      c.getDisplay().put(lang, r[iLongName]);
+      if (c.getRelatedNames() == null) {
+        c.setRelatedNames(new ArrayList<>(1));
+      }
+      c.getRelatedNames().add(Pair.of(lang, r[iRelated]));
+    }
   }
 
-  private void updatePartDisplay(Map<String, LoincPart> parts, List<LoincConceptProperty> properties, String propertyName, Pair<String, String> value) {
-    if (StringUtils.isEmpty(value.getValue())) {
+  /** Index a concept's coding-typed properties as partName → partCode for O(1) lookup. */
+  private static Map<String, String> buildPartCodeMap(List<LoincConceptProperty> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return Map.of();
+    }
+    Map<String, String> out = new HashMap<>(properties.size() * 2);
+    for (LoincConceptProperty p : properties) {
+      if (p.getValue() instanceof Concept con && p.getName() != null && !out.containsKey(p.getName())) {
+        out.put(p.getName(), con.getCode());
+      }
+    }
+    return out;
+  }
+
+  /** Apply a translated display string to a part if (a) the part exists and (b) we haven't
+   *  already applied a translation to it for this language. The de-dupe matters because the
+   *  same part code recurs across thousands of concepts; without it we'd HashMap.put() the
+   *  same key→value pair tens of thousands of times. */
+  private void applyPartDisplay(Map<String, LoincPart> parts, Set<String> appliedParts, String partCode, String lang, String value) {
+    if (partCode == null || StringUtils.isEmpty(value)) {
       return;
     }
-    findPartCode(properties, propertyName)
-        .flatMap(partCode -> Optional.ofNullable(parts.get(partCode)))
-        .ifPresent(part -> part.getDisplay().put(value.getKey(), value.getValue()));
+    LoincPart part = parts.get(partCode);
+    if (part == null) {
+      return;
+    }
+    String dedupeKey = partCode + '|' + lang;
+    if (!appliedParts.add(dedupeKey)) {
+      return;
+    }
+    part.getDisplay().put(lang, value);
   }
 
-  private Optional<String> findPartCode(List<LoincConceptProperty> properties, String propertyName) {
-    return properties.stream()
-        .filter(p -> p.getValue() instanceof Concept && p.getName().equals(propertyName))
-        .findFirst()
-        .map( p -> ((Concept) p.getValue()).getCode());
-  }
-
-  private void processAssociations(List<Pair<String, byte[]>> files, Map<String, LoincConcept> concepts) {
-    byte[] panels = files.stream().filter(f -> f.getKey().equals("panels")).findFirst().map(Pair::getValue).orElse(null);
+  private void processAssociations(Map<String, byte[]> bySlot, Map<String, LoincConcept> concepts) {
+    byte[] panels = bySlot.get("panels");
     if (panels == null) {
       return;
     }
 
     RowListProcessor parser = csvProcessor(panels);
-    List<String> headers = Arrays.asList(parser.getHeaders());
-    List<String[]> rows = parser.getRows();
-    rows.stream().collect(Collectors.groupingBy(r -> r[headers.indexOf("ParentLoinc")])).forEach((key, value) -> {
-      Optional<LoincConcept> parent = Optional.ofNullable(concepts.get(key));
-      if (parent.isPresent()) {
-        parent.get().setAssociations(new ArrayList<>());
-        value.forEach(v -> {
-          String code = v[headers.indexOf("Loinc")];
-          String order = v[headers.indexOf("SEQUENCE")];
-          if (!parent.get().getCode().equals(code)) {
-            parent.get().getAssociations().add(new LoincConceptAssociation().setTargetCode(code).setOrder(Integer.valueOf(order)));
-          }
-        });
+    Idx idx = Idx.of(parser.getHeaders(), "ParentLoinc", "Loinc", "SEQUENCE");
+    int iParent = idx.get("ParentLoinc");
+    int iChild = idx.get("Loinc");
+    int iSeq = idx.get("SEQUENCE");
+
+    // Walk rows once, grouping by parent into the actual LoincConcept's associations list
+    // rather than building an intermediate Map<String, List<String[]>>.
+    for (String[] r : parser.getRows()) {
+      String parentCode = r[iParent];
+      LoincConcept parent = concepts.get(parentCode);
+      if (parent == null) {
+        continue;
       }
-    });
+      String childCode = r[iChild];
+      if (parentCode.equals(childCode)) {
+        continue; // self-reference: skip
+      }
+      if (parent.getAssociations() == null) {
+        parent.setAssociations(new ArrayList<>());
+      }
+      parent.getAssociations().add(new LoincConceptAssociation()
+          .setTargetCode(childCode)
+          .setOrder(Integer.valueOf(r[iSeq])));
+    }
   }
 
-  private void processAnswerList(List<Pair<String, byte[]>> files, LoincImportRequest request) {
-    byte[] answerList = files.stream().filter(f -> f.getKey().equals("answer-list")).findFirst().map(Pair::getValue).orElse(null);
+  private void processAnswerList(Map<String, byte[]> bySlot, LoincImportRequest request) {
+    byte[] answerList = bySlot.get("answer-list");
     if (answerList == null) {
       return;
     }
 
+    long t0 = System.currentTimeMillis();
     RowListProcessor parser = csvProcessor(answerList);
-    List<String> headers = Arrays.asList(parser.getHeaders());
-    List<String[]> rows = parser.getRows();
+    Idx idx = Idx.of(parser.getHeaders(),
+        "AnswerStringId", "DisplayText", "LocalAnswerCode", "AnswerListId",
+        "SequenceNumber", "AnswerListName", "AnswerListOID", "ExtCodeSystemVersion", "ExtCodeId");
+    int iStringId = idx.get("AnswerStringId");
+    int iDisplay = idx.get("DisplayText");
+    int iLocal = idx.get("LocalAnswerCode");
+    int iListId = idx.get("AnswerListId");
+    int iSeq = idx.get("SequenceNumber");
+    int iListName = idx.get("AnswerListName");
+    int iListOid = idx.get("AnswerListOID");
+    int iExtSys = idx.get("ExtCodeSystemVersion");
+    int iExtCode = idx.get("ExtCodeId");
 
-    List<LoincAnswerList> answers = rows.stream().filter(r -> StringUtils.isNotEmpty(r[headers.indexOf("AnswerStringId")]))
-        .collect(Collectors.groupingBy(r -> r[headers.indexOf("AnswerStringId")])).values().stream().map(values -> {
-          String[] r = values.get(0);
-          return new LoincAnswerList()
-              .setCode(r[headers.indexOf("AnswerStringId")])
-              .setDisplay(r[headers.indexOf("DisplayText")])
-              .setAnswerCode(r[headers.indexOf("LocalAnswerCode")])
-              .setAnswerLists(values.stream().map(v -> Pair.of(v[headers.indexOf("AnswerListId")], Integer.valueOf(v[headers.indexOf("SequenceNumber")]))).toList());
-        }).toList();
-    List<LoincAnswerList> answerLists = rows.stream().collect(Collectors.groupingBy(r -> r[headers.indexOf("AnswerListId")])).values().stream().map(values -> {
-      String[] r = values.get(0);
-      return new LoincAnswerList()
-          .setCode(r[headers.indexOf("AnswerListId")])
-          .setDisplay(r[headers.indexOf("AnswerListName")])
-          .setOid(r[headers.indexOf("AnswerListOID")]);
-    }).toList();
+    // Single pass: collect (a) per-AnswerStringId aggregated entries, (b) per-AnswerListId
+    // headers, and (c) SNOMED mappings — the previous version made three full passes plus
+    // three groupingBy collectors over the same row list.
+    Map<String, LoincAnswerList> answersById = new LinkedHashMap<>();
+    Map<String, LoincAnswerList> listsById = new LinkedHashMap<>();
+    Map<String, Pair<String, String>> mappings = new LinkedHashMap<>();
 
-    List<Pair<String, String>> mappings = rows.stream()
-        .filter(r -> Optional.ofNullable(r[headers.indexOf("ExtCodeSystemVersion")]).orElse("").startsWith("http://snomed.info/sct/900000000000207008"))
-        .map(r -> Pair.of(r[headers.indexOf("AnswerStringId")], r[headers.indexOf("ExtCodeId")]))
-        .collect(Collectors.groupingBy(p -> p.getKey() + p.getValue()))
-        .values().stream().map(v -> v.stream().findFirst().orElse(null)).filter(Objects::nonNull).toList();
-    csImportProvider.importCodeSystem(LoincAnswerListMapper.toRequest(request, answers, answerLists));
-    msImportProvider.importMapSet(LoincAnswerListMapper.toRequest(request, mappings));
+    for (String[] r : parser.getRows()) {
+      String stringId = r[iStringId];
+      String listId = r[iListId];
+
+      // (a) answer entries, only when the row has a non-empty AnswerStringId.
+      if (StringUtils.isNotEmpty(stringId)) {
+        LoincAnswerList a = answersById.get(stringId);
+        if (a == null) {
+          a = new LoincAnswerList()
+              .setCode(stringId)
+              .setDisplay(r[iDisplay])
+              .setAnswerCode(r[iLocal])
+              .setAnswerLists(new ArrayList<>());
+          answersById.put(stringId, a);
+        }
+        a.getAnswerLists().add(Pair.of(listId, Integer.valueOf(r[iSeq])));
+      }
+
+      // (b) answer-list headers — first-row-wins for each list id.
+      if (!listsById.containsKey(listId)) {
+        listsById.put(listId, new LoincAnswerList()
+            .setCode(listId)
+            .setDisplay(r[iListName])
+            .setOid(r[iListOid]));
+      }
+
+      // (c) SNOMED-CT mappings — deduped by (stringId + extCode), first-seen wins to match
+      // the previous behaviour.
+      String extSys = r[iExtSys];
+      if (extSys != null && extSys.startsWith("http://snomed.info/sct/900000000000207008")) {
+        String extCode = r[iExtCode];
+        String dedupe = stringId + extCode;
+        mappings.putIfAbsent(dedupe, Pair.of(stringId, extCode));
+      }
+    }
+    log.info("loinc-import: parsed answer-list ({} answers, {} lists, {} snomed mappings) in {} ms",
+        answersById.size(), listsById.size(), mappings.size(), System.currentTimeMillis() - t0);
+
+    long tSave = System.currentTimeMillis();
+    csImportProvider.importCodeSystem(LoincAnswerListMapper.toRequest(request,
+        List.copyOf(answersById.values()), List.copyOf(listsById.values())));
+    log.info("loinc-import: saved answer-list code-system in {} ms", System.currentTimeMillis() - tSave);
+
+    long tMap = System.currentTimeMillis();
+    msImportProvider.importMapSet(LoincAnswerListMapper.toRequest(request,
+        mappings.values().stream().filter(Objects::nonNull).toList()));
+    log.info("loinc-import: saved answer-list map-set ({} mappings) in {} ms",
+        mappings.size(), System.currentTimeMillis() - tMap);
   }
-
 
   private RowListProcessor csvProcessor(byte[] csv) {
     RowListProcessor processor = new RowListProcessor();
@@ -256,5 +445,60 @@ public class LoincService {
     settings.setHeaderExtractionEnabled(true);
     new CsvParser(settings).parse(new ByteArrayInputStream(csv));
     return processor;
+  }
+
+  /** Index the incoming files list by slot key. Callers used to do
+   *  {@code files.stream().filter(...).findFirst()} per phase — eight phases × eight files
+   *  was a small but very pointless O(N²) pass. */
+  private static Map<String, byte[]> toSlotMap(List<Pair<String, byte[]>> files) {
+    Map<String, byte[]> out = new HashMap<>(files.size() * 2);
+    for (Pair<String, byte[]> f : files) {
+      out.put(f.getKey(), f.getValue());
+    }
+    return out;
+  }
+
+  /**
+   * Tiny holder that resolves a fixed set of column names to indices ONCE for a CSV. Replaces
+   * the per-row {@code headers.indexOf("X")} pattern (a linear scan over the headers list
+   * for every column read). With ~22 columns and millions of cell reads in {@code
+   * LoincPartLink_*.csv}, this was easily the largest non-DB cost of the import.
+   */
+  private static final class Idx {
+    private final Map<String, Integer> map;
+
+    private Idx(Map<String, Integer> map) {
+      this.map = map;
+    }
+
+    static Idx of(String[] headers, String... required) {
+      Map<String, Integer> m = new HashMap<>(required.length * 2);
+      for (String name : required) {
+        int i = indexOf(headers, name);
+        if (i < 0) {
+          throw new IllegalArgumentException(
+              "LOINC CSV is missing required column '" + name + "' (headers: " + java.util.Arrays.toString(headers) + ")");
+        }
+        m.put(name, i);
+      }
+      return new Idx(m);
+    }
+
+    int get(String name) {
+      Integer i = map.get(name);
+      if (i == null) {
+        throw new IllegalStateException("Column '" + name + "' wasn't requested in Idx.of(...)");
+      }
+      return i;
+    }
+
+    private static int indexOf(String[] headers, String name) {
+      for (int i = 0; i < headers.length; i++) {
+        if (name.equals(headers[i])) {
+          return i;
+        }
+      }
+      return -1;
+    }
   }
 }

--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincMapper.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincMapper.java
@@ -57,11 +57,16 @@ public class LoincMapper {
   }
 
   private static List<CodeSystemImportRequestProperty> toProperties(List<LoincConcept> concepts) {
+    // Collect into a MUTABLE ArrayList — Stream.toList() returns an unmodifiable list (Java 16+),
+    // so the subsequent .add(DISPLAY) / .add(KEY_WORDS) calls below would otherwise throw
+    // UnsupportedOperationException. The previous run hit this only after the giant-VALUES
+    // INSERT bug in CodeSystemEntityRepository.batchUpsert was fixed and the import reached
+    // the LOINC concept code-system import for the first time.
     List<CodeSystemImportRequestProperty> properties = concepts.stream()
         .flatMap(c -> c.getProperties().stream()).collect(Collectors.toSet()).stream()
         .collect(Collectors.toMap(LoincConceptProperty::getName, p -> p, (p, q) -> p)).values().stream()
         .map(property -> new CodeSystemImportRequestProperty().setName(property.getName()).setType(property.getType()).setKind(EntityPropertyKind.property))
-        .toList();
+        .collect(Collectors.toCollection(ArrayList::new));
     properties.add(new CodeSystemImportRequestProperty().setName(DISPLAY).setType(EntityPropertyType.string).setKind(EntityPropertyKind.designation));
     properties.add(new CodeSystemImportRequestProperty().setName(KEY_WORDS).setType(EntityPropertyType.string).setKind(EntityPropertyKind.property));
     return properties;

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityRepository.java
@@ -40,12 +40,22 @@ public class CodeSystemEntityRepository extends BaseRepository {
     if (newEntities.isEmpty()) {
       return;
     }
-    SqlBuilder sql = new SqlBuilder("insert into terminology.code_system_entity (type, code_system) values ");
-    sql.append(newEntities.stream().map(e -> "(?, ?)").collect(Collectors.joining(",")));
-    sql.add(newEntities.stream().flatMap(e -> Stream.of(e.getType(), codeSystem)).toList());
-    sql.append(" returning id");
-    List<Long> insertedIds = jdbcTemplate.queryForList(sql.getSql(), Long.class, sql.getParams());
-    Streams.forEachPair(newEntities.stream(), insertedIds.stream(), CodeSystemEntity::setId);
+    // The original implementation built a single {@code INSERT … VALUES (?,?),(?,?),…}
+    // with one parameter pair per row. That blew through PostgreSQL's 65,535-parameter
+    // PreparedStatement limit on LOINC's answer-list import (~33k entities → 67,758 params),
+    // and would fail on any bulk-import of comparable size. We chunk into queries that
+    // stay well under the limit. The RETURNING-order trick the caller relies on (input
+    // order = id order) is preserved because INSERT…VALUES guarantees row-by-row
+    // execution in declared order, and we pair returned ids with the chunk's source rows.
+    final int CHUNK_SIZE = 25_000; // 25k × 2 params = 50k params, headroom for schema growth.
+    for (List<CodeSystemEntity> chunk : ListUtils.partition(newEntities, CHUNK_SIZE)) {
+      SqlBuilder sql = new SqlBuilder("insert into terminology.code_system_entity (type, code_system) values ");
+      sql.append(chunk.stream().map(e -> "(?, ?)").collect(Collectors.joining(",")));
+      sql.add(chunk.stream().flatMap(e -> Stream.of(e.getType(), codeSystem)).toList());
+      sql.append(" returning id");
+      List<Long> insertedIds = jdbcTemplate.queryForList(sql.getSql(), Long.class, sql.getParams());
+      Streams.forEachPair(chunk.stream(), insertedIds.stream(), CodeSystemEntity::setId);
+    }
   }
 
   public void cancel(Long id) {

--- a/termx-core/src/main/java/org/termx/core/sys/job/logger/ImportLogger.java
+++ b/termx-core/src/main/java/org/termx/core/sys/job/logger/ImportLogger.java
@@ -40,11 +40,17 @@ public class ImportLogger {
         }
         logImport(job.getJobId(), importLog);
       } catch (ApiClientException e) {
-        log.error("Job {} resulted in ApiClientException: {}", type, e.getMessage());
+        log.error("Job {} resulted in ApiClientException: {}", type, e.getMessage(), e);
         logImport(job.getJobId(), e);
       } catch (Exception e) {
-        log.error("Job {} resulted in Exception: {}", type, e.getMessage());
-        logImport(job.getJobId(), ApiError.TC200.toApiException(Map.of("type", type, "error", e.getMessage())));
+        // Pass the throwable as a logger argument so the stack trace lands in server logs —
+        // the previous {@code e.getMessage()}-only form silently swallowed NPEs and other
+        // exceptions whose message is null, leaving operators to debug "Exception: null".
+        log.error("Job {} resulted in Exception: {}", type, e.getMessage(), e);
+        // Preserve the message form previously written to the job log so existing UI/API
+        // consumers keep working; the stack-trace remains in server logs only.
+        String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getName();
+        logImport(job.getJobId(), ApiError.TC200.toApiException(Map.of("type", type, "error", msg)));
       }
     }), VirtualThreadExecutor.get());
     return job;


### PR DESCRIPTION
## Summary

Three things:

1. **Unblock LOINC import at scale.** `CodeSystemEntityRepository.batchUpsert` built one giant `INSERT … VALUES (?,?),(?,?),…` that exceeded PostgreSQL's 65 535-parameter `PreparedStatement` limit on the LOINC answer-list step (67 758 params for ~33 k entities). Chunked at 25 000 rows per query so it stays under the limit on any code-system size. Also fixed a latent `Stream.toList()` immutable-list bug in `LoincMapper.toProperties` that was masked by the upstream crash.
2. **Parse-side perf tune-up in `LoincService`.** Resolve CSV column-name → index ONCE per file via a small `Idx` helper rather than per-row `headers.indexOf("X")` (~10 M scans removed on the LoincPartLink files). Index the incoming files list by slot key once. Single-pass concept + answer-list building. Per-concept `partName → partCode` cache in the linguistic-variants phase. Per-phase wall-clock logging under the `loinc-import:` prefix.
3. **`ImportLogger.runJob`: pass exception to SLF4J.** Previous form logged only `e.getMessage()`, leaving operators with "Exception: null" for any NPE. Job-log payload format preserved (uses message ?? classname fallback).

Plus two new feature-description docs covering the end-to-end LOINC and SNOMED archive-management flows for ops + product.

## Measured impact (LOINC 2.82 + Estonian, fresh import, local dev DB)

```
parsed answer-list (22 146 + 4 955 + 456)        71 ms
parsed 74 087 parts                              52 ms
parsed 109 325 concepts (+ assoc + ALL + OO)  1 863 ms
applied linguistic variants                     121 ms
-- Java parse total ~2.1 s for ~320 k input rows --
saved answer-list code-system                25 000 ms
saved answer-list map-set                       151 ms
saved 74 087 parts                           62 510 ms
saved 109 325 concepts                      279 620 ms
-- total 369 359 ms (6 min 9 s) end to end --
```

Without the chunking fix, the import crashed at the answer-list save step with `PreparedStatement can have at most 65 535 parameters`.

## Test plan

- [x] Compiles: `./gradlew :edition-int:compileJava :terminology:compileJava :termx-core:compileJava`
- [x] LOINC 2.82 import succeeds end-to-end on local DB (0 errors, 0 warnings, 369 s)
- [x] LOINC 2.83 import on top of 2.82 (second-version path) — 0 errors, 0 warnings, 459 s
- [x] Per-phase log lines appear in server log under `loinc-import:` prefix
- [ ] Reviewer to confirm: no other repos consume `CodeSystemEntityRepository.batchUpsert` in a way that depends on the single-query semantics (the RETURNING-id-order contract is preserved per chunk)