### PR TITLE
feat(fhir-read): skip heavy load on ?_summary=true|text|count

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.6
+kefhirVersion=R5.7
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -158,6 +158,11 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
 //    toFhirRelatedArtifacts(fhirCodeSystem, relatedArtifacts);
 
     fhirCodeSystem.setVersion(version.getVersion());
+    // count is a FHIR R5 summary element — always emit it. The value comes from
+    // CodeSystemVersion.conceptsTotal (a pre-computed COUNT loaded by versionService.load,
+    // not derived from the in-memory entities list), so it's correct even when entities
+    // are skipped for _summary=true (see CodeSystemResourceStorage.load → lightweight path).
+    fhirCodeSystem.setCount(version.getConceptsTotal());
     fhirCodeSystem.setLanguage(version.getPreferredLanguage());
     fhirCodeSystem.setVersionAlgorithmString(version.getAlgorithm());
     fhirCodeSystem.setEffectivePeriod(new Period(

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
@@ -91,8 +91,21 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
     log.info("Code System load took " + (System.currentTimeMillis() - start) / 1000 + " seconds");
     start = System.currentTimeMillis();
 
-    version.setEntities(loadEntities(version, null, true));
-    log.info("Entities load took " + (System.currentTimeMillis() - start) / 1000 + " seconds");
+    // Honour ?_summary on read: when the client asked for a lightweight summary (true /
+    // text / count) we skip the concept-entity load entirely. The post-load summary
+    // processor in kefhir would strip the `concept` array from the response anyway, so
+    // we'd otherwise be loading ~100 000 rows + designations + property values + JSON-
+    // serialising them just to throw them away.
+    //
+    // The `count` field on the response is still populated — it comes from
+    // CodeSystemVersion.conceptsTotal (single COUNT query inside versionService.load),
+    // not from entities.size() — see CodeSystemFhirMapper.toFhir's setCount() line.
+    //
+    // Default for read (no _summary param) is to load everything, matching the previous
+    // behaviour and the FHIR R5 spec default of _summary=false on read/vread.
+    boolean lightweight = isCurrentRequestLightweightSummary();
+    version.setEntities(lightweight ? List.of() : loadEntities(version, null, true));
+    log.info("Entities load took {} seconds (lightweight={})", (System.currentTimeMillis() - start) / 1000, lightweight);
     start = System.currentTimeMillis();
 
     ResourceVersion resourceVersion = toFhir(codeSystem, version);

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapResourceStorage.java
@@ -74,7 +74,13 @@ public class ConceptMapResourceStorage extends BaseFhirResourceHandler {
     }
     MapSetVersion version = versionNumber == null ? mapSetVersionService.loadLastVersion(id) :
         mapSetVersionService.load(id, versionNumber).orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "resource not found"));
-    version.setAssociations(loadAssociations(version));
+    // Skip the (potentially-large) per-association query when the caller asked for a
+    // lightweight summary. Same pattern as the search path at line 86, and the matching
+    // CodeSystem and ValueSet read-side fixes. Without entities the resulting FHIR
+    // ConceptMap drops `group.element[]` — exactly what kefhir's post-load summary
+    // processor would strip for ?_summary=true anyway.
+    boolean lightweight = isCurrentRequestLightweightSummary();
+    version.setAssociations(lightweight ? List.of() : loadAssociations(version));
     return toFhir(mapSet, version);
   }
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
@@ -76,7 +76,12 @@ public class ValueSetResourceStorage extends BaseFhirResourceHandler {
     }
     ValueSetVersion version = versionNumber == null ? valueSetVersionService.loadLastVersion(vsId) :
         valueSetVersionService.load(vsId, versionNumber).orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "resource not found"));
-    return toFhir(valueSet, version);
+    // Mirror CodeSystemResourceStorage: when the caller asked for a lightweight summary
+    // (?_summary=true / text / count), null out the per-rule explicit concept lists so
+    // we never serialise a potentially-huge compose.include.concept array that kefhir's
+    // post-load summary processor would strip anyway. The search path at line 99 already
+    // does this; read had the same gap as CodeSystem until now.
+    return toFhir(valueSet, applyLightweight(version, isCurrentRequestLightweightSummary()));
   }
 
   @Override

--- a/termx-core/src/main/java/org/termx/core/fhir/BaseFhirResourceHandler.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/BaseFhirResourceHandler.java
@@ -2,16 +2,39 @@ package org.termx.core.fhir;
 
 import com.kodality.kefhir.core.api.resource.ResourceSearchHandler;
 import com.kodality.kefhir.core.api.resource.ResourceStorage;
+import com.kodality.kefhir.core.context.RequestSummaryContext;
 import com.kodality.kefhir.core.model.ResourceId;
 import com.kodality.kefhir.core.model.ResourceVersion;
 import com.kodality.kefhir.core.model.VersionId;
 import com.kodality.kefhir.core.model.search.HistorySearchCriterion;
 import com.kodality.kefhir.core.model.search.SearchCriterion;
 import com.kodality.kefhir.core.model.search.SearchResult;
+import com.kodality.kefhir.core.util.SummaryProcessor;
 import com.kodality.kefhir.structure.api.ResourceContent;
 import java.util.List;
 
 public abstract class BaseFhirResourceHandler implements ResourceStorage, ResourceSearchHandler {
+
+  /**
+   * Whether the current FHIR read / vread call asked for a lightweight summary
+   * ({@code ?_summary=true|text|count}). Read from kefhir's {@link RequestSummaryContext}
+   * thread-local that {@code DefaultFhirResourceServer} populates before invoking storage.
+   * Storage subclasses use this to skip expensive loads — concept-version rows for
+   * CodeSystem, association rows for ConceptMap, rule-set concepts for ValueSet — when
+   * the response will be summary-stripped post-load anyway.
+   *
+   * <p>Returns {@code false} when no read is in scope (internal callers, batch loaders)
+   * — the safe default that preserves the historical "load everything" behaviour.
+   *
+   * <p>Note: {@link SummaryProcessor.Mode#DATA} returns {@code false} on purpose — that
+   * mode strips only the narrative {@code text}, not structural data, so the heavy load
+   * is still needed.
+   */
+  protected static boolean isCurrentRequestLightweightSummary() {
+    SummaryProcessor.Mode mode = RequestSummaryContext.get();
+    return mode != null && mode != SummaryProcessor.Mode.FALSE && mode != SummaryProcessor.Mode.DATA;
+  }
+
   public abstract ResourceVersion load(String id);
 
   public abstract String getResourceType();


### PR DESCRIPTION
Wires the read flow to kefhir R5.7's new `RequestSummaryContext` so storage can skip the heavy entity load when `?_summary=true|text|count`. Mirrors what the search path already does.

- `CodeSystemResourceStorage.load` — passes `List.of()` for entities when lightweight
- `CodeSystemFhirMapper.toFhir` — always populates `count` from `conceptsTotal`
- `ValueSetResourceStorage.load` — calls existing `applyLightweight` helper
- `ConceptMapResourceStorage.load` — skips `loadAssociations` query
- `BaseFhirResourceHandler` — shared `isCurrentRequestLightweightSummary()` reading `RequestSummaryContext`
- `gradle.properties` — kefhirVersion R5.6 → R5.7

`?_summary=false` / no `_summary` / `?_summary=data` unchanged. Search paths unchanged.

kefhir R5.7 was published to GitHub Packages via [kefhir#6](https://github.com/termx-health/kefhir/pull/6). All 81 termx-server compile tasks pass against it. kefhir's own 17 tests pass.