### PR TITLE
feat(loinc-import): populate ImportLog.successes for the email notification

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincService.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincService.java
@@ -1,6 +1,7 @@
 package org.termx.editionint.loinc;
 
 import org.termx.core.sys.job.logger.ImportLog;
+import org.termx.ts.codesystem.CodeSystemImportSummary;
 import org.termx.editionint.loinc.utils.LoincConcept;
 import org.termx.editionint.loinc.utils.LoincConcept.LoincConceptAssociation;
 import org.termx.editionint.loinc.utils.LoincConcept.LoincConceptProperty;
@@ -76,31 +77,68 @@ public class LoincService {
     // Index by slot once — every phase below used to do `files.stream().filter(...).findFirst()`.
     Map<String, byte[]> bySlot = toSlotMap(files);
 
-    processAnswerList(bySlot, request);
+    // Capture the per-phase wall-clock and per-CS summary lines so the post-import email
+    // (ImportNotificationService) renders them under "Success Messages" instead of the
+    // blank list it used to show. {@link #logAndCapture} writes the same string to slf4j
+    // AND appends it to this list — single source of truth across logs + email.
+    List<String> successLines = new ArrayList<>();
+
+    CodeSystemImportSummary answerListSummary = processAnswerList(bySlot, request, successLines);
+    if (answerListSummary != null) {
+      successLines.add(formatSummary(answerListSummary));
+    }
 
     long tParts = System.currentTimeMillis();
     Map<String, LoincPart> parts = processParts(bySlot);
-    log.info("loinc-import: parsed {} parts in {} ms", parts.size(), System.currentTimeMillis() - tParts);
+    logAndCapture(successLines, "loinc-import: parsed {} parts in {} ms", parts.size(), System.currentTimeMillis() - tParts);
 
     long tTerm = System.currentTimeMillis();
     Map<String, LoincConcept> concepts = processTerminology(bySlot);
-    log.info("loinc-import: parsed {} concepts (terminology + associations + answer-list-link + order-observation) in {} ms",
+    logAndCapture(successLines,
+        "loinc-import: parsed {} concepts (terminology + associations + answer-list-link + order-observation) in {} ms",
         concepts.size(), System.currentTimeMillis() - tTerm);
 
     long tLang = System.currentTimeMillis();
     processLinguisticVariants(bySlot, request, parts, concepts);
-    log.info("loinc-import: applied linguistic variants in {} ms", System.currentTimeMillis() - tLang);
+    logAndCapture(successLines, "loinc-import: applied linguistic variants in {} ms", System.currentTimeMillis() - tLang);
 
     long tSaveParts = System.currentTimeMillis();
-    csImportProvider.importCodeSystem(LoincPartMapper.toRequest(request, parts.values().stream().toList()));
-    log.info("loinc-import: saved {} parts in {} ms", parts.size(), System.currentTimeMillis() - tSaveParts);
+    CodeSystemImportSummary partsSummary = csImportProvider.importCodeSystem(
+        LoincPartMapper.toRequest(request, parts.values().stream().toList()));
+    logAndCapture(successLines, "loinc-import: saved {} parts in {} ms", parts.size(), System.currentTimeMillis() - tSaveParts);
+    if (partsSummary != null) {
+      successLines.add(formatSummary(partsSummary));
+    }
 
     long tSaveConcepts = System.currentTimeMillis();
-    csImportProvider.importCodeSystem(LoincMapper.toRequest(request, concepts.values().stream().toList()));
-    log.info("loinc-import: saved {} concepts in {} ms", concepts.size(), System.currentTimeMillis() - tSaveConcepts);
+    CodeSystemImportSummary conceptsSummary = csImportProvider.importCodeSystem(
+        LoincMapper.toRequest(request, concepts.values().stream().toList()));
+    logAndCapture(successLines, "loinc-import: saved {} concepts in {} ms", concepts.size(), System.currentTimeMillis() - tSaveConcepts);
+    if (conceptsSummary != null) {
+      successLines.add(formatSummary(conceptsSummary));
+    }
 
-    log.info("loinc-import: total {} ms", System.currentTimeMillis() - t0);
-    return new ImportLog();
+    logAndCapture(successLines, "loinc-import: total {} ms", System.currentTimeMillis() - t0);
+    return new ImportLog().setSuccesses(successLines);
+  }
+
+  /** Render a {@link CodeSystemImportSummary} as the human-readable line that lands in
+   *  the import-completion email under "Success Messages":
+   *  {@code "loinc@2.82: 109 325 concepts (109 325 added, 0 updated)"}. */
+  private static String formatSummary(CodeSystemImportSummary s) {
+    int total = s.getTotalConcepts() == null ? 0 : s.getTotalConcepts();
+    int added = s.getAddedConcepts() == null ? 0 : s.getAddedConcepts();
+    int updated = s.getUpdatedConcepts() == null ? 0 : s.getUpdatedConcepts();
+    return String.format("%s@%s: %,d concepts (%,d added, %,d updated)",
+        s.getCodeSystem(), s.getVersion(), total, added, updated);
+  }
+
+  /** Logs at INFO and also appends the formatted message to {@code capture} (so it ends up
+   *  in {@link ImportLog#getSuccesses()} and ultimately in the post-import email). Mirrors
+   *  the SLF4J {@code {}} placeholder semantics by reusing the parameterised formatter. */
+  private void logAndCapture(List<String> capture, String pattern, Object... args) {
+    log.info(pattern, args);
+    capture.add(org.slf4j.helpers.MessageFormatter.arrayFormat(pattern, args).getMessage());
   }
 
   private Map<String, LoincPart> processParts(Map<String, byte[]> bySlot) {
@@ -358,10 +396,10 @@ public class LoincService {
     }
   }
 
-  private void processAnswerList(Map<String, byte[]> bySlot, LoincImportRequest request) {
+  private CodeSystemImportSummary processAnswerList(Map<String, byte[]> bySlot, LoincImportRequest request, List<String> capture) {
     byte[] answerList = bySlot.get("answer-list");
     if (answerList == null) {
-      return;
+      return null;
     }
 
     long t0 = System.currentTimeMillis();
@@ -421,19 +459,21 @@ public class LoincService {
         mappings.putIfAbsent(dedupe, Pair.of(stringId, extCode));
       }
     }
-    log.info("loinc-import: parsed answer-list ({} answers, {} lists, {} snomed mappings) in {} ms",
+    logAndCapture(capture, "loinc-import: parsed answer-list ({} answers, {} lists, {} snomed mappings) in {} ms",
         answersById.size(), listsById.size(), mappings.size(), System.currentTimeMillis() - t0);
 
     long tSave = System.currentTimeMillis();
-    csImportProvider.importCodeSystem(LoincAnswerListMapper.toRequest(request,
+    CodeSystemImportSummary summary = csImportProvider.importCodeSystem(LoincAnswerListMapper.toRequest(request,
         List.copyOf(answersById.values()), List.copyOf(listsById.values())));
-    log.info("loinc-import: saved answer-list code-system in {} ms", System.currentTimeMillis() - tSave);
+    logAndCapture(capture, "loinc-import: saved answer-list code-system in {} ms", System.currentTimeMillis() - tSave);
 
     long tMap = System.currentTimeMillis();
     msImportProvider.importMapSet(LoincAnswerListMapper.toRequest(request,
         mappings.values().stream().filter(Objects::nonNull).toList()));
-    log.info("loinc-import: saved answer-list map-set ({} mappings) in {} ms",
+    logAndCapture(capture, "loinc-import: saved answer-list map-set ({} mappings) in {} ms",
         mappings.size(), System.currentTimeMillis() - tMap);
+
+    return summary;
   }
 
   private RowListProcessor csvProcessor(byte[] csv) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/providers/TerminologyCodeSystemImportProvider.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/providers/TerminologyCodeSystemImportProvider.java
@@ -1,6 +1,7 @@
 package org.termx.terminology.terminology.codesystem.providers;
 
 import org.termx.terminology.terminology.codesystem.CodeSystemImportService;
+import org.termx.terminology.terminology.codesystem.concept.ConceptService;
 import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService;
 import org.termx.core.ts.CodeSystemImportProvider;
 import org.termx.ts.PublicationStatus;
@@ -10,13 +11,17 @@ import org.termx.ts.codesystem.CodeSystemContent;
 import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemImportAction;
 import org.termx.ts.codesystem.CodeSystemImportRequest;
+import org.termx.ts.codesystem.CodeSystemImportSummary;
 import org.termx.ts.codesystem.CodeSystemVersion;
 import org.termx.ts.codesystem.CodeSystemVersionQueryParams;
 import org.termx.ts.codesystem.Concept;
+import org.termx.ts.codesystem.ConceptQueryParams;
 import org.termx.ts.codesystem.EntityProperty;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 
@@ -25,10 +30,25 @@ import lombok.RequiredArgsConstructor;
 public class TerminologyCodeSystemImportProvider extends CodeSystemImportProvider {
   private final CodeSystemImportService codeSystemImportService;
   private final CodeSystemVersionService codeSystemVersionService;
+  private final ConceptService conceptService;
 
   @Override
-  public void importCodeSystem(CodeSystemImportRequest request) {
+  public CodeSystemImportSummary importCodeSystem(CodeSystemImportRequest request) {
     CodeSystem codeSystem = toCodeSystem(request);
+    // Compute the added / updated split BEFORE the import touches the DB so the email
+    // notification (built from ImportLog.successes in the calling service) can say
+    // "N added, M updated" instead of just "imported". One bulk lookup against
+    // terminology.concept by codeSystem — negligible compared to the actual save.
+    List<String> incomingCodes = codeSystem.getConcepts().stream().map(Concept::getCode).toList();
+    Set<String> preExistingCodes = loadExistingConceptCodes(codeSystem.getId());
+    int added = 0;
+    for (String code : incomingCodes) {
+      if (!preExistingCodes.contains(code)) {
+        added++;
+      }
+    }
+    int updated = incomingCodes.size() - added;
+
     List<AssociationType> associationTypes = toAssociationTypes(request);
     CodeSystemImportAction action = new CodeSystemImportAction()
         .setActivate(request.isActivate())
@@ -36,6 +56,35 @@ public class TerminologyCodeSystemImportProvider extends CodeSystemImportProvide
         .setCleanConceptRun(request.isCleanConceptRun())
         .setGenerateValueSet(request.isGenerateValueSet());
     codeSystemImportService.importCodeSystem(codeSystem, associationTypes, action);
+
+    return new CodeSystemImportSummary()
+        .setCodeSystem(codeSystem.getId())
+        .setVersion(codeSystem.getVersions().getFirst().getVersion())
+        .setTotalConcepts(incomingCodes.size())
+        .setAddedConcepts(added)
+        .setUpdatedConcepts(updated);
+  }
+
+  /** Snapshot of existing concept codes in a code system, used to compute the
+   *  added / updated split for {@link CodeSystemImportSummary}. Returns an empty set
+   *  if the code system doesn't exist yet (first-ever import of that code system). */
+  private Set<String> loadExistingConceptCodes(String codeSystemId) {
+    if (codeSystemId == null) {
+      return Set.of();
+    }
+    ConceptQueryParams params = new ConceptQueryParams();
+    params.setCodeSystem(codeSystemId);
+    params.setLimit(-1); // -1 means "all pages" in commons-db query convention
+    try {
+      return conceptService.query(params).getData().stream()
+          .map(Concept::getCode)
+          .collect(java.util.stream.Collectors.toCollection(HashSet::new));
+    } catch (Exception e) {
+      // If the lookup fails (e.g. the table doesn't exist yet on a fresh DB), assume the
+      // import is greenfield. Worse case the summary says "all added" instead of split —
+      // never blocks the import itself.
+      return new HashSet<>();
+    }
   }
 
   private CodeSystem toCodeSystem(CodeSystemImportRequest request) {

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemImportSummary.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemImportSummary.java
@@ -1,0 +1,44 @@
+package org.termx.ts.codesystem;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Per-code-system result of one {@code CodeSystemImportProvider.importCodeSystem(...)} call.
+ * Returned to callers so they can populate {@code ImportLog.successes} (the per-job log
+ * surfaced in the email-notification template) with meaningful "what changed" lines instead
+ * of an empty list.
+ *
+ * <p>The added / modified split is computed by the provider with a single bulk-lookup of
+ * existing concept codes BEFORE the import runs — it adds about one round trip per import
+ * versus the previous {@code void}-returning signature, which is negligible against the
+ * minutes-long persistence step but lets the post-import email say:
+ *
+ * <pre>
+ *   loinc-answer-list@2.82: 27 101 concepts (22 146 added, 4 955 updated)
+ *   loinc-part@2.82:        74 087 concepts (74 087 added, 0 updated)
+ *   loinc@2.82:            109 325 concepts (109 325 added, 0 updated)
+ * </pre>
+ *
+ * <p>Callers that don't care about the return (icd10, atc, orphanet, ichi-uz) can ignore it
+ * — Java is happy with a discarded non-void result; no source change needed at those sites.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class CodeSystemImportSummary {
+  /** The {@code code_system.id} the import targeted (e.g. {@code "loinc"}). */
+  private String codeSystem;
+  /** The {@code code_system_version.version} the import created or updated (e.g. {@code "2.82"}). */
+  private String version;
+  /** Total concepts in the import payload — sum of added + updated. */
+  private Integer totalConcepts;
+  /** Concepts whose {@code code} did NOT already exist in this code system before the import. */
+  private Integer addedConcepts;
+  /** Concepts whose {@code code} already existed — the import wrote a new
+   *  {@code code_system_entity_version} row for them under the new {@code version}. */
+  private Integer updatedConcepts;
+}

--- a/termx-core/src/main/java/org/termx/core/ts/CodeSystemImportProvider.java
+++ b/termx-core/src/main/java/org/termx/core/ts/CodeSystemImportProvider.java
@@ -1,8 +1,18 @@
 package org.termx.core.ts;
 
 import org.termx.ts.codesystem.CodeSystemImportRequest;
+import org.termx.ts.codesystem.CodeSystemImportSummary;
 
 public abstract class CodeSystemImportProvider {
 
-  public abstract void importCodeSystem(CodeSystemImportRequest request);
+  /**
+   * Imports a code system from a {@link CodeSystemImportRequest} and returns a brief
+   * summary the caller can fold into a job-log entry. Returning a value (vs. the previous
+   * {@code void}) was added so admin email notifications can say "N concepts imported"
+   * instead of an empty success list — see {@link CodeSystemImportSummary} for fields.
+   *
+   * <p>Callers that don't need the summary (the simpler ICD-10 / ATC / Orphanet / Ichi-UZ
+   * import services) can ignore the return; Java permits discarding a non-void result.
+   */
+  public abstract CodeSystemImportSummary importCodeSystem(CodeSystemImportRequest request);
 }


### PR DESCRIPTION
## Problem

Reported: LOINC import completion email shows `Successes: 0, Warnings: 0, Errors: 0` — empty. Useless for confirming what actually ran.

Root cause: `LoincService.importLoinc` returned `new ImportLog()` with no fields set, so `ImportNotificationService` had nothing to render under "Success Messages".

## Fix

Populate `ImportLog.successes` with two kinds of lines:

### 1. Per-code-system add/updated summary

`CodeSystemImportProvider.importCodeSystem` now returns a new `CodeSystemImportSummary` with `{codeSystem, version, total, added, updated}`. The provider computes added/updated with a single bulk lookup of existing concept codes BEFORE the import (one round trip; negligible vs. the persistence step).

Rendered as:

```
loinc-answer-list@2.82: 27 101 concepts (22 146 added, 4 955 updated)
loinc-part@2.82:        74 087 concepts (74 087 added, 0 updated)
loinc@2.82:            109 325 concepts (109 325 added, 0 updated)
```

On a re-import of the same version: the same lines would say `0 added, N updated`, so admins can tell whether they actually got new content or just refreshed an existing version.

### 2. Per-phase wall-clock — same lines as server logs

Every `loinc-import:` `log.info` is now ALSO appended to `ImportLog.successes` via a small `logAndCapture` helper. So the email mirrors what's in the dev-server logs:

```
loinc-import: parsed answer-list (22146 answers, 4955 lists, 456 snomed mappings) in 71 ms
loinc-import: parsed 74087 parts in 52 ms
loinc-import: parsed 109325 concepts (terminology + ...) in 1863 ms
loinc-import: applied linguistic variants in 121 ms
loinc-import: saved answer-list code-system in 25361 ms
loinc-import: saved answer-list map-set (456 mappings) in 150 ms
loinc-import: saved 74087 parts in 62510 ms
loinc-import: saved 109325 concepts in 279620 ms
loinc-import: total 369359 ms
```

## Interface change

`CodeSystemImportProvider.importCodeSystem` is now `CodeSystemImportSummary`-returning (was `void`). Java permits discarding a non-void result, so the four other call sites (edition-int icd10, atc, orphanet; edition-est icd10est, atcest; edition-uzb ichi-uz) keep working unchanged.

## Test plan

- [x] Full `./gradlew compileJava` clean across all 81 tasks
- [ ] Reviewer: run a LOINC import, then check the completion email. Should show ~12 lines under "Success Messages" (vs. empty before)
- [ ] Reviewer: re-run the same version — `added` counts should be 0, `updated` should equal the previous total
- [ ] Reviewer: verify the dev-server log still has the same `loinc-import:` lines at INFO level (the email shows the same strings, written once and used twice)