### PR TITLE
feat(snomed-import): capture lifecycle log lines into the completion email

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
@@ -70,7 +70,17 @@ public class SnomedImportPollingService {
         tracking.setFinished(OffsetDateTime.now());
         tracking.setErrorMessage(snowstormJob.getErrorMessage());
         tracking.setNotified(true);
-        
+
+        // Append the terminal-status line to the lifecycle log surfaced in the email.
+        if (tracking.getDetails() == null) {
+          tracking.setDetails(new java.util.ArrayList<>());
+        }
+        Duration processed = Duration.between(tracking.getStarted(), tracking.getFinished());
+        tracking.getDetails().add(String.format(
+            "Snowstorm reported status %s after %s",
+            currentStatus, formatDuration(processed)));
+        log.info("snomed-rf2-import: {}", tracking.getDetails().getLast());
+
         trackingRepository.save(tracking);
         
         long start = System.currentTimeMillis();
@@ -178,6 +188,8 @@ public class SnomedImportPollingService {
             .details-section { background-color: white; padding: 15px; margin: 10px 0; border-left: 4px solid #007bff; border-radius: 3px; }
             .details-section h3 { margin-top: 0; color: #007bff; font-size: 16px; }
             .error-message { color: #dc3545; padding: 10px; background-color: #f8d7da; border-radius: 3px; }
+            .message-list { margin: 0; padding-left: 20px; }
+            .message-list li { margin: 5px 0; }
             .footer { text-align: center; margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6; color: #6c757d; font-size: 12px; }
           </style>
         </head>
@@ -242,18 +254,34 @@ public class SnomedImportPollingService {
   }
 
   private String buildDetailsSection(SnomedImportTracking tracking, SnomedImportJob snowstormJob) {
+    StringBuilder out = new StringBuilder("<div class='details'>");
+
+    // Lifecycle log lines captured by SnomedRF2ImportFromArchiveService during the upload
+    // and by checkAndNotify() when the terminal status is reached. Mirrors the LOINC
+    // import-completion email "Success Messages" block.
+    if (CollectionUtils.isNotEmpty(tracking.getDetails())) {
+      out.append("""
+          <div class="details-section">
+            <h3>Import Lifecycle</h3>
+            <ul class="message-list">
+          """);
+      for (String line : tracking.getDetails()) {
+        out.append("<li>").append(escapeHtml(line)).append("</li>");
+      }
+      out.append("</ul></div>");
+    }
+
     if (tracking.getErrorMessage() != null || snowstormJob.getErrorMessage() != null) {
       String errorMsg = tracking.getErrorMessage() != null ? tracking.getErrorMessage() : snowstormJob.getErrorMessage();
-      return """
-          <div class="details">
-            <div class="details-section">
-              <h3>Error Details</h3>
-              <div class="error-message">%s</div>
-            </div>
+      out.append("""
+          <div class="details-section">
+            <h3>Error Details</h3>
+            <div class="error-message">%s</div>
           </div>
-          """.formatted(escapeHtml(errorMsg));
+          """.formatted(escapeHtml(errorMsg)));
     }
-    return "";
+    out.append("</div>");
+    return out.toString();
   }
 
   private String formatDuration(Duration duration) {

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedImportTrackingRepository.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedImportTrackingRepository.java
@@ -4,6 +4,7 @@ import com.kodality.commons.db.bean.PgBeanProcessor;
 import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
 import com.kodality.commons.db.sql.SqlBuilder;
+import com.kodality.commons.db.util.PgUtil;
 import org.termx.snomed.rf2.SnomedImportTracking;
 import io.micronaut.core.util.CollectionUtils;
 import jakarta.inject.Singleton;
@@ -11,7 +12,11 @@ import java.util.List;
 
 @Singleton
 public class SnomedImportTrackingRepository extends BaseRepository {
-  private final PgBeanProcessor bp = new PgBeanProcessor(SnomedImportTracking.class);
+  // text[] columns: register the matching ColumnProcessor so `details` lands as
+  // List<String> on the bean. Same idiom CodeSystemVersionRepository /
+  // ValueSetVersionRepository use for `supported_languages`.
+  private final PgBeanProcessor bp = new PgBeanProcessor(SnomedImportTracking.class, pb ->
+      pb.addColumnProcessor("details", PgBeanProcessor.fromArray()));
 
   public Long save(SnomedImportTracking tracking) {
     SaveSqlBuilder ssb = new SaveSqlBuilder();
@@ -24,6 +29,10 @@ public class SnomedImportTrackingRepository extends BaseRepository {
     ssb.property("finished", tracking.getFinished());
     ssb.property("error_message", tracking.getErrorMessage());
     ssb.property("notified", tracking.isNotified());
+    // text[] write side — PgUtil.array(...) renders the Postgres `{a,b,c}` literal, the
+    // `?::text[]` cast in the placeholder tells the driver to treat the parameter as an
+    // array. Same pattern as supported_languages in CodeSystemVersionRepository.
+    ssb.property("details", "?::text[]", PgUtil.array(tracking.getDetails()));
 
     SqlBuilder sb = ssb.buildSave("sys.snomed_import_tracking", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
@@ -63,18 +63,36 @@ public class SnomedRF2ImportFromArchiveService {
     Long processId = process.getId();
 
     CompletableFuture.runAsync(SessionStore.wrap(() -> {
+      // Lifecycle log lines for the post-import email — same pattern as LoincService's
+      // ImportLog.successes. Captured into SnomedImportTracking.details when we save the
+      // row; polling appends one more line on terminal status.
+      java.util.List<String> details = new java.util.ArrayList<>();
+      long phaseStart = System.currentTimeMillis();
       try {
         lorqueProcessService.reportProgress(processId, 5, "creating Snowstorm import job");
         String jobId = snowstormClient.createImportJob(importRequest).join();
+        long createMs = System.currentTimeMillis() - phaseStart;
+        details.add(String.format("Created Snowstorm import job %s on branch %s (type %s) in %d ms",
+            jobId, importRequest.getBranchPath(), importRequest.getType(), createMs));
+        log.info("snomed-rf2-import: {}", details.getLast());
+
         lorqueProcessService.reportProgress(processId, 20, "uploading archive (streaming)");
+        long uploadStart = System.currentTimeMillis();
         snowstormClient.uploadRF2File(jobId, () -> bobObjectService.loadContentStream(archive)).join();
+        long uploadMs = System.currentTimeMillis() - uploadStart;
+        details.add(String.format("Streamed archive (Bob uuid %s) to Snowstorm in %d ms",
+            req.getArchiveUuid(), uploadMs));
+        log.info("snomed-rf2-import: {}", details.getLast());
+
+        details.add("Snowstorm processing started; awaiting polling-based completion notification");
         trackingRepository.save(new SnomedImportTracking()
             .setSnowstormJobId(jobId)
             .setBranchPath(importRequest.getBranchPath())
             .setType(importRequest.getType())
             .setStatus("RUNNING")
             .setStarted(OffsetDateTime.now())
-            .setNotified(false));
+            .setNotified(false)
+            .setDetails(details));
         lorqueProcessService.reportProgress(processId, 100, "Snowstorm job " + jobId);
         lorqueProcessService.complete(processId, ProcessResult.text(JsonUtil.toJson(Map.of("jobId", jobId))));
       } catch (Exception e) {

--- a/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportTracking.java
+++ b/termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportTracking.java
@@ -2,6 +2,8 @@ package org.termx.snomed.rf2;
 
 import io.micronaut.core.annotation.Introspected;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -20,4 +22,13 @@ public class SnomedImportTracking {
   private OffsetDateTime finished;
   private String errorMessage;
   private boolean notified;
+  /**
+   * Per-import lifecycle log lines surfaced under "Success Messages" in the post-import
+   * email (same pattern as {@code ImportLog.successes} for LOINC). Populated by the
+   * upload service as the import moves through createImportJob → uploadRF2File →
+   * tracking-recorded phases, then by the polling service when Snowstorm reports a
+   * terminal status. Stored as a Postgres {@code text[]} on
+   * {@code sys.snomed_import_tracking.details}.
+   */
+  private List<String> details = new ArrayList<>();
 }

--- a/termx-core/src/main/resources/sys/changelog/sys/73-snomed_import_tracking_details.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/73-snomed_import_tracking_details.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset termx:snomed_import_tracking_details
+-- Add a text[] column to capture the lifecycle log lines an admin sees in the
+-- post-import email under "Success Messages" — same shape as the LoincService
+-- ImportLog.successes treatment introduced in PR #138. SnomedRF2ImportFromArchiveService
+-- and SnomedImportPollingService append entries here as the import moves through its
+-- phases (createImportJob → uploadRF2File → Snowstorm processing → terminal status).
+-- Default empty array so existing rows behave like brand-new ones with no details.
+alter table sys.snomed_import_tracking
+  add column if not exists details text[] not null default '{}';

--- a/termx-core/src/main/resources/sys/changelog/sys/changelog.xml
+++ b/termx-core/src/main/resources/sys/changelog/sys/changelog.xml
@@ -17,6 +17,7 @@
   <include file="70-snomed_import_tracking.sql" relativeToChangelogFile="true"/>
   <include file="71-snomed_rf2_upload.sql" relativeToChangelogFile="true"/>
   <include file="72-snomed_rf2_upload_bob_object_uuid.sql" relativeToChangelogFile="true"/>
+  <include file="73-snomed_import_tracking_details.sql" relativeToChangelogFile="true"/>
   <include file="80-ecosystem.sql" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

Mirror of PR #138 for LOINC, applied to SNOMED. The post-import SNOMED email used to show only a flat summary table — no actual log lines of what the import did. Now an "Import Lifecycle" section renders the captured log lines:

```
Created Snowstorm import job 56423 on branch MAIN (type SNAPSHOT) in 412 ms
Streamed archive (Bob uuid a3b…) to Snowstorm in 41 832 ms
Snowstorm processing started; awaiting polling-based completion notification
Snowstorm reported status COMPLETED after 8 min 22 sec
```

Same lines also go to slf4j at INFO under the `snomed-rf2-import:` prefix, so the email mirrors the dev-server logs (LOINC has the same dual-write pattern).

## Schema

- New `text[]` column `sys.snomed_import_tracking.details default '{}'`
- Liquibase changeset `73-snomed_import_tracking_details.sql` (idempotent with `if not exists`)
- Existing rows behave like empty-detail rows on display
- Repository uses the same `fromArray()` / `PgUtil.array()` idiom as `CodeSystemVersion.supported_languages`

## Wiring

- `SnomedRF2ImportFromArchiveService.startImport` appends create/upload lines as the upload moves through phases, persists them when saving tracking
- `SnomedImportPollingService.checkAndNotify` appends terminal-status line + Snowstorm processing duration when poll detects COMPLETED/FAILED
- `SnomedImportPollingService.buildDetailsSection` renders the list under "Import Lifecycle"; keeps the existing "Error Details" block

## Test plan

- [x] `./gradlew :termx-api:compileJava :termx-core:compileJava :snomed:compileJava` clean
- [ ] Reviewer: Liquibase applies on existing DB; `\d sys.snomed_import_tracking` shows `details text[]`
- [ ] Reviewer: run a SNOMED import, wait for polling to fire (or trigger manually). Email should now include "Import Lifecycle" section with 4 lines
- [ ] Reviewer: upload-stage failure still shows in the email (PR #137 path) — verify it's not broken