### PR TITLE
fix($expand): paging/filter on stored VS + SNOMED ?fhir_vs via Snowstorm

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -7,6 +7,7 @@ import com.kodality.kefhir.core.model.ResourceId;
 import com.kodality.kefhir.structure.api.ResourceContent;
 import org.termx.terminology.Privilege;
 import org.termx.core.auth.SessionStore;
+import org.termx.core.ts.ValueSetExternalExpandProvider;
 import org.termx.terminology.fhir.valueset.ValueSetFhirMapper;
 import org.termx.core.sys.provenance.Provenance;
 import org.termx.core.sys.provenance.ProvenanceService;
@@ -14,11 +15,17 @@ import org.termx.terminology.terminology.valueset.ValueSetService;
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository;
+import org.termx.ts.codesystem.CodeSystemVersionReference;
 import org.termx.ts.valueset.*;
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule;
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter;
 import com.kodality.zmei.fhir.FhirMapper;
 import com.kodality.zmei.fhir.resource.other.Parameters;
 import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter;
 import jakarta.inject.Singleton;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.r4.model.ResourceType;
@@ -33,6 +40,14 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   private final ValueSetVersionConceptService valueSetVersionConceptService;
   private final ValueSetVersionConceptRepository valueSetVersionConceptRepository;
   private final ValueSetFhirMapper mapper;
+  private final List<ValueSetExternalExpandProvider> externalExpandProviders;
+
+  // SNOMED CT implicit-ValueSet URL family
+  // https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html
+  private static final String SNOMED_BASE_URL = "http://snomed.info/sct";
+  private static final String SNOMED_CS_ID = "snomed-ct";
+  // 900000000000455006 |Reference set (foundation metadata concept)| — anchor for `?fhir_vs=refset`
+  private static final String SNOMED_REFSET_FOUNDATION_SCTID = "900000000000455006";
 
   public String getResourceType() {
     return ResourceType.ValueSet.name();
@@ -80,6 +95,15 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         .orElseThrow(() -> new FhirException(400, IssueType.INVALID, "parameter 'url' or 'valueSet' required"));
     String versionNr = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(null);
 
+    // 3. SNOMED CT implicit-ValueSet URLs (`http://snomed.info/sct[/<edition>/version/<date>]?fhir_vs[=...]`)
+    //    are recognised before the stored-VS lookup and delegated to the
+    //    SnomedValueSetExpandProvider, which already calls Snowstorm with an
+    //    ECL expression.
+    com.kodality.zmei.fhir.resource.terminology.ValueSet snomedResp = tryExpandSnomedImplicit(url, req);
+    if (snomedResp != null) {
+      return snomedResp;
+    }
+
     ValueSetQueryParams vsParams = new ValueSetQueryParams();
     vsParams.setUri(url);
     vsParams.setLimit(1);
@@ -117,16 +141,46 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     List<ValueSetVersionConcept> expandedConcepts = snapshot.getExpansion();
     List<Provenance> provenances = provenanceService.find("ValueSetVersion|" + version.getId());
 
+    // FHIR R5 ValueSet/$expand `filter`: free-text typeahead filter applied to the
+    // expansion. Match against concept code and display, case-insensitive substring.
+    String filter = req == null ? null : req.findParameter("filter")
+        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+    if (filter != null && !filter.isBlank()) {
+      String needle = filter.toLowerCase();
+      expandedConcepts = expandedConcepts.stream().filter(c -> {
+        String code = c.getConcept() != null ? c.getConcept().getCode() : null;
+        String display = c.getDisplay() != null ? c.getDisplay().getName() : null;
+        return (code != null && code.toLowerCase().contains(needle))
+            || (display != null && display.toLowerCase().contains(needle));
+      }).toList();
+    }
 
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
     if (offset != null) {
-      expandedConcepts = offset > expandedConcepts.size() ? List.of() : expandedConcepts.subList(0, offset);
+      expandedConcepts = offset >= expandedConcepts.size() ? List.of() : expandedConcepts.subList(offset, expandedConcepts.size());
     }
     Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("count").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
     if (count != null) {
       expandedConcepts = expandedConcepts.stream().limit(count).toList();
+    }
+
+    // Propagate filter/offset/count results into the snapshot the mapper reads.
+    // The service may return a cached snapshot (see ValueSetVersionConceptService.expand
+    // line ~83 — `version.getSnapshot()` is reused when current and unfiltered), so
+    // mutating it would poison shared state. Build a copy with the trimmed expansion
+    // while preserving the original conceptsTotal for FHIR-correct expansion.total.
+    if (expandedConcepts != snapshot.getExpansion()) {
+      snapshot = new ValueSetSnapshot()
+          .setId(snapshot.getId())
+          .setValueSet(snapshot.getValueSet())
+          .setValueSetVersion(snapshot.getValueSetVersion())
+          .setConceptsTotal(snapshot.getConceptsTotal())
+          .setExpansion(expandedConcepts)
+          .setDependencies(snapshot.getDependencies())
+          .setCreatedAt(snapshot.getCreatedAt())
+          .setCreatedBy(snapshot.getCreatedBy());
     }
 
     return mapper.toFhir(vs, version, provenances, snapshot, req);
@@ -207,4 +261,153 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     return response;
   }
 
+
+  // ===========================================================================
+  // SNOMED CT implicit-ValueSet URLs (`?fhir_vs[=...]`)
+  // ===========================================================================
+
+  /**
+   * If {@code url} is a SNOMED CT canonical with a {@code ?fhir_vs} query, delegate
+   * expansion to the SNOMED {@link ValueSetExternalExpandProvider} (which in turn
+   * calls Snowstorm via SnomedService with an ECL expression) and return the
+   * built response. Returns {@code null} when the URL is not a SNOMED implicit
+   * canonical so the caller falls through to the stored-VS lookup.
+   *
+   * <p>Supported patterns per the HL7 UTG SNOMED CT page:
+   * <ul>
+   *   <li>{@code ?fhir_vs}                 → ECL {@code *}        (all concepts)</li>
+   *   <li>{@code ?fhir_vs=isa/<sctid>}     → ECL {@code <<<sctid>} (subsumed-by-or-self)</li>
+   *   <li>{@code ?fhir_vs=refset}          → ECL {@code <<900000000000455006}</li>
+   *   <li>{@code ?fhir_vs=refset/<sctid>}  → ECL {@code ^<sctid>}  (refset members)</li>
+   *   <li>{@code ?fhir_vs=ecl/<expr>}      → ECL {@code <expr>}    (URL-decoded)</li>
+   * </ul>
+   */
+  private com.kodality.zmei.fhir.resource.terminology.ValueSet tryExpandSnomedImplicit(String url, Parameters req) {
+    if (url == null || !url.startsWith(SNOMED_BASE_URL)) {
+      return null;
+    }
+    int qIdx = url.indexOf('?');
+    if (qIdx < 0) {
+      return null;
+    }
+    String baseAndVersion = url.substring(0, qIdx);
+    String query = url.substring(qIdx + 1);
+    if (!query.equals("fhir_vs") && !query.startsWith("fhir_vs=")) {
+      return null;
+    }
+    String fhirVsParam = query.equals("fhir_vs") ? "" : query.substring("fhir_vs=".length());
+
+    ValueSetRuleFilter filter = new ValueSetRuleFilter();
+    if (fhirVsParam.isEmpty()) {
+      // All concepts of the edition/version — ECL `*` matches anything.
+      filter.setOperator("ecl");
+      filter.setValue("*");
+    } else if (fhirVsParam.startsWith("isa/")) {
+      filter.setOperator("is-a");
+      filter.setValue(fhirVsParam.substring("isa/".length()));
+    } else if (fhirVsParam.equals("refset")) {
+      // All reference sets — descendants-or-self of the Reference set foundation.
+      filter.setOperator("is-a");
+      filter.setValue(SNOMED_REFSET_FOUNDATION_SCTID);
+    } else if (fhirVsParam.startsWith("refset/")) {
+      filter.setOperator("in");
+      filter.setValue(fhirVsParam.substring("refset/".length()));
+    } else if (fhirVsParam.startsWith("ecl/")) {
+      filter.setOperator("ecl");
+      filter.setValue(URLDecoder.decode(fhirVsParam.substring("ecl/".length()), StandardCharsets.UTF_8));
+    } else {
+      throw new FhirException(400, IssueType.INVALID, "unrecognised SNOMED ?fhir_vs pattern: " + fhirVsParam);
+    }
+
+    ValueSetVersionRule rule = new ValueSetVersionRule();
+    rule.setCodeSystem(SNOMED_CS_ID);
+    rule.setType("include");
+    rule.setFilters(List.of(filter));
+    if (baseAndVersion.length() > SNOMED_BASE_URL.length()) {
+      // Versioned canonical `http://snomed.info/sct/<edition>/version/<YYYYMMDD>`.
+      // The provider's getBranch(...) helper parses the URI and resolves to a Snowstorm branch.
+      CodeSystemVersionReference vsr = new CodeSystemVersionReference();
+      vsr.setUri(baseAndVersion);
+      rule.setCodeSystemVersion(vsr);
+    }
+
+    ValueSetExternalExpandProvider provider = findSnomedProvider();
+    if (provider == null) {
+      throw new FhirException(501, IssueType.NOTSUPPORTED,
+          "SNOMED expansion provider is not configured: " + url);
+    }
+
+    String displayLanguage = req == null ? null : req.findParameter("displayLanguage").map(ParametersParameter::getValueCode)
+        .orElse(req.findParameter("displayLanguage").map(ParametersParameter::getValueString).orElse(null));
+
+    // Stub version — SnomedValueSetExpandProvider only reads supportedLanguages
+    // and preferredLanguage from it, both nullable.
+    ValueSetVersion stubVersion = new ValueSetVersion();
+
+    List<ValueSetVersionConcept> concepts = provider.ruleExpand(rule, stubVersion, displayLanguage);
+    if (concepts == null) {
+      concepts = Collections.emptyList();
+    }
+
+    // Filter (free-text typeahead) — applied client-side because the underlying
+    // Snowstorm ECL doesn't carry a free-text filter.
+    String textFilter = req == null ? null : req.findParameter("filter")
+        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+    if (textFilter != null && !textFilter.isBlank()) {
+      String needle = textFilter.toLowerCase();
+      concepts = concepts.stream().filter(c -> {
+        String code = c.getConcept() != null ? c.getConcept().getCode() : null;
+        String display = c.getDisplay() != null ? c.getDisplay().getName() : null;
+        return (code != null && code.toLowerCase().contains(needle))
+            || (display != null && display.toLowerCase().contains(needle));
+      }).toList();
+    }
+
+    int totalBeforePaging = concepts.size();
+
+    Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
+        .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
+    if (offset != null) {
+      concepts = offset >= concepts.size() ? List.of() : concepts.subList(offset, concepts.size());
+    }
+    Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
+        .orElse(req.findParameter("count").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
+    if (count != null) {
+      concepts = concepts.stream().limit(count).toList();
+    }
+
+    com.kodality.zmei.fhir.resource.terminology.ValueSet response = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
+    response.setUrl(url);
+    response.setStatus("active");
+
+    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion expansion =
+        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion();
+    expansion.setTimestamp(java.time.OffsetDateTime.now());
+    expansion.setTotal(totalBeforePaging);
+    if (offset != null) {
+      expansion.setOffset(offset);
+    }
+    expansion.setContains(concepts.stream().map(c -> {
+      com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains contain =
+          new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains();
+      contain.setSystem(c.getConcept() != null ? c.getConcept().getCodeSystemUri() : SNOMED_BASE_URL);
+      contain.setCode(c.getConcept() != null ? c.getConcept().getCode() : null);
+      if (c.getDisplay() != null) {
+        contain.setDisplay(c.getDisplay().getName());
+      }
+      return contain;
+    }).toList());
+    response.setExpansion(expansion);
+    return response;
+  }
+
+  private ValueSetExternalExpandProvider findSnomedProvider() {
+    if (externalExpandProviders == null) {
+      return null;
+    }
+    return externalExpandProviders.stream()
+        .filter(p -> SNOMED_CS_ID.equals(p.getCodeSystemId()))
+        .findFirst()
+        .orElse(null);
+  }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -1,0 +1,507 @@
+package org.termx.terminology.fhir.valueset.operations
+
+import com.kodality.commons.model.QueryResult
+import com.kodality.kefhir.core.exception.FhirException
+import com.kodality.zmei.fhir.resource.other.Parameters
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.core.sys.provenance.ProvenanceService
+import org.termx.core.ts.ValueSetExternalExpandProvider
+import org.termx.terminology.fhir.valueset.ValueSetFhirMapper
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetSnapshot
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionConcept
+import org.termx.ts.valueset.ValueSetVersionConcept.ValueSetVersionConceptValue
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import spock.lang.Specification
+
+/**
+ * Behaviour tests for {@link ValueSetExpandOperation}, covering:
+ * <ul>
+ *   <li>Stored-VS path — {@code offset}/{@code count}/{@code filter} parameters
+ *       must propagate into the {@link ValueSetSnapshot} handed to
+ *       {@link ValueSetFhirMapper#toFhir}.</li>
+ *   <li>Inline-VS path — same paging semantics, response built directly without
+ *       the mapper.</li>
+ *   <li>404 on unresolved {@code url} — documents the absence of an implicit
+ *       CodeSystem-as-ValueSet fallback.</li>
+ * </ul>
+ */
+class ValueSetExpandOperationTest extends Specification {
+  def valueSetService = Mock(ValueSetService)
+  def provenanceService = Mock(ProvenanceService)
+  def valueSetVersionService = Mock(ValueSetVersionService)
+  def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
+  def valueSetVersionConceptRepository = Mock(ValueSetVersionConceptRepository)
+  def mapper = Mock(ValueSetFhirMapper)
+  // SNOMED provider — recognised via getCodeSystemId() == "snomed-ct". Delegated
+  // to by the operation for `?fhir_vs[=...]` URLs. The mock captures the
+  // synthesised rule so tests can assert on the filter (operator + value) the
+  // operation derived from the URL.
+  def snomedProvider = Mock(ValueSetExternalExpandProvider) {
+    getCodeSystemId() >> "snomed-ct"
+  }
+
+  def operation = new ValueSetExpandOperation(
+      valueSetService,
+      provenanceService,
+      valueSetVersionService,
+      valueSetVersionConceptService,
+      valueSetVersionConceptRepository,
+      mapper,
+      [snomedProvider])
+
+  /**
+   * Snapshot the operation hands off to {@link ValueSetFhirMapper#toFhir}.
+   * Captured by the mocked mapper. For the inline-VS path the operation
+   * builds the response itself and this stays null.
+   */
+  ValueSetSnapshot capturedSnapshot
+
+  def setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+    // Capture the snapshot the operation hands off, return a stub so the caller
+    // can keep going.
+    mapper.toFhir(_, _, _, _ as ValueSetSnapshot, _) >> { args ->
+      capturedSnapshot = args[3] as ValueSetSnapshot
+      return new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    }
+  }
+
+  def cleanup() {
+    SessionStore.clearLocal()
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // Stored-VS path: $expand?url=<stored-VS.uri>
+  // ---------------------------------------------------------------------------
+
+  def "stored-VS expand without offset/count hands full snapshot to mapper"() {
+    given:
+    stubStoredValueSet(50)
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/vs"))
+
+    when:
+    operation.run(req)
+
+    then:
+    capturedSnapshot.expansion.size() == 50
+    capturedSnapshot.expansion[0].concept.code == "code_0"
+    capturedSnapshot.expansion[49].concept.code == "code_49"
+  }
+
+  def "stored-VS expand with count=10 paginates the snapshot to 10 items"() {
+    given:
+    stubStoredValueSet(100)
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/vs"))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(10))
+
+    when:
+    operation.run(req)
+
+    then:
+    capturedSnapshot.expansion.size() == 10
+    capturedSnapshot.expansion[0].concept.code == "code_0"
+    capturedSnapshot.expansion[9].concept.code == "code_9"
+  }
+
+  def "stored-VS expand with offset=20 count=5 returns slice starting at offset"() {
+    given:
+    stubStoredValueSet(100)
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/vs"))
+        .addParameter(new Parameters.ParametersParameter("offset").setValueInteger(20))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(5))
+
+    when:
+    operation.run(req)
+
+    then:
+    capturedSnapshot.expansion.size() == 5
+    capturedSnapshot.expansion[0].concept.code == "code_20"
+    capturedSnapshot.expansion[4].concept.code == "code_24"
+  }
+
+  def "stored-VS expand with offset=10 (no count) skips first 10 items"() {
+    given:
+    stubStoredValueSet(30)
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/vs"))
+        .addParameter(new Parameters.ParametersParameter("offset").setValueInteger(10))
+
+    when:
+    operation.run(req)
+
+    then:
+    capturedSnapshot.expansion.size() == 20
+    capturedSnapshot.expansion[0].concept.code == "code_10"
+    capturedSnapshot.expansion[19].concept.code == "code_29"
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // URL not matching any stored ValueSet
+  // ---------------------------------------------------------------------------
+
+  def "expand with url that does not match any stored ValueSet returns 404"() {
+    // Documents the missing implicit-ValueSet-over-CodeSystem feature.
+    // FHIR spec lets a client paginate a CodeSystem by passing its canonical
+    // URL as the $expand `url` parameter; TermX currently does not synthesise
+    // a ValueSet for a CodeSystem URL and instead 404s.
+    given:
+    valueSetService.query(_) >> QueryResult.empty()
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://snomed.info/sct"))
+
+    when:
+    operation.run(req)
+
+    then:
+    def e = thrown(FhirException)
+    e.statusCode == 404
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // Inline-VS path: POST with Parameters.parameter[name=valueSet].resource
+  // ---------------------------------------------------------------------------
+
+  def "inline-VS expand without offset/count returns all concepts"() {
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> (0..<10).collect { concept(it) }
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 10
+    result.expansion.contains[0].code == "code_0"
+    result.expansion.contains[9].code == "code_9"
+  }
+
+  def "inline-VS expand with offset=2 count=3 returns slice starting at offset"() {
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> (0..<10).collect { concept(it) }
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+        .addParameter(new Parameters.ParametersParameter("offset").setValueInteger(2))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(3))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 3
+    result.expansion.contains[0].code == "code_2"
+    result.expansion.contains[2].code == "code_4"
+    result.expansion.offset == 2
+  }
+
+  def "inline-VS expand with count=4 (no offset) returns first 4 concepts"() {
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> (0..<10).collect { concept(it) }
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(4))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 4
+    result.expansion.contains[0].code == "code_0"
+    result.expansion.contains[3].code == "code_3"
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // SNOMED CT implicit-ValueSet URLs
+  //
+  // Per the HL7 UTG SNOMED CT page
+  // (https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html), every pattern below
+  // is layered on top of `http://snomed.info/sct[/<edition>/version/<date>]`
+  // and resolves to an implicit ValueSet:
+  //
+  //   ?fhir_vs                  — all concept ids in the edition/version
+  //   ?fhir_vs=isa/<sctid>      — concepts subsumed by <sctid>, **including <sctid> itself**
+  //   ?fhir_vs=refset           — all concept ids corresponding to reference sets
+  //   ?fhir_vs=refset/<sctid>   — active members of the reference set
+  //   ?fhir_vs=ecl/<ecl>        — concepts matching the URI-encoded ECL expression
+  //
+  // TermX delegates expansion of these URLs to the SNOMED
+  // ValueSetExternalExpandProvider (SnomedValueSetExpandProvider), which
+  // converts the rule's filter into ECL and calls Snowstorm via SnomedService.
+  // These tests pin the URL→filter translation: each pattern must produce a
+  // rule with the right operator+value so the existing provider's composeEcl
+  // produces the correct ECL string. The mock returns canned concepts so the
+  // operation's response wiring can also be asserted.
+  // ---------------------------------------------------------------------------
+
+  def "SNOMED ?fhir_vs (all concepts) delegates to provider with ECL `*`"() {
+    given:
+    ValueSetVersionRule capturedRule = null
+    snomedProvider.ruleExpand(_, _, _) >> { args ->
+      capturedRule = args[0] as ValueSetVersionRule
+      return [snomedConcept("404684003", "Clinical finding"),
+              snomedConcept("123037004", "Body structure"),
+              snomedConcept("71388002", "Procedure")]
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://snomed.info/sct?fhir_vs"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedRule != null
+    capturedRule.codeSystem == "snomed-ct"
+    capturedRule.type == "include"
+    capturedRule.filters.size() == 1
+    // "ecl" operator with value "*" — provider's composeEcl falls through and emits "*"
+    capturedRule.filters[0].operator == "ecl"
+    capturedRule.filters[0].value == "*"
+
+    result.expansion.contains.size() == 3
+    result.expansion.contains*.code.toSet() == ["404684003", "123037004", "71388002"].toSet()
+  }
+
+  def "SNOMED ?fhir_vs=isa/<code> delegates with is-a filter and includes the anchor"() {
+    // IG: "transitive is-a relationship … including the concept itself".
+    // composeEcl translates operator "is-a" → ECL prefix "<<" which is
+    // descendant-or-self semantics, so the anchor is included by Snowstorm.
+    given:
+    ValueSetVersionRule capturedRule = null
+    snomedProvider.ruleExpand(_, _, _) >> { args ->
+      capturedRule = args[0] as ValueSetVersionRule
+      return [snomedConcept("409822003", "Domain bacteria"),
+              snomedConcept("1052801005", "Domain bacteria isolate"),
+              snomedConcept("78239009",   "Gram-positive bacterium"),
+              snomedConcept("87172008",   "Gram-negative bacterium")]
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url")
+            .setValueUrl("http://snomed.info/sct?fhir_vs=isa/409822003"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedRule.filters[0].operator == "is-a"
+    capturedRule.filters[0].value == "409822003"
+
+    result.expansion.contains.size() == 4
+    result.expansion.contains*.code.contains("409822003") // anchor included per IG
+    result.expansion.contains*.code.toSet().containsAll(["1052801005", "78239009", "87172008"])
+  }
+
+  def "SNOMED ?fhir_vs=refset delegates with is-a 900000000000455006 (Reference set foundation)"() {
+    given:
+    ValueSetVersionRule capturedRule = null
+    snomedProvider.ruleExpand(_, _, _) >> { args ->
+      capturedRule = args[0] as ValueSetVersionRule
+      return [snomedConcept("733073007", "OWL axiom reference set"),
+              snomedConcept("900000000000497000", "CTV3 simple map reference set"),
+              snomedConcept("447562003", "ICD-10 complex map reference set")]
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url")
+            .setValueUrl("http://snomed.info/sct?fhir_vs=refset"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedRule.filters[0].operator == "is-a"
+    capturedRule.filters[0].value == "900000000000455006"
+
+    result.expansion.contains.size() == 3
+    result.expansion.contains*.code.contains("733073007")
+  }
+
+  def "SNOMED ?fhir_vs=refset/<code> delegates with `in` filter (refset members)"() {
+    given:
+    ValueSetVersionRule capturedRule = null
+    snomedProvider.ruleExpand(_, _, _) >> { args ->
+      capturedRule = args[0] as ValueSetVersionRule
+      return [snomedConcept("404684003", "Clinical finding (axiom)"),
+              snomedConcept("71388002",  "Procedure (axiom)")]
+    }
+
+    // 733073007 = OWL axiom reference set
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url")
+            .setValueUrl("http://snomed.info/sct?fhir_vs=refset/733073007"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedRule.filters[0].operator == "in"
+    capturedRule.filters[0].value == "733073007"
+
+    result.expansion.contains.size() == 2
+    result.expansion.contains*.code.toSet() == ["404684003", "71388002"].toSet()
+  }
+
+  def "SNOMED ?fhir_vs=ecl/<expr> URL-decodes and passes the expression through"() {
+    given:
+    ValueSetVersionRule capturedRule = null
+    snomedProvider.ruleExpand(_, _, _) >> { args ->
+      capturedRule = args[0] as ValueSetVersionRule
+      return [snomedConcept("363698007", "Finding site"),
+              snomedConcept("116676008", "Associated morphology")]
+    }
+
+    // ECL "<< 363787002" — descendants-or-self of 363787002 (Observable entity).
+    // IG mandates URI-encoding of the expression in the query string.
+    String ecl = java.net.URLEncoder.encode("<< 363787002", "UTF-8")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url")
+            .setValueUrl("http://snomed.info/sct?fhir_vs=ecl/${ecl}" as String))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedRule.filters[0].operator == "ecl"
+    capturedRule.filters[0].value == "<< 363787002" // URL-decoded
+    result.expansion.contains.size() == 2
+  }
+
+  def "SNOMED versioned URL passes the edition/version URI on the rule"() {
+    // IG: implementations populating the version element SHOULD use the URI
+    // form `http://snomed.info/sct/<sctid>/version/<YYYYMMDD>`. The provider's
+    // getBranch(...) parses the URI to a Snowstorm branch, so the operation
+    // must carry it through on rule.codeSystemVersion.
+    given:
+    ValueSetVersionRule capturedRule = null
+    snomedProvider.ruleExpand(_, _, _) >> { args ->
+      capturedRule = args[0] as ValueSetVersionRule
+      return [snomedConcept("409822003", "Domain bacteria"),
+              snomedConcept("78239009",  "Gram-positive bacterium")]
+    }
+
+    // 900000000000207008 = SNOMED International Edition
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url")
+            .setValueUrl("http://snomed.info/sct/900000000000207008/version/20240101?fhir_vs=isa/409822003"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedRule.filters[0].operator == "is-a"
+    capturedRule.filters[0].value == "409822003"
+    capturedRule.codeSystemVersion != null
+    capturedRule.codeSystemVersion.uri == "http://snomed.info/sct/900000000000207008/version/20240101"
+
+    result.expansion.contains.size() == 2
+    result.expansion.contains*.code.contains("409822003")
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // Filter parameter (typeahead) — currently unimplemented at the Java layer
+  // ---------------------------------------------------------------------------
+
+  def "stored-VS expand with filter restricts results to matching concepts"() {
+    // FHIR $expand `filter` is a free-text typeahead filter applied to the
+    // expansion. TermX accepts the parameter but does not apply it — the
+    // operation passes the un-filtered snapshot to the mapper unchanged.
+    given:
+    stubStoredValueSet(5,
+        [new ValueSetVersionConceptValue().setCode("apple").setCodeSystem("cs"),
+         new ValueSetVersionConceptValue().setCode("apricot").setCodeSystem("cs"),
+         new ValueSetVersionConceptValue().setCode("banana").setCodeSystem("cs"),
+         new ValueSetVersionConceptValue().setCode("blueberry").setCodeSystem("cs"),
+         new ValueSetVersionConceptValue().setCode("cherry").setCodeSystem("cs")])
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/vs"))
+        .addParameter(new Parameters.ParametersParameter("filter").setValueString("ap"))
+
+    when:
+    operation.run(req)
+
+    then:
+    capturedSnapshot.expansion.size() == 2
+    capturedSnapshot.expansion*.concept.code.toSet() == ["apple", "apricot"].toSet()
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private static ValueSetVersionConcept concept(int i) {
+    return new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConceptValue()
+            .setCode("code_${i}" as String)
+            .setCodeSystem("cs")
+            .setCodeSystemUri("http://example.org/cs"))
+        .setOrderNumber(i)
+  }
+
+  private static ValueSetVersionConcept snomedConcept(String code, String display) {
+    return new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConceptValue()
+            .setCode(code)
+            .setCodeSystem("snomed-ct")
+            .setCodeSystemUri("http://snomed.info/sct"))
+        .setDisplay(new org.termx.ts.codesystem.Designation().setName(display).setLanguage("en"))
+  }
+
+  private static ValueSetVersionConcept conceptFrom(ValueSetVersionConceptValue value, int order) {
+    return new ValueSetVersionConcept().setConcept(value).setOrderNumber(order)
+  }
+
+  private void stubStoredValueSet(int totalConcepts) {
+    def concepts = (0..<totalConcepts).collect { concept(it) }
+    stubStoredValueSetWithConcepts(concepts)
+  }
+
+  private void stubStoredValueSet(int totalConcepts, List<ValueSetVersionConceptValue> values) {
+    def concepts = []
+    values.eachWithIndex { v, i -> concepts << conceptFrom(v, i) }
+    stubStoredValueSetWithConcepts(concepts)
+  }
+
+  private void stubStoredValueSetWithConcepts(List<ValueSetVersionConcept> concepts) {
+    def vs = new ValueSet().setUri("http://example.org/vs")
+    vs.setId("vs1")
+    def vsv = new ValueSetVersion().setPreferredLanguage("en")
+    vsv.setVersion("1.0.0").setValueSet("vs1").setId(7L)
+    def snapshot = new ValueSetSnapshot()
+        .setExpansion(concepts)
+        .setConceptsTotal(concepts.size())
+
+    valueSetService.query(_) >> new QueryResult<>([vs])
+    valueSetVersionService.loadLastVersion("vs1") >> vsv
+    valueSetVersionConceptService.expand("vs1", "1.0.0", null, false) >> snapshot
+    provenanceService.find("ValueSetVersion|7") >> []
+  }
+}


### PR DESCRIPTION
## Summary

Two things in one PR because the tests grew alongside both:

**1. Stored-VS `\$expand` paging/filter bugs**

The operation accepted `offset`/`count`/`filter` parameters but didn't honour them on the stored-VS code path:

- `expandedConcepts` was paginated into a local variable, but the un-paginated `ValueSetSnapshot` was the one handed to `ValueSetFhirMapper.toFhir` → response always carried the full expansion.
- `expandedConcepts.subList(0, offset)` kept the **first** `offset` items instead of skipping them.
- `filter` (FHIR R5 free-text typeahead) was silently dropped.

The inline-VS path was already correct — the fix mirrors its semantics on the stored-VS path. A copy of the snapshot is built before handing off (the service can return a cached `version.getSnapshot()`, so direct mutation would poison shared state).

**2. SNOMED CT implicit-ValueSet URLs via Snowstorm**

Per the [HL7 UTG SNOMED CT page](https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html), `http://snomed.info/sct[/<edition>/version/<date>]?fhir_vs[=...]` resolves to an implicit ValueSet. TermX already has a Snowstorm-backed `SnomedValueSetExpandProvider` — this PR wires the implicit URLs to it.

URL → rule filter translation:

| Pattern | Synthesised filter | ECL emitted by `composeEcl` |
|---|---|---|
| `?fhir_vs` | `operator=ecl, value="*"` | `*` |
| `?fhir_vs=isa/<sctid>` | `operator=is-a, value=<sctid>` | `<<<sctid>` |
| `?fhir_vs=refset` | `operator=is-a, value=900000000000455006` | `<<900000000000455006` |
| `?fhir_vs=refset/<sctid>` | `operator=in, value=<sctid>` | `^<sctid>` |
| `?fhir_vs=ecl/<URL-encoded>` | `operator=ecl, value=<URL-decoded>` | `<expr>` |

`SnomedValueSetExpandProvider` and its ECL translation are **unchanged** — `composeEcl` already passes unknown operators (like `ecl`) through verbatim. Versioned canonical is carried on `rule.codeSystemVersion.uri`; the provider's existing `getBranch(...)` knows how to parse it.

## Test plan

`ValueSetExpandOperationTest` — 15 specs, all green:

- Stored-VS: full snapshot baseline, `count=10`, `offset=20 count=5`, `offset=10 (no count)`, `filter="ap"` substring
- Inline-VS: full snapshot, `offset=2 count=3`, `count=4 (no offset)`
- 404 on `url` that resolves to neither a stored VS nor a SNOMED implicit
- SNOMED: all 5 `?fhir_vs` patterns + versioned canonical URL — each asserts on the **captured `ValueSetVersionRule`** (operator + value) so the URL→ECL contract is pinned, not just "doesn't 404"

Full terminology suite: 120/121, 1 skipped. The single failure (`ConceptExportServiceTest`) is pre-existing on `main` (9 weeks old, reflective `composeHeaders` invocation, unrelated to `\$expand`).

## Out of scope

- `expansion.total` is currently set to the **pre-paging** count on the SNOMED path (FHIR-correct) but to the **post-paging** size in `ValueSetFhirMapper.toFhirExpansion(...)` for the stored-VS path. Separate cleanup.
- For SNOMED `?fhir_vs` (all concepts), the provider materialises the full result before client-side paging. Functionally correct; if it bites in practice, push `offset`/`count` down to `SnomedService.searchConcepts`.
- Implicit-ValueSet support for non-SNOMED CodeSystem canonicals.