### PR TITLE
fix(value_set_expand): cannot cast jsonb object to type boolean on activate

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
@@ -251,13 +251,22 @@ expressions as (
                      and ep.sys_status = 'A' and ep.id = epv.entity_property_id
                      and (t.filter_ -> 'property' ->> 'name')::text = ep.name
                      and ((t.filter_ ->> 'value') is null or
-                          (t.filter_ ->> 'operator')::text = 'exists' and true = (t.filter_ -> 'value')::boolean or
+                          -- 'exists' boolean check: compare ->> 'value' (text form) to 'true' rather than
+                          -- casting -> 'value' to boolean. The boolean cast fails with "cannot cast jsonb
+                          -- object to type boolean" when a SIBLING filter on the same rule carries a
+                          -- Coding-shaped object value like {"code":"X","codeSystem":"…"} — Postgres can
+                          -- evaluate the cast on those objects even though they belong to a different
+                          -- operator branch, because OR/AND short-circuiting through the CTE planner is
+                          -- not guaranteed. ->> gives '{"code":"X",…}' for objects, 'true'/'false' for
+                          -- JSON booleans — comparison is then a plain text equality, never throws.
+                          (t.filter_ ->> 'operator')::text = 'exists' and (t.filter_ ->> 'value')::text = 'true' or
                           (t.filter_ ->> 'operator')::text = '=' and (epv.value::jsonb = (t.filter_ -> 'value') or (epv.value ->> 'code')::text = (t.filter_ ->> 'value')::text) or
                           (t.filter_ ->> 'operator')::text = 'regex' and (epv.value::text = any(regexp_match(epv.value::text, (t.filter_ ->> 'value')::text||'$')) or (epv.value ->> 'code')::text = any(regexp_match((epv.value ->> 'code')::text, (t.filter_ ->> 'value')::text||'$'))) or
                           (t.filter_ ->> 'operator')::text = 'in' and (epv.value::text = any(string_to_array((t.filter_ ->> 'value')::text, ',')) or (epv.value ->> 'code')::text = any(string_to_array((t.filter_ ->> 'value')::text, ','))) or
                           (t.filter_ ->> 'operator')::text = 'not-in' and (epv.value::text != all(string_to_array((t.filter_ ->> 'value')::text, ',')) and (epv.value ->> 'code')::text != all(string_to_array((t.filter_ ->> 'value')::text, ',')))
                      ))
-          or (t.filter_ ->> 'operator')::text = 'exists' and false = (t.filter_ -> 'value')::boolean and
+          -- Same text-vs-boolean swap as above; symmetric for 'exists = false'.
+          or (t.filter_ ->> 'operator')::text = 'exists' and (t.filter_ ->> 'value')::text = 'false' and
              not exists (select 1 from terminology.entity_property_value epv, terminology.entity_property ep
                           where epv.sys_status = 'A' and c.csev_id = epv.code_system_entity_version_id
                             and ep.sys_status = 'A' and ep.id = epv.entity_property_id


### PR DESCRIPTION
## Problem

Reported on CodeSystem → version activate:

\`\`\`
POST /ts/code-systems/lt-lab-klt-nomenclature-test/versions/1.0.9/activate
DataIntegrityViolationException → Postgres: ERROR: cannot cast jsonb object
to type boolean while running terminology.value_set_expand(?::bigint)
\`\`\`

## Root cause

The bigint variant of \`terminology.value_set_expand\` in \`01-value_set_expand.sql\` had two unguarded boolean casts on a JSONB filter value:

\`\`\`sql
(t.filter_ ->> 'operator')::text = 'exists' and true  = (t.filter_ -> 'value')::boolean
(t.filter_ ->> 'operator')::text = 'exists' and false = (t.filter_ -> 'value')::boolean
\`\`\`

These casts fire whenever the rule has multiple filters and any filter on the same rule carries a Coding-shaped value like \`{"code":"CHROM","codeSystem":"lt-lab-methods"}\`. The AND-guard against \`operator = 'exists'\` doesn't help — Postgres's planner doesn't guarantee short-circuiting OR/AND through the CTE, and the cast can be evaluated on rows where the operator isn't \`'exists'\`.

## Fix

Compare \`->> 'value'\` (text form) to the literal strings \`'true'\` / \`'false'\` instead of casting \`-> 'value'\` (jsonb) to boolean:

\`\`\`sql
-- before: blows up on object-valued filters
true  = (t.filter_ -> 'value')::boolean
-- after: text-equality, can never throw
(t.filter_ ->> 'value')::text = 'true'
\`\`\`

For JSON booleans \`->>'value'\` returns \`'true'\` / \`'false'\`. For JSON objects it returns the serialised JSON like \`'{"code":"X",…}'\`, which never equals \`'true'\` or \`'false'\` — so the branch correctly evaluates false WITHOUT touching the type system.

## What else this touches

- Only \`01-value_set_expand.sql\` (the \`bigint\` variant). The \`37-value_set_expand_jsonb.sql\` text variant doesn't have this pattern.
- Both function changesets are \`runOnChange=\"true\"\` so Liquibase re-applies the corrected SQL on next startup — no new changeset file needed.

## Test plan

- [ ] Reviewer: against the production DB containing \`lt-lab-klt-nomenclature-test\` 1.0.9, restart termx-server → Liquibase reports \`functions\` changeset re-run → \`POST /ts/code-systems/lt-lab-klt-nomenclature-test/versions/1.0.9/activate\` returns 2xx instead of 500
- [ ] Reviewer: regression — pick a value set that legitimately uses the \`'exists'\` filter operator (boolean value), confirm expansion still filters correctly