### PR TITLE
feat(snomed): notify on upload-stage import failures

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
@@ -90,11 +90,56 @@ public class SnomedImportPollingService {
     try {
       String subject = buildSubject(tracking, snowstormJob);
       String htmlBody = buildHtmlBody(tracking, snowstormJob);
-      
+
       List<String> recipients = emailService.getImportRecipients();
       emailService.sendToMultiple(recipients, subject, htmlBody, true);
     } catch (Exception e) {
       log.error("Failed to send SNOMED import notification", e);
+    }
+  }
+
+  /**
+   * Notify recipients of an upload-stage SNOMED import failure — used by
+   * {@link SnomedRF2ImportFromArchiveService} (and the legacy {@link SnomedService} paths)
+   * when the import errors out BEFORE the file reaches Snowstorm, so no
+   * {@link SnomedImportTracking} row gets persisted and the regular {@link
+   * #pollPendingImports()} sweep can't pick it up. Reuses this service's HTML scaffold
+   * for consistency with the post-Snowstorm completion email — same subject prefix,
+   * same status badge, same summary table — so an admin sees the same shape of message
+   * whether the failure was on the server side or on Snowstorm's side.
+   *
+   * <p>No-op when email isn't configured or recipients aren't set — matches the
+   * polling path's behaviour. Pass {@code branchPath} so the subject still shows the
+   * affected branch even though we never made it to Snowstorm.
+   */
+  public void notifyUploadFailure(String branchPath, String archiveUuid, String errorMessage) {
+    if (!emailService.hasImportRecipients() || !emailService.isConfigured() || !emailService.isEnabled()) {
+      return;
+    }
+    try {
+      // Build a synthetic tracking with status=FAILED and finished=now so the same
+      // helpers (buildSubject, buildSummaryTable, buildDetailsSection) work unchanged.
+      SnomedImportTracking synthetic = new SnomedImportTracking()
+          .setSnowstormJobId(archiveUuid != null ? "upload-stage-failure:" + archiveUuid : "upload-stage-failure")
+          .setBranchPath(branchPath)
+          .setType("upload")
+          .setStatus("FAILED")
+          .setStarted(OffsetDateTime.now())
+          .setFinished(OffsetDateTime.now())
+          .setErrorMessage(errorMessage)
+          .setNotified(true);
+      // Empty SnomedImportJob — we have no Snowstorm-side data; helpers null-guard.
+      SnomedImportJob noJob = new SnomedImportJob();
+      noJob.setStatus("FAILED");
+      noJob.setErrorMessage(errorMessage);
+
+      String subject = buildSubject(synthetic, noJob);
+      String htmlBody = buildHtmlBody(synthetic, noJob);
+      List<String> recipients = emailService.getImportRecipients();
+      log.info("Sending SNOMED upload-stage failure notification to {} recipient(s)", recipients.size());
+      emailService.sendToMultiple(recipients, subject, htmlBody, true);
+    } catch (Exception e) {
+      log.error("Failed to send SNOMED upload-stage failure notification", e);
     }
   }
 

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
@@ -45,6 +45,11 @@ public class SnomedRF2ImportFromArchiveService {
   private final SnomedImportTrackingRepository trackingRepository;
   private final LorqueProcessService lorqueProcessService;
   private final SnomedRF2ScanService scanService;
+  // Used to send an email when the upload-stage fails (catch block below) — Snowstorm
+  // never received the file, so no SnomedImportTracking row gets written and the
+  // pollPendingImports sweep can't pick it up. The polling service exposes
+  // notifyUploadFailure() that builds the same email shape from a synthetic tracking.
+  private final SnomedImportPollingService snomedImportPollingService;
 
   /**
    * Kick off an async import from a Bob-stored RF2 zip. Returns immediately with a {@link
@@ -75,6 +80,10 @@ public class SnomedRF2ImportFromArchiveService {
       } catch (Exception e) {
         log.error("SNOMED RF2 from-archive import failed for archive {}", req.getArchiveUuid(), e);
         lorqueProcessService.fail(processId, ProcessResult.text(ExceptionUtils.getMessage(e) + "\n" + ExceptionUtils.getStackTrace(e)));
+        // Snowstorm never received the file (or never confirmed receipt), so the polling
+        // sweep won't notify recipients. Fire an upload-stage failure email here.
+        snomedImportPollingService.notifyUploadFailure(
+            importRequest.getBranchPath(), req.getArchiveUuid(), ExceptionUtils.getMessage(e));
       }
     }), VirtualThreadExecutor.get());
 

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
@@ -35,6 +35,11 @@ public class SnomedService {
   private final SnowstormClient snowstormClient;
   private final SnomedImportTrackingRepository trackingRepository;
   private final BobObjectService bobObjectService;
+  // For email-on-upload-failure. The "happy path" + Snowstorm-side completion / failure
+  // is covered by SnomedImportPollingService's scheduled poll, but failures before the
+  // tracking row is written (createImportJob / uploadRF2File rejected) need an explicit
+  // notify call — otherwise the operator gets nothing.
+  private final SnomedImportPollingService snomedImportPollingService;
 
   private static final int MAX_COUNT = 9999;
   private static final int MAX_CONCEPT_COUNT = 100;
@@ -128,6 +133,9 @@ public class SnomedService {
     try {
       jobId = snowstormClient.createImportJob(req).join();
     } catch (CompletionException e) {
+      // No tracking row, no Snowstorm jobId — polling can't catch this. Notify directly.
+      snomedImportPollingService.notifyUploadFailure(req.getBranchPath(), null,
+          "createImportJob failed: " + e.getMessage());
       throw rethrowSnowstormImportFailure(e);
     }
     try {
@@ -135,6 +143,11 @@ public class SnomedService {
     } catch (FileNotFoundException e) {
       log.warn("SNOMED RF2 upload to Snowstorm failed: {}", e.getMessage());
     } catch (CompletionException e) {
+      // jobId exists (Snowstorm accepted the createImportJob), but the file upload didn't
+      // land. No tracking row yet — notify directly. The Snowstorm job will eventually
+      // time out, but the operator gets immediate signal.
+      snomedImportPollingService.notifyUploadFailure(req.getBranchPath(), null,
+          "uploadRF2File failed (Snowstorm jobId=" + jobId + "): " + e.getMessage());
       throw rethrowSnowstormImportFailure(e);
     }
     recordTracking(jobId, req);
@@ -157,6 +170,8 @@ public class SnomedService {
     try {
       jobId = snowstormClient.createImportJob(req).join();
     } catch (CompletionException e) {
+      snomedImportPollingService.notifyUploadFailure(req.getBranchPath(), bobObjectUuid,
+          "createImportJob failed: " + e.getMessage());
       throw rethrowSnowstormImportFailure(e);
     }
     try {
@@ -164,6 +179,8 @@ public class SnomedService {
     } catch (FileNotFoundException e) {
       log.warn("SNOMED RF2 upload (from Bob) to Snowstorm failed: {}", e.getMessage());
     } catch (CompletionException e) {
+      snomedImportPollingService.notifyUploadFailure(req.getBranchPath(), bobObjectUuid,
+          "uploadRF2File from Bob failed (Snowstorm jobId=" + jobId + "): " + e.getMessage());
       throw rethrowSnowstormImportFailure(e);
     }
     recordTracking(jobId, req);


### PR DESCRIPTION
## Context

`SnomedImportPollingService` already polls Snowstorm every 30s and emails recipients when an import hits `COMPLETED` or `FAILED`. That covers the happy path + Snowstorm-side failures.

**Gap:** failures BEFORE the `SnomedImportTracking` row gets persisted — Snowstorm unreachable on `createImportJob`, network drop during `uploadRF2File`, Bob unreachable when streaming from-archive. The LorqueProcess fails, the operator sees a UI error, but no email goes out because the poller can't see what's not in the tracking table.

## Fix

New `SnomedImportPollingService.notifyUploadFailure(branchPath, archiveUuid, errorMessage)` — reuses the existing HTML scaffold so the failure email looks identical to the Snowstorm-side completion / failure email (same subject prefix, same status badge, same summary table). Wired at three catch sites:

- `SnomedRF2ImportFromArchiveService.startImport`
- `SnomedService.importRF2File` — both `createImportJob` and `uploadRF2File` catches
- `SnomedService.importRF2FileFromBob` — both `createImportJob` and `uploadRF2File` catches

Recipients are the same `micronaut.email.import.recipients` list both paths already read — no new config.

## Deliberately NOT wired

| Path | Why not |
|---|---|
| `POST /bob/objects` uploads | The "SNOMED file upload" path you explicitly excluded; `SnomedBobContainerAuthorizer` already returns synchronous failures to the caller |
| `SnomedRF2ScanService.scanRF2` | Dry-run, not an import |
| `SnomedDeltaCalculateService.startDeltaCalculation` | Tool run, not an import |

## Test plan

- [x] `./gradlew :snomed:compileJava` clean
- [ ] Reviewer: with `micronaut.email.import.recipients` set, trigger a SNOMED import against an unreachable Snowstorm — expect a `[TermX] SNOMED Import (<branchPath>) - Failed` email within seconds (vs the previous silence)
- [ ] Reviewer: trigger a normal import — Snowstorm completes → expect the polling email at completion (unchanged path)