### PR TITLE
chore: TODO blocks for deeper import-completion email content

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/LoincService.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/LoincService.java
@@ -69,6 +69,19 @@ public class LoincService {
   @Inject
   private MapSetImportProvider msImportProvider;
 
+  // TODO(loinc-import): surface the DEEP-stage timings in the post-import email too.
+  // ImportLog.successes currently captures everything LoincService logs at INFO under the
+  // "loinc-import:" prefix, but the heavy lines from CodeSystemImportService and
+  // CodeSystemEntityVersionService — "Concepts created (39 sec)", "Versions saved (58 sec)",
+  // "Designations saved 'N' (62 sec)", "Properties saved 'N' (387 sec)", "Linkage created
+  // (22 sec)", "Associations created (58 sec)" — are NOT captured because those classes
+  // log directly to slf4j with no collector callback. To surface them, plumb a List<String>
+  // (or a small LogCollector) through CodeSystemImportProvider.importCodeSystem →
+  // TerminologyCodeSystemImportProvider → CodeSystemImportService.importCodeSystem →
+  // CodeSystemEntityVersionService.batchUpsert. Each log.info(...) call there gets a
+  // sibling collector.add(MessageFormatter.format(...).getMessage()) line, same pattern as
+  // logAndCapture() below. Owner of the email then sees the full ~17-line timing breakdown
+  // instead of the 9 LoincService-level lines we currently emit.
   @Transactional
   public ImportLog importLoinc(Map<String, Object> params) {
     long t0 = System.currentTimeMillis();

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
@@ -253,6 +253,22 @@ public class SnomedImportPollingService {
         );
   }
 
+  // TODO(snomed-import): pull Snowstorm-side entity counts into the email.
+  // Snowstorm's GET /imports/{id} returns only status + branchPath + moduleIds + error —
+  // not "X concepts added, Y descriptions added, Z relationships added". Getting those
+  // requires a second integration:
+  //   * Snapshot the branch state BEFORE submitting the import (e.g. GET /branches/{path}
+  //     to capture the head-effective-time, or GET /branches/{path}/effective-time/{date}
+  //     for per-effective-time counts).
+  //   * After polling sees COMPLETED, run the same queries against the new head and diff
+  //     them.
+  // Caveats — branch-merge windows make the "before" snapshot fragile if the branch was
+  // active when the import landed; SCT release timing can mean entity-counts queries miss
+  // the just-imported delta until Snowstorm's effective-time index is refreshed. Either
+  // add a small retry loop around the post-import query, or skip count reporting and
+  // surface only the timestamps Snowstorm DOES expose. When implemented, append the
+  // resulting lines to tracking.getDetails() before save() so they land in the same
+  // "Import Lifecycle" section the email already renders.
   private String buildDetailsSection(SnomedImportTracking tracking, SnomedImportJob snowstormJob) {
     StringBuilder out = new StringBuilder("<div class='details'>");
 


### PR DESCRIPTION
Two inline TODO blocks pinning the gaps called out when shipping #138 (LOINC) and #139 (SNOMED) — at the exact code sites that would need the change, with enough detail that whoever picks them up knows the integration shape + caveats.

- LoincService.importLoinc — capture the DEEP-stage timings from CodeSystemImportService / CodeSystemEntityVersionService by threading a collector through the provider chain.
- SnomedImportPollingService.buildDetailsSection — pull Snowstorm entity counts via pre/post branch-state diff, with notes on the branch-merge race + effective-time-index lag.

No functional change.