### PR TITLE
feat(fhir-vs): emit expansion.total without loading the expansion list

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -110,6 +110,31 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return FhirMapper.toJson(toFhir(vs, vsv, provenances));
   }
 
+  /**
+   * Same as {@link #toFhirJson(ValueSet, ValueSetVersion, List)} but additionally
+   * populates {@code ValueSet.expansion.total} with the snapshot's saved concept count
+   * when {@code expansionCount} is non-null. The {@code expansion.contains} list is
+   * NOT populated — only the count — so the response stays small even for value sets
+   * with tens of thousands of expanded concepts. Used by the FHIR read flow on
+   * {@code ?_summary=false} via the open-in-FHIR list link.
+   *
+   * @param expansionCount the snapshot's {@code concepts_total}, or {@code null}
+   *                       when no snapshot exists for this version (no expansion block emitted)
+   */
+  public String toFhirJson(ValueSet vs, ValueSetVersion vsv, List<Provenance> provenances, Integer expansionCount) {
+    com.kodality.zmei.fhir.resource.terminology.ValueSet fhir = toFhir(vs, vsv, provenances);
+    if (expansionCount != null) {
+      ValueSetExpansion expansion = new ValueSetExpansion();
+      expansion.setTotal(expansionCount);
+      // No setContains(...) — the whole point is to surface "there is an expansion of
+      // size N stored" without paying for the inline expansion list. Consumers that
+      // want the actual contains[] can call /fhir/ValueSet/{id}/$expand or hit the
+      // expansion endpoint directly.
+      fhir.setExpansion(expansion);
+    }
+    return FhirMapper.toJson(fhir);
+  }
+
   public com.kodality.zmei.fhir.resource.terminology.ValueSet toFhir(ValueSet valueSet, ValueSetVersion version, List<Provenance> provenances) {
     com.kodality.zmei.fhir.resource.terminology.ValueSet fhirValueSet = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
     if (StringUtils.isNotEmpty(valueSet.getExternalWebSource())) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
@@ -12,6 +12,7 @@ import org.termx.core.fhir.BaseFhirResourceHandler;
 import org.termx.core.sys.provenance.Provenance;
 import org.termx.core.sys.provenance.ProvenanceService;
 import org.termx.terminology.terminology.valueset.ValueSetService;
+import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotService;
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.ts.valueset.ValueSet;
 import org.termx.ts.valueset.ValueSetQueryParams;
@@ -30,6 +31,7 @@ public class ValueSetResourceStorage extends BaseFhirResourceHandler {
   private final ValueSetVersionService valueSetVersionService;
   private final ValueSetFhirImportService importService;
   private final ProvenanceService provenanceService;
+  private final ValueSetSnapshotService snapshotService;
   private final ValueSetFhirMapper mapper;
   private final String defaultSearchSummary;
 
@@ -37,12 +39,14 @@ public class ValueSetResourceStorage extends BaseFhirResourceHandler {
                                  ValueSetVersionService valueSetVersionService,
                                  ValueSetFhirImportService importService,
                                  ProvenanceService provenanceService,
+                                 ValueSetSnapshotService snapshotService,
                                  ValueSetFhirMapper mapper,
                                  @Value("${termx.fhir.valueset.search.default-summary:true}") String defaultSearchSummary) {
     this.valueSetService = valueSetService;
     this.valueSetVersionService = valueSetVersionService;
     this.importService = importService;
     this.provenanceService = provenanceService;
+    this.snapshotService = snapshotService;
     this.mapper = mapper;
     this.defaultSearchSummary = defaultSearchSummary;
   }
@@ -122,9 +126,15 @@ public class ValueSetResourceStorage extends BaseFhirResourceHandler {
 
   private ResourceVersion toFhir(ValueSet vs, ValueSetVersion vsv) {
     List<Provenance> provenances = provenanceService.find("ValueSetVersion|" + vsv.getId());
+    // Surface expansion.total when a snapshot exists, WITHOUT loading the (potentially
+    // huge) expansion list. Lets ?_summary=false consumers see "there's an expansion of
+    // size N" on the open-in-FHIR list link from termx-web without paying for the
+    // contains[] payload. Returns null when no snapshot is stored — mapper then emits
+    // no expansion block at all.
+    Integer expansionCount = vs == null ? null : snapshotService.loadConceptsTotal(vs.getId(), vsv.getId());
     return vs == null ? null : new ResourceVersion(
         new VersionId("ValueSet", ValueSetFhirMapper.toFhirId(vs, vsv)),
-        new ResourceContent(mapper.toFhirJson(vs, vsv, provenances), "json")
+        new ResourceContent(mapper.toFhirJson(vs, vsv, provenances, expansionCount), "json")
     );
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotRepository.java
@@ -41,4 +41,17 @@ public class ValueSetSnapshotRepository extends BaseRepository {
     return getBean(sql, bp, valueSet, valueSetVersionId);
   }
 
+  /**
+   * Returns ONLY {@code concepts_total} for the saved snapshot, without loading the
+   * (potentially huge) {@code expansion} jsonb column. Lets the FHIR read flow emit
+   * {@code expansion.total} on {@code ?_summary=false} without paying for the full
+   * expansion list — used by {@link ValueSetResourceStorage} to populate the count
+   * on the open-in-FHIR list link. Returns {@code null} when no snapshot exists.
+   */
+  public Integer loadConceptsTotal(String valueSet, Long valueSetVersionId) {
+    String sql = "select concepts_total from terminology.value_set_snapshot " +
+        "where sys_status = 'A' and value_set = ? and value_set_version_id = ? limit 1";
+    return jdbcTemplate.query(sql, rs -> rs.next() ? rs.getInt(1) : null, valueSet, valueSetVersionId);
+  }
+
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotService.java
@@ -41,4 +41,16 @@ public class ValueSetSnapshotService {
   public ValueSetSnapshot load(String valueSet, Long versionId) {
     return repository.load(valueSet, versionId);
   }
+
+  /**
+   * Returns ONLY the saved snapshot's {@code concepts_total} — a single int — without
+   * loading the (potentially large) expansion list. Used by the FHIR read flow on
+   * {@code ?_summary=false} to populate {@code ValueSet.expansion.total} without
+   * shipping the full expansion contents.
+   *
+   * @return concept count of the saved snapshot, or {@code null} if no snapshot exists
+   */
+  public Integer loadConceptsTotal(String valueSet, Long versionId) {
+    return repository.loadConceptsTotal(valueSet, versionId);
+  }
 }


### PR DESCRIPTION
On `GET /fhir/ValueSet/{id}?_summary=false`, the inline `expansion.contains[]` is correctly absent (the storage doesn't load a snapshot at read-time), but admins want to see HOW BIG the saved expansion is — count alone, without the contains[] payload.

Count-only path through the snapshot stack:

- `ValueSetSnapshotRepository.loadConceptsTotal` — single SELECT of the existing `concepts_total` column. No jsonb materialisation
- `ValueSetSnapshotService.loadConceptsTotal` — passthrough
- `ValueSetFhirMapper.toFhirJson(.., expansionCount)` — when non-null, populates a stripped `expansion` with only `total` set
- `ValueSetResourceStorage.toFhir` — calls the count loader during read and threads the value through

Effect:
- No saved snapshot → no expansion block (unchanged)
- Saved snapshot → `expansion.total = N`, no `expansion.contains`
- Cost: one SELECT of an existing int column

Consumers who want the actual expansion still call `/fhir/ValueSet/{id}/$expand`. Unchanged.