### PR TITLE
fix($expand): expansion.total + display correctness; implicit-CS via ConceptService.query

### DIFF
--- a/docs/features/value-set-expand.md
+++ b/docs/features/value-set-expand.md
@@ -1,8 +1,8 @@
 # FHIR `ValueSet/$expand`
 
-**Feature:** Paged, filtered `$expand` over stored ValueSets, inline ValueSets posted in the request body, **implicit ValueSets synthesised over any stored CodeSystem**, and SNOMED CT implicit-ValueSet URLs (`?fhir_vs[=…]`).
+**Feature:** Paged, filtered `$expand` over stored ValueSets, inline ValueSets posted in the request body, **implicit ValueSets over any stored CodeSystem** (delegated to `ConceptService.query`), and SNOMED CT implicit-ValueSet URLs (`?fhir_vs[=…]`).
 **Spans:** [`terminology`](../../terminology) module (`ValueSetExpandOperation`) + delegation to [`snomed`](../../snomed) module (`SnomedValueSetExpandProvider` → Snowstorm).
-**Introduced:** [termx-server#145](https://github.com/termx-health/termx-server/pull/145) — paging/filter fix on stored-VS path, SNOMED implicit-VS URL routing. Extended in [#146](https://github.com/termx-health/termx-server/pull/146) — synthetic VS over any stored CodeSystem URI (`http://loinc.org/answer-list`, `http://loinc.org/answer-list|2.82`, …).
+**Introduced:** [termx-server#145](https://github.com/termx-health/termx-server/pull/145) — paging/filter fix on stored-VS path, SNOMED implicit-VS URL routing. Extended in [#146](https://github.com/termx-health/termx-server/pull/146) — CodeSystem-canonical resolution via inline VS synthesis. Refined in [#147](https://github.com/termx-health/termx-server/pull/147) — `expansion.total` correctness on all paths; implicit-CS path now routes through `ConceptService.query` instead of the SQL function so displays surface correctly and pagination happens at the DB level.
 
 ---
 
@@ -15,7 +15,7 @@
 | 1 | **Inline-VS** | `valueSet` parameter carries a `ValueSet` resource constructed by the client | `ValueSetVersionConceptRepository.expandFromJson(...)` — Postgres function `value_set_expand_jsonb` resolves `compose.include[].system + filter + concept` directly |
 | 2 | **SNOMED implicit-VS** | `url` is `http://snomed.info/sct[/<edition>/version/<date>]?fhir_vs[=…]` | `SnomedValueSetExpandProvider.ruleExpand(...)` — calls Snowstorm via `SnomedService.searchConcepts(ecl=…, branch=…)` |
 | 3 | **Stored-VS** | `url` matches a `ValueSet.uri` already stored in TermX, or the operation runs at instance level (`/ValueSet/{id}/$expand`) | `ValueSetVersionConceptService.expand(...)` — snapshot persisted by TermX (re-uses cache when current) |
-| 4 | **Implicit VS over a stored CodeSystem** | `url` matches a `CodeSystem.uri`; no matching stored VS exists | Synthesises an inline ValueSet with `compose.include[].system=<url>` (+ optional `version`) and routes through path 1 |
+| 4 | **Implicit VS over a stored CodeSystem** | `url` matches a `CodeSystem.uri`; no matching stored VS exists | Delegates to `ConceptService.query(codeSystem=…, codeSystemVersion=…, textContains=filter, limit=count, offset=offset, displayLanguage=…)` — same path the UI's concept-list endpoint uses |
 
 A request that resolves none of the four returns `404 NOTFOUND`.
 
@@ -136,21 +136,24 @@ When no `?fhir_vs` query is present (`http://snomed.info/sct` alone), the operat
 
 ## 6. Implicit ValueSet over a stored CodeSystem
 
-Any `url` that doesn't match a stored ValueSet but **does** match a stored `CodeSystem.uri` is treated as the implicit ValueSet of that CodeSystem. The operation synthesises:
+Any `url` that doesn't match a stored ValueSet but **does** match a stored `CodeSystem.uri` is treated as the implicit ValueSet of that CodeSystem. After URL cleaning (see syntax table below), the operation delegates to `ConceptService.query(...)` — the same internal API the UI's concept-list endpoint uses — with the following parameter mapping:
 
-```json
-{
-  "resourceType": "ValueSet",
-  "url":     "<stripped-canonical>",
-  "status":  "active",
-  "compose": { "include": [{
-    "system":  "<stripped-canonical>",
-    "version": "<resolved-version, if any>"
-  }]}
-}
-```
+| `$expand` parameter | `ConceptQueryParams` field |
+|---|---|
+| `url` (canonical) | `codeSystem` (id of the resolved `CodeSystem.uri`) |
+| `valueSetVersion` / pipe-version | `codeSystemVersion` |
+| `filter` | `textContains` (matches concept code **and** display) |
+| `displayLanguage` / `defaultLanguage` | `displayLanguage` |
+| `count` | `limit` |
+| `offset` | `offset` |
 
-and routes it through the inline-VS path (`expandFromJson`). `filter`, `offset`, `count`, and the rest of the parameter set apply unchanged.
+The response is built from the `QueryResult<Concept>`:
+
+- `expansion.total` ← `result.meta.total` (pre-paging count from the DB)
+- `expansion.contains[].code` ← `concept.code`
+- `expansion.contains[].display` ← `ConceptUtil.getDisplay(concept.versions[0].designations, displayLanguage, [])` — same helper `CodeSystemLookupOperation` uses
+
+**Why this route and not the SQL function?** The `value_set_expand_jsonb` SQL function is built for arbitrary compose rules (filters, exclusions, recursion). For the implicit-CS case the synthesised compose has only `{system, version}` — no filter complexity — and the SQL function's `cs` CTE doesn't fetch designations for system-only includes (LOINC bug observed on dev.termx.org). `ConceptService.query` fetches designations by default, pushes `limit`/`offset` into the DB, and reports the pre-paging total — three properties this path needs and the SQL function doesn't provide for system-only includes.
 
 ### URL syntax tolerated
 
@@ -166,7 +169,7 @@ Non-SNOMED canonicals with a **valued** `?fhir_vs=<pattern>` (e.g. `http://loinc
 
 ## 7. Test coverage
 
-Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy` — 20 specs.
+Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy` — 25 specs.
 
 **Stored-VS** (5 specs)
 
@@ -184,6 +187,17 @@ Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/op
 - `inline-VS expand with offset=2 count=3 returns slice starting at offset`
 - `inline-VS expand with count=4 (no offset) returns first 4 concepts`
 
+**`expansion.total` correctness** (3 specs) — FHIR R5: total reflects the post-filter, pre-pagination count.
+
+- `inline-VS expand: expansion.total is the full pre-paging count`
+- `inline-VS expand: total reflects the post-filter pre-paging count`
+- `implicit-CS expand: expansion.total is the full pre-paging count from ConceptService`
+
+**`expansion.contains[].display` propagation** (2 specs)
+
+- `inline-VS expand: contains[].display is populated from concept's display field`
+- `implicit-CS expand: contains[].display is picked from the concept's designations`
+
 **SNOMED implicit-VS** (6 specs) — each asserts on the **captured `ValueSetVersionRule`** (operator + value) the operation hands to the mocked `ValueSetExternalExpandProvider`, so the URL→ECL contract is pinned, not just "the call doesn't 404":
 
 - ``SNOMED ?fhir_vs (all concepts) delegates to provider with ECL `*` ``
@@ -193,19 +207,19 @@ Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/op
 - `SNOMED ?fhir_vs=ecl/<expr> URL-decodes and passes the expression through`
 - `SNOMED versioned URL passes the edition/version URI on the rule`
 
-**Implicit VS over a stored CodeSystem** (6 specs) — each captures the JSON the operation hands to `expandFromJson` and asserts the synthesised `compose.include[].system` (+ optional `version`):
+**Implicit VS over a stored CodeSystem** (6 specs) — each captures the `ConceptQueryParams` the operation hands to the mocked `ConceptService.query`, so the URL → query-param translation (`codeSystem`, `codeSystemVersion`, `limit`, `offset`) is pinned:
 
-- `expand with url matching a stored CodeSystem synthesises inline VS over that CS`
+- `expand with url matching a stored CodeSystem delegates to ConceptService.query`
 - `expand with url + bare ?fhir_vs strips the suffix and resolves via CS lookup`
-- `expand with parent CodeSystem canonical (http://loinc.org) ?fhir_vs synthesises VS for the parent CS`
+- `expand with parent CodeSystem canonical (http://loinc.org) ?fhir_vs delegates against that CS`
 - `expand with url containing |<version> canonical syntax extracts the version`
 - `expand with url + valueSetVersion param pins the include version`
 - `expand with url matching neither stored ValueSet nor stored CodeSystem returns 404`
 
 ## 8. Limitations & known gaps
 
-- **`expansion.total` on stored-VS path** reports the post-paging slice size because the mapper at `ValueSetFhirMapper.toFhirExpansion(...)` reads `concepts.size()` rather than `snapshot.conceptsTotal`. The operation now passes the original `conceptsTotal` through on a snapshot copy, but the mapper still wins. Cosmetic — clients can fall back to `expansion.contains.length + offset` for now. Separate task.
 - **SNOMED "all concepts" materialises the full result** before client-side paging. `SnomedValueSetExpandProvider.filterConcepts()` uses `SnomedConceptSearchParams.setAll(true)`, which is fine for hundreds of concepts but expensive for the international edition (~350k). The fix is to push `offset`/`count` down into `SnomedService.searchConcepts`; left as a separate optimisation.
 - **`filter` on the SNOMED path is client-side**. Snowstorm's ECL doesn't carry a free-text filter parameter, so TermX applies the substring match after the provider returns. Functionally correct, less efficient than letting Snowstorm filter.
 - **Non-SNOMED `?fhir_vs=<pattern>` URLs are not interpreted.** The full `?fhir_vs=isa/…`, `?fhir_vs=refset[/…]`, `?fhir_vs=ecl/…` family is SNOMED-only; the bare `?fhir_vs` suffix is leniently stripped on any canonical, but non-SNOMED canonicals with a valued `?fhir_vs=…` 404. Equivalent semantics on LOINC etc. would need a per-CodeSystem ECL-like evaluator that TermX doesn't currently embed.
 - **`activeOnly` is honoured only on the stored-VS / inline-VS paths.** For SNOMED, "active" semantics depend on Snowstorm and the ECL expression — most patterns (`isa/`, `refset/`) already return active concepts by default.
+- **Latent: SQL function `value_set_expand_jsonb` drops `display` on system-only includes.** A client posting an inline ValueSet whose `compose.include[]` has only `{system, version}` (no `concept[]`) and going through the inline-VS path will get codes back without displays. The implicit-CS path no longer goes through this function (it routes through `ConceptService.query` instead) so the user-visible bug is fixed for that case. Clients hitting the inline-VS path with system-only includes should either include explicit `concept[]` entries or fetch displays out-of-band; a SQL-level fix is tracked separately.

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -344,7 +344,11 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     if (concepts == null) {
       return expansion;
     }
-    expansion.setTotal(concepts.size());
+    // FHIR R5: expansion.total is the post-filter, pre-pagination count. The
+    // operation pre-populates snapshot.conceptsTotal with that value before
+    // handing off; fall back to concepts.size() only when the snapshot is
+    // un-paginated (e.g. legacy callers).
+    expansion.setTotal(snapshot.getConceptsTotal() != null ? snapshot.getConceptsTotal() : concepts.size());
     expansion.setParameter(toValueSetParameter(param));
     expansion.setTimestamp(snapshot.getCreatedAt());
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -12,13 +12,20 @@ import org.termx.terminology.fhir.valueset.ValueSetFhirMapper;
 import org.termx.core.sys.provenance.Provenance;
 import org.termx.core.sys.provenance.ProvenanceService;
 import org.termx.terminology.terminology.codesystem.CodeSystemService;
+import org.termx.terminology.terminology.codesystem.concept.ConceptService;
+import org.termx.terminology.terminology.codesystem.concept.ConceptUtil;
 import org.termx.terminology.terminology.valueset.ValueSetService;
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository;
 import org.termx.ts.codesystem.CodeSystem;
+import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemQueryParams;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
+import org.termx.ts.codesystem.Concept;
+import org.termx.ts.codesystem.ConceptQueryParams;
+import org.termx.ts.codesystem.Designation;
+import com.kodality.commons.model.QueryResult;
 import org.termx.ts.valueset.*;
 import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule;
 import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter;
@@ -45,6 +52,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   private final ValueSetFhirMapper mapper;
   private final List<ValueSetExternalExpandProvider> externalExpandProviders;
   private final CodeSystemService codeSystemService;
+  private final ConceptService conceptService;
 
   // SNOMED CT implicit-ValueSet URL family
   // https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html
@@ -172,6 +180,10 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       }).toList();
     }
 
+    // FHIR R5 expansion.total: post-filter, pre-pagination count. Capture HERE.
+    // The mapper reads snapshot.conceptsTotal in preference to expansion.size().
+    int totalAfterFilter = expandedConcepts.size();
+
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
     if (offset != null) {
@@ -187,13 +199,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // The service may return a cached snapshot (see ValueSetVersionConceptService.expand
     // line ~83 — `version.getSnapshot()` is reused when current and unfiltered), so
     // mutating it would poison shared state. Build a copy with the trimmed expansion
-    // while preserving the original conceptsTotal for FHIR-correct expansion.total.
+    // and the FHIR-correct conceptsTotal (post-filter, pre-paging).
     if (expandedConcepts != snapshot.getExpansion()) {
       snapshot = new ValueSetSnapshot()
           .setId(snapshot.getId())
           .setValueSet(snapshot.getValueSet())
           .setValueSetVersion(snapshot.getValueSetVersion())
-          .setConceptsTotal(snapshot.getConceptsTotal())
+          .setConceptsTotal(totalAfterFilter)
           .setExpansion(expandedConcepts)
           .setDependencies(snapshot.getDependencies())
           .setCreatedAt(snapshot.getCreatedAt())
@@ -220,11 +232,34 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         .map(pr -> pr.getValueBoolean() != null && pr.getValueBoolean() || "true".equals(pr.getValueString()))
         .orElse(false);
 
+    // Apply FHIR R5 `filter` (free-text typeahead) before pagination, matching
+    // the stored-VS path semantics. Filters affect `expansion.total`;
+    // pagination does not.
+    String textFilter = req == null ? null : req.findParameter("filter")
+        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+    if (textFilter != null && !textFilter.isBlank()) {
+      String needle = textFilter.toLowerCase();
+      expandedConcepts = expandedConcepts.stream().filter(c -> {
+        String code = c.getConcept() != null ? c.getConcept().getCode() : null;
+        String display = c.getDisplay() != null ? c.getDisplay().getName() : null;
+        return (code != null && code.toLowerCase().contains(needle))
+            || (display != null && display.toLowerCase().contains(needle));
+      }).toList();
+    }
+
+    // FHIR R5 ValueSet.expansion.total: "If the number of codes in an expansion
+    // is changed by the parameters supplied, then this should be the count of
+    // codes corresponding to the parameters." Filters change the set; offset
+    // and count only window it. Capture total HERE — after filter, before
+    // pagination — so the response reflects the full set size and clients can
+    // paginate without re-issuing a `count=0` discovery probe.
+    int totalAfterFilter = expandedConcepts.size();
+
     // Apply paging
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
     if (offset != null) {
-      expandedConcepts = offset > expandedConcepts.size() ? List.of() : expandedConcepts.subList(offset, expandedConcepts.size());
+      expandedConcepts = offset >= expandedConcepts.size() ? List.of() : expandedConcepts.subList(offset, expandedConcepts.size());
     }
     Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("count").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
@@ -242,10 +277,10 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     response.setCompose(inlineVs.getCompose());
 
     // Build expansion
-    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion expansion = 
+    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion expansion =
         new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion();
     expansion.setTimestamp(java.time.OffsetDateTime.now());
-    expansion.setTotal(expandedConcepts.size());
+    expansion.setTotal(totalAfterFilter);
     if (offset != null) {
       expansion.setOffset(offset);
     }
@@ -434,29 +469,30 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   // ===========================================================================
 
   /**
-   * If {@code url} matches a stored CodeSystem URI, synthesise an inline
-   * ValueSet whose {@code compose.include[].system} (and optional
-   * {@code version}) points at that CodeSystem, then route through the inline
-   * expand path. Returns {@code null} when no matching CodeSystem exists so
-   * the caller can 404.
+   * If {@code url} matches a stored CodeSystem URI, delegate expansion to the
+   * internal {@link ConceptService#query} API. This bypasses the SQL function
+   * `value_set_expand_jsonb`, which is built for arbitrary compose rules and
+   * doesn't fetch designations for system-only includes; the concept-query API
+   * does both display resolution and DB-level pagination correctly. Returns
+   * {@code null} when no matching CodeSystem exists so the caller can 404.
    *
    * <p>Tolerated URL forms:
    * <ul>
    *   <li>{@code <canonical>}                       — bare canonical</li>
    *   <li>{@code <canonical>?fhir_vs}               — bare fhir_vs suffix is stripped (SNOMED-only when valued)</li>
-   *   <li>{@code <canonical>|<version>}             — pipe-version syntax; the version is forwarded as compose.include[].version</li>
+   *   <li>{@code <canonical>|<version>}             — pipe-version syntax</li>
    *   <li>{@code <canonical>|<version>?fhir_vs}     — combination of the above</li>
    * </ul>
    * The {@code valueSetVersion} parameter wins when both it and the pipe form
-   * carry a version (the latter is the client-supplied source of truth).
+   * carry a version.
    */
   private com.kodality.zmei.fhir.resource.terminology.ValueSet tryExpandCodeSystemImplicit(String url, String versionNr, Parameters req) {
     if (url == null) {
       return null;
     }
     String stripped = url;
-    // Strip bare ?fhir_vs suffix (with or without trailing slash). Non-SNOMED
-    // ?fhir_vs=<pattern> URLs aren't interpreted — they fall through and 404.
+    // Strip bare ?fhir_vs suffix. Non-SNOMED ?fhir_vs=<pattern> URLs aren't
+    // interpreted — they fall through and 404.
     int qIdx = stripped.indexOf('?');
     if (qIdx >= 0) {
       String query = stripped.substring(qIdx + 1);
@@ -476,8 +512,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       return null;
     }
 
-    // Resolve the CodeSystem by URI. We don't need the full body — only
-    // confirmation that the canonical exists. Empty result → fall through 404.
+    // Resolve the CodeSystem by URI. Empty result → fall through to 404.
     CodeSystemQueryParams csParams = new CodeSystemQueryParams();
     csParams.setUri(stripped);
     csParams.setLimit(1);
@@ -486,24 +521,76 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       return null;
     }
 
-    // Prefer the explicit valueSetVersion parameter; fall back to the
-    // pipe-version. Either is forwarded as compose.include[].version.
     String resolvedVersion = versionNr != null ? versionNr : pipeVersion;
 
-    com.kodality.zmei.fhir.resource.terminology.ValueSet synthesisedVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
-    synthesisedVs.setUrl(stripped);
-    synthesisedVs.setStatus("active");
-    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetCompose compose =
-        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetCompose();
-    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude include =
-        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude();
-    include.setSystem(stripped);
-    if (resolvedVersion != null) {
-      include.setVersion(resolvedVersion);
-    }
-    compose.setInclude(List.of(include));
-    synthesisedVs.setCompose(compose);
+    // Extract paging + filter + display-language parameters
+    String displayLanguage = req == null ? null : req.findParameter("displayLanguage").map(ParametersParameter::getValueCode)
+        .orElse(req.findParameter("displayLanguage").map(ParametersParameter::getValueString)
+        .orElse(req.findParameter("defaultLanguage").map(ParametersParameter::getValueCode)
+        .orElse(req.findParameter("defaultLanguage").map(ParametersParameter::getValueString).orElse(null))));
+    String textFilter = req == null ? null : req.findParameter("filter")
+        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+    Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
+        .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
+    Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
+        .orElse(req.findParameter("count").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
 
-    return expandInline(synthesisedVs, req);
+    // Delegate to the concept-query API — same path the UI's concept list uses.
+    // The API matches `textContains` against both code and display, returns
+    // designations for each concept, supports DB-level paging, and reports the
+    // pre-paging total in QueryResult.meta.
+    ConceptQueryParams cqParams = new ConceptQueryParams();
+    cqParams.setCodeSystem(cs.getId());
+    if (resolvedVersion != null) {
+      cqParams.setCodeSystemVersion(resolvedVersion);
+    }
+    if (textFilter != null && !textFilter.isBlank()) {
+      cqParams.setTextContains(textFilter);
+    }
+    if (displayLanguage != null) {
+      cqParams.setDisplayLanguage(displayLanguage);
+    }
+    if (count != null) {
+      cqParams.setLimit(count);
+    }
+    if (offset != null) {
+      cqParams.setOffset(offset);
+    }
+
+    QueryResult<Concept> result = conceptService.query(cqParams);
+    Integer total = result.getMeta() != null ? result.getMeta().getTotal() : null;
+    List<Concept> concepts = result.getData() != null ? result.getData() : Collections.emptyList();
+
+    com.kodality.zmei.fhir.resource.terminology.ValueSet response = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
+    response.setUrl(stripped);
+    response.setStatus("active");
+
+    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion expansion =
+        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion();
+    expansion.setTimestamp(java.time.OffsetDateTime.now());
+    expansion.setTotal(total != null ? total : concepts.size());
+    if (offset != null) {
+      expansion.setOffset(offset);
+    }
+
+    final String systemUri = stripped;
+    final String displayLang = displayLanguage;
+    expansion.setContains(concepts.stream().map(c -> {
+      com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains contain =
+          new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains();
+      contain.setSystem(systemUri);
+      contain.setCode(c.getCode());
+      // Pick the right display using the same helper CodeSystemLookupOperation uses.
+      List<Designation> designations = c.getVersions() != null && !c.getVersions().isEmpty() && c.getVersions().get(0).getDesignations() != null
+          ? c.getVersions().get(0).getDesignations()
+          : Collections.emptyList();
+      Designation display = ConceptUtil.getDisplay(designations, displayLang, List.of());
+      if (display != null) {
+        contain.setDisplay(display.getName());
+      }
+      return contain;
+    }).toList());
+    response.setExpansion(expansion);
+    return response;
   }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -9,12 +9,17 @@ import org.termx.core.sys.provenance.ProvenanceService
 import org.termx.core.ts.ValueSetExternalExpandProvider
 import org.termx.terminology.fhir.valueset.ValueSetFhirMapper
 import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
 import org.termx.terminology.terminology.valueset.ValueSetService
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
 import org.termx.ts.codesystem.CodeSystem
+import org.termx.ts.codesystem.CodeSystemEntityVersion
 import org.termx.ts.codesystem.CodeSystemQueryParams
+import org.termx.ts.codesystem.Concept
+import org.termx.ts.codesystem.ConceptQueryParams
+import org.termx.ts.codesystem.Designation
 import org.termx.ts.valueset.ValueSet
 import org.termx.ts.valueset.ValueSetSnapshot
 import org.termx.ts.valueset.ValueSetVersion
@@ -43,6 +48,7 @@ class ValueSetExpandOperationTest extends Specification {
   def valueSetVersionConceptRepository = Mock(ValueSetVersionConceptRepository)
   def mapper = Mock(ValueSetFhirMapper)
   def codeSystemService = Mock(CodeSystemService)
+  def conceptService = Mock(ConceptService)
   // SNOMED provider — recognised via getCodeSystemId() == "snomed-ct". Delegated
   // to by the operation for `?fhir_vs[=...]` URLs. The mock captures the
   // synthesised rule so tests can assert on the filter (operator + value) the
@@ -59,7 +65,8 @@ class ValueSetExpandOperationTest extends Specification {
       valueSetVersionConceptRepository,
       mapper,
       [snomedProvider],
-      codeSystemService)
+      codeSystemService,
+      conceptService)
 
   /**
    * Snapshot the operation hands off to {@link ValueSetFhirMapper#toFhir}.
@@ -156,18 +163,21 @@ class ValueSetExpandOperationTest extends Specification {
   // Implicit ValueSet over a stored CodeSystem
   //
   // When `url` doesn't match any stored ValueSet but DOES match a stored
-  // CodeSystem URI, TermX synthesises an inline ValueSet whose
-  // `compose.include[].system` (and optionally `.version`) point at the
-  // CodeSystem, then routes through the existing `expandFromJson` SQL path.
+  // CodeSystem URI, TermX delegates expansion to the internal
+  // ConceptService.query(...) — the same API the UI's concept-list endpoint
+  // uses. That gives correct displays (from the concept's designations),
+  // DB-level pagination, and a pre-paging total — three things the SQL
+  // function `value_set_expand_jsonb` does NOT do for system-only includes.
+  //
   // The `?fhir_vs` query convention is SNOMED-only, but a bare `?fhir_vs`
   // suffix on a non-SNOMED canonical is leniently stripped so client libraries
   // that always append it (or copy-paste examples) don't 404. The `|<version>`
   // canonical-with-version syntax is also accepted.
   // ---------------------------------------------------------------------------
 
-  def "expand with url matching a stored CodeSystem synthesises inline VS over that CS"() {
+  def "expand with url matching a stored CodeSystem delegates to ConceptService.query"() {
     given:
-    String capturedJson = null
+    ConceptQueryParams capturedParams = null
     valueSetService.query(_) >> QueryResult.empty()
     codeSystemService.query(_) >> { args ->
       CodeSystemQueryParams p = args[0]
@@ -175,9 +185,11 @@ class ValueSetExpandOperationTest extends Specification {
           ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org/answer-list").tap { setId("loinc-answer-list") }])
           : QueryResult.empty()
     }
-    valueSetVersionConceptRepository.expandFromJson(_) >> { args ->
-      capturedJson = args[0] as String
-      return (0..<3).collect { concept(it) }
+    conceptService.query(_) >> { args ->
+      capturedParams = args[0] as ConceptQueryParams
+      def qr = new QueryResult<Concept>([cncpt("a", "Alpha"), cncpt("b", "Beta"), cncpt("c", "Gamma")])
+      qr.meta.total = 3
+      return qr
     }
 
     def req = new Parameters()
@@ -187,24 +199,26 @@ class ValueSetExpandOperationTest extends Specification {
     def result = operation.run(req)
 
     then:
-    capturedJson != null
-    capturedJson.contains("http://loinc.org/answer-list")
+    capturedParams.codeSystem == "loinc-answer-list"
     result.expansion.contains.size() == 3
+    result.expansion.contains*.code == ["a", "b", "c"]
   }
 
   def "expand with url + bare ?fhir_vs strips the suffix and resolves via CS lookup"() {
     given:
-    String capturedJson = null
+    String capturedCs = null
     valueSetService.query(_) >> QueryResult.empty()
     codeSystemService.query(_) >> { args ->
       CodeSystemQueryParams p = args[0]
+      capturedCs = p.uri
       return p.uri == "http://loinc.org/answer-list"
           ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org/answer-list").tap { setId("loinc-answer-list") }])
           : QueryResult.empty()
     }
-    valueSetVersionConceptRepository.expandFromJson(_) >> { args ->
-      capturedJson = args[0] as String
-      return [concept(0), concept(1)]
+    conceptService.query(_) >> {
+      def qr = new QueryResult<Concept>([cncpt("a", "Alpha"), cncpt("b", "Beta")])
+      qr.meta.total = 2
+      return qr
     }
 
     def req = new Parameters()
@@ -214,13 +228,13 @@ class ValueSetExpandOperationTest extends Specification {
     def result = operation.run(req)
 
     then:
-    capturedJson.contains("http://loinc.org/answer-list")
-    !capturedJson.contains("fhir_vs") // suffix stripped before CS lookup
+    capturedCs == "http://loinc.org/answer-list" // suffix stripped before CS lookup
     result.expansion.contains.size() == 2
   }
 
-  def "expand with parent CodeSystem canonical (http://loinc.org) ?fhir_vs synthesises VS for the parent CS"() {
+  def "expand with parent CodeSystem canonical (http://loinc.org) ?fhir_vs delegates against that CS"() {
     given:
+    ConceptQueryParams capturedParams = null
     valueSetService.query(_) >> QueryResult.empty()
     codeSystemService.query(_) >> { args ->
       CodeSystemQueryParams p = args[0]
@@ -228,7 +242,12 @@ class ValueSetExpandOperationTest extends Specification {
           ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org").tap { setId("loinc") }])
           : QueryResult.empty()
     }
-    valueSetVersionConceptRepository.expandFromJson(_) >> (0..<5).collect { concept(it) }
+    conceptService.query(_) >> { args ->
+      capturedParams = args[0] as ConceptQueryParams
+      def qr = new QueryResult<Concept>((0..<5).collect { cncpt("c${it}" as String, "Display ${it}" as String) })
+      qr.meta.total = 5
+      return qr
+    }
 
     def req = new Parameters()
         .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://loinc.org?fhir_vs"))
@@ -237,12 +256,13 @@ class ValueSetExpandOperationTest extends Specification {
     def result = operation.run(req)
 
     then:
+    capturedParams.codeSystem == "loinc"
     result.expansion.contains.size() == 5
   }
 
   def "expand with url containing |<version> canonical syntax extracts the version"() {
     given:
-    String capturedJson = null
+    ConceptQueryParams capturedParams = null
     valueSetService.query(_) >> QueryResult.empty()
     codeSystemService.query(_) >> { args ->
       CodeSystemQueryParams p = args[0]
@@ -250,9 +270,11 @@ class ValueSetExpandOperationTest extends Specification {
           ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org/answer-list").tap { setId("loinc-answer-list") }])
           : QueryResult.empty()
     }
-    valueSetVersionConceptRepository.expandFromJson(_) >> { args ->
-      capturedJson = args[0] as String
-      return [concept(0)]
+    conceptService.query(_) >> { args ->
+      capturedParams = args[0] as ConceptQueryParams
+      def qr = new QueryResult<Concept>([cncpt("a", "Alpha")])
+      qr.meta.total = 1
+      return qr
     }
 
     def req = new Parameters()
@@ -262,15 +284,14 @@ class ValueSetExpandOperationTest extends Specification {
     def result = operation.run(req)
 
     then:
-    capturedJson.contains("http://loinc.org/answer-list")
-    capturedJson.contains("2.82") // version forwarded as compose.include[].version
-    !capturedJson.contains("|2.82") // pipe stripped from the system URI
+    capturedParams.codeSystem == "loinc-answer-list"
+    capturedParams.codeSystemVersion == "2.82"
     result.expansion.contains.size() == 1
   }
 
   def "expand with url + valueSetVersion param pins the include version"() {
     given:
-    String capturedJson = null
+    ConceptQueryParams capturedParams = null
     valueSetService.query(_) >> QueryResult.empty()
     codeSystemService.query(_) >> { args ->
       CodeSystemQueryParams p = args[0]
@@ -278,9 +299,11 @@ class ValueSetExpandOperationTest extends Specification {
           ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org/answer-list").tap { setId("loinc-answer-list") }])
           : QueryResult.empty()
     }
-    valueSetVersionConceptRepository.expandFromJson(_) >> { args ->
-      capturedJson = args[0] as String
-      return [concept(0)]
+    conceptService.query(_) >> { args ->
+      capturedParams = args[0] as ConceptQueryParams
+      def qr = new QueryResult<Concept>([cncpt("a", "Alpha")])
+      qr.meta.total = 1
+      return qr
     }
 
     def req = new Parameters()
@@ -291,8 +314,7 @@ class ValueSetExpandOperationTest extends Specification {
     def result = operation.run(req)
 
     then:
-    capturedJson.contains("http://loinc.org/answer-list")
-    capturedJson.contains("2.82")
+    capturedParams.codeSystemVersion == "2.82"
     result.expansion.contains.size() == 1
   }
 
@@ -375,6 +397,170 @@ class ValueSetExpandOperationTest extends Specification {
     result.expansion.contains.size() == 4
     result.expansion.contains[0].code == "code_0"
     result.expansion.contains[3].code == "code_3"
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // expansion.total
+  //
+  // FHIR R5 ValueSet.expansion.total:
+  //   "Total number of codes in the expansion. If the number of codes in an
+  //    expansion is changed by the parameters supplied, then this should be
+  //    the count of codes corresponding to the parameters."
+  //
+  // The "parameters" here are FILTERS (filter=, activeOnly) that change the
+  // set, NOT pagination (offset/count) which only changes the window. So
+  // `total` must be the post-filter, **pre-paging** count.
+  // ---------------------------------------------------------------------------
+
+  def "inline-VS expand: expansion.total is the full pre-paging count"() {
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> (0..<20).collect { concept(it) }
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(5))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 5
+    result.expansion.total == 20
+  }
+
+  def "implicit-CS expand: expansion.total is the full pre-paging count from ConceptService"() {
+    // The concept-query API reports the pre-paging total in QueryResult.meta.total.
+    // The operation must forward that as expansion.total — NOT the size of the
+    // paginated `data` list.
+    given:
+    ConceptQueryParams capturedParams = null
+    valueSetService.query(_) >> QueryResult.empty()
+    codeSystemService.query(_) >> { args ->
+      CodeSystemQueryParams p = args[0]
+      return p.uri == "http://loinc.org/answer-list"
+          ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org/answer-list").tap { setId("loinc-answer-list") }])
+          : QueryResult.empty()
+    }
+    conceptService.query(_) >> { args ->
+      capturedParams = args[0] as ConceptQueryParams
+      // 20 concepts returned (DB applied count=20), but the underlying set is 72656
+      def qr = new QueryResult<Concept>((0..<20).collect { cncpt("c${it}" as String, "Display ${it}" as String) })
+      qr.meta.total = 72656
+      return qr
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://loinc.org/answer-list?fhir_vs"))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(20))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedParams.limit == 20 // count pushed down to DB
+    result.expansion.contains.size() == 20
+    result.expansion.total == 72656 // pre-paging count from QueryResult.meta.total
+  }
+
+  def "inline-VS expand: total reflects the post-filter pre-paging count"() {
+    // When `filter` removes concepts, `total` should report the filtered count.
+    // Pagination (offset/count) then slices that filtered set, but total stays
+    // at the post-filter value.
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> [
+        concept(0).tap { it.getConcept().setCode("apple") },
+        concept(1).tap { it.getConcept().setCode("apricot") },
+        concept(2).tap { it.getConcept().setCode("banana") },
+        concept(3).tap { it.getConcept().setCode("blueberry") },
+        concept(4).tap { it.getConcept().setCode("cherry") }]
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+        .addParameter(new Parameters.ParametersParameter("filter").setValueString("ap"))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(1))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 1
+    result.expansion.total == 2 // apple + apricot match the filter, count=1 slices to 1
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // expansion.contains[].display
+  //
+  // FHIR contract: when the source concept carries a display, the expanded
+  // ValueSet must surface it on contains[].display. The Java projection in
+  // expandInline copies concept.display.name into contains[].display when
+  // present — these tests pin that contract so a future refactor doesn't
+  // regress it.
+  //
+  // (Separately, the SQL function `value_set_expand_jsonb` is responsible for
+  // populating concept.display in the first place. That contract belongs in
+  // an integration test against the real DB, not here.)
+  // ---------------------------------------------------------------------------
+
+  def "inline-VS expand: contains[].display is populated from concept's display field"() {
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> [
+        concept(0).tap { it.setDisplay(new org.termx.ts.codesystem.Designation().setName("Male").setLanguage("en")) },
+        concept(1).tap { it.setDisplay(new org.termx.ts.codesystem.Designation().setName("Female").setLanguage("en")) },
+        concept(2)] // no display
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 3
+    result.expansion.contains[0].display == "Male"
+    result.expansion.contains[1].display == "Female"
+    result.expansion.contains[2].display == null
+  }
+
+  def "implicit-CS expand: contains[].display is picked from the concept's designations"() {
+    // ConceptService.query returns Concepts with their versions and designations.
+    // The operation uses ConceptUtil.getDisplay(designations, preferredLang, ...)
+    // — same helper CodeSystemLookupOperation uses — to pick the display
+    // matching the requested language.
+    given:
+    valueSetService.query(_) >> QueryResult.empty()
+    codeSystemService.query(_) >> { args ->
+      CodeSystemQueryParams p = args[0]
+      return p.uri == "http://loinc.org/answer-list"
+          ? new QueryResult<>([new CodeSystem().setUri("http://loinc.org/answer-list").tap { setId("loinc-answer-list") }])
+          : QueryResult.empty()
+    }
+    conceptService.query(_) >> {
+      def qr = new QueryResult<Concept>([cncpt("LA29797-0", "Decreased")])
+      qr.meta.total = 1
+      return qr
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://loinc.org/answer-list"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 1
+    result.expansion.contains[0].code == "LA29797-0"
+    result.expansion.contains[0].display == "Decreased"
   }
 
 
@@ -606,6 +792,21 @@ class ValueSetExpandOperationTest extends Specification {
             .setCodeSystem("cs")
             .setCodeSystemUri("http://example.org/cs"))
         .setOrderNumber(i)
+  }
+
+  /**
+   * Build a real `Concept` (not a ValueSetVersionConcept) for tests that mock
+   * the concept-query API. The first version carries a single "display"
+   * designation in English — matches what the production code expects from
+   * ConceptService.query when displayLanguage is unset or "en".
+   */
+  private static Concept cncpt(String code, String displayName) {
+    return new Concept().tap { c ->
+      c.setCode(code)
+      c.setVersions([new CodeSystemEntityVersion().setDesignations([
+          new Designation().setName(displayName).setLanguage("en").setDesignationType("display")
+      ])])
+    }
   }
 
   private static ValueSetVersionConcept snomedConcept(String code, String display) {


### PR DESCRIPTION
## Summary

Two bugs the tx-router work surfaced against dev.termx.org's `\$expand`:

**1. `expansion.total` was the page size, not the full set size.** `count=20` against the 72656-concept LOINC `part` CodeSystem returned `total=20`. FHIR R5 says total is post-filter, pre-pagination — filters change the set, pagination only windows it.

**2. `expansion.contains[].display` was missing on the implicit-CS path.** LOINC concepts have displays in the source CodeSystem, but `\$expand` stripped them — the catalog's LEFT JOIN against `exact_concepts` is empty for system-only includes, so display came back NULL.

## What changed

**Inline-VS path** (`expandInline`)
- `filter` parameter was silently dropped (gap from #145 — only stored-VS had the wiring). Now applied as case-insensitive substring against code+display, before pagination.
- `total` is captured **after filter, before pagination** and used directly in `expansion.setTotal`.

**Stored-VS path** (`expand`)
- The snapshot copy handed to the mapper now carries `conceptsTotal = totalAfterFilter` instead of the un-filtered original.
- `ValueSetFhirMapper.toFhirExpansion` prefers `snapshot.conceptsTotal` over `concepts.size()` when set, falling back to the old behaviour for legacy callers.

**Implicit-CS path** — rerouted (the bigger structural change)

Before this PR the path synthesised an inline ValueSet with `compose.include[].system=<canonical>` and ran it through the SQL function `value_set_expand_jsonb`. That function's `cs` CTE only fetches designations from `exact_concepts` — codes explicitly listed in `compose.include[].concept[]` — so system-only includes (the whole point of the implicit-CS pattern) come back display-less.

The path now delegates to `ConceptService.query(...)` — the same internal API the UI's concept-list endpoint uses. URL → ConceptQueryParams mapping:

| `\$expand` parameter | `ConceptQueryParams` field |
|---|---|
| `url` canonical | `codeSystem` (from `CodeSystemService.query(uri=…)`) |
| `valueSetVersion` / pipe-version | `codeSystemVersion` |
| `filter` | `textContains` — matches code AND display (per user confirmation) |
| `count` | `limit` |
| `offset` | `offset` |
| `displayLanguage` / `defaultLanguage` | `displayLanguage` |

Response built from `QueryResult<Concept>`:

- `expansion.total` ← `result.meta.total` (pre-paging count, from the DB)
- `expansion.contains[].code` ← `concept.code`
- `expansion.contains[].display` ← `ConceptUtil.getDisplay(designations, displayLang, [])` (same helper `CodeSystemLookupOperation` uses)

**Three wins over the SQL-function route**: displays surface correctly (the reported LOINC bug), pagination pushed into the DB (no more materialising 72k concepts to return 20), and `expansion.total` is correct by construction.

The SQL function's display bug for system-only includes is now **latent** — the implicit-CS path doesn't hit it. Clients posting inline-VS bodies with `compose.include[]` that has only `{system, version}` (no `concept[]`) are still affected; tracked separately.

## Test plan

`ValueSetExpandOperationTest` — 25/25 green:

- 5 new specs:
  - 3 `expansion.total` correctness (inline, inline+filter, implicit-CS)
  - 2 `contains[].display` propagation (inline, implicit-CS)
- 6 implicit-CS specs rewritten to mock `ConceptService.query` and assert on the **captured `ConceptQueryParams`** (`codeSystem`, `codeSystemVersion`, `limit`) — pins the URL → internal-query contract, not just "doesn't 404"

Wider terminology suite: only the pre-existing `ConceptExportServiceTest` failure (9 weeks old, reflective `composeHeaders`, unrelated to `\$expand`).

## Docs

`docs/features/value-set-expand.md` updated:
- §1 path-4 row now reads "delegates to `ConceptService.query`"
- §6 rewritten with parameter-mapping table and rationale for the SQL-function bypass
- §7 test list shows 25 specs in 5 groups (added "expansion.total correctness" and "expansion.contains[].display propagation")
- §8 limitations: removed the now-fixed `expansion.total` cosmetic bug; added the latent SQL-function display bug for system-only inline includes

## Tx-router followup

User's note from the discussion that triggered this: *"Once those two are fixed I can drop the catalog-count fallback in ConceptPaginationHandler (the workaround for #1) and the UI will show displays without intervention."* Both fixed.