### PR TITLE
fix(test): ConceptExportServiceTest — use EntityProperty, not its parent PropertyReference

### DIFF
--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/concept/ConceptExportServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/concept/ConceptExportServiceTest.groovy
@@ -8,10 +8,10 @@ import org.termx.ts.codesystem.CodeSystemEntityVersion
 import org.termx.ts.codesystem.Concept
 import org.termx.ts.codesystem.ConceptQueryParams
 import org.termx.ts.codesystem.Designation
+import org.termx.ts.codesystem.EntityProperty
 import org.termx.ts.codesystem.EntityPropertyType
 import org.termx.ts.codesystem.EntityPropertyValue
 import org.termx.ts.codesystem.EntityPropertyValue.EntityPropertyValueCodingValue
-import org.termx.ts.property.PropertyReference
 import spock.lang.Specification
 
 import static org.termx.ts.codesystem.EntityPropertyType.coding
@@ -35,7 +35,7 @@ class ConceptExportServiceTest extends Specification {
     CodeSystem codeSystem = new CodeSystem()
     codeSystem.setId(codeSystemId)
     codeSystem.setProperties([
-      new PropertyReference().setName("status")
+      new EntityProperty().setName("status")
     ])
     
     // Create concept with designations
@@ -309,9 +309,9 @@ class ConceptExportServiceTest extends Specification {
     CodeSystem codeSystem = new CodeSystem()
     codeSystem.setId("test1")
     codeSystem.setProperties([
-      new PropertyReference().setName("itemWeight"),
-      new PropertyReference().setName("synonym"),
-      new PropertyReference().setName("type")
+      new EntityProperty().setName("itemWeight"),
+      new EntityProperty().setName("synonym"),
+      new EntityProperty().setName("type")
     ])
     
     // Concept a1: has display, itemWeight, 2 synonyms, 2 type codings
@@ -696,9 +696,9 @@ class ConceptExportServiceTest extends Specification {
     CodeSystem codeSystem = new CodeSystem()
     codeSystem.setId("test-cs")
     codeSystem.setProperties([
-      new PropertyReference().setName("itemWeight"),
-      new PropertyReference().setName("synonym"),
-      new PropertyReference().setName("type")
+      new EntityProperty().setName("itemWeight"),
+      new EntityProperty().setName("synonym"),
+      new EntityProperty().setName("type")
     ])
     
     Concept concept = new Concept()


### PR DESCRIPTION
## Summary

Fix a 9-week-old test failure in `ConceptExportServiceTest.should order columns correctly`.

The test was throwing `ClassCastException: PropertyReference cannot be cast to EntityProperty` at `ConceptExportService.composeHeaders:271`, because it stuffed `PropertyReference` instances into a slot typed `List<EntityProperty>` — `PropertyReference` is the *parent* of `EntityProperty`, not a subclass. Java would reject this at compile time, but Groovy's looser generic enforcement let it through; the runtime cast in production blew up.

The same commit that introduced the bad test (`d6e3848d`) also flipped an unrelated production-code spot from `PropertyReference::getName` → `EntityProperty::getName`, so the author was working through the type distinction — they just didn't update the test data alongside.

## Change

One file, 7 instance swaps + one import:

- `new PropertyReference()` → `new EntityProperty()`  (×7)
- `import org.termx.ts.property.PropertyReference` → `import org.termx.ts.codesystem.EntityProperty`

`EntityProperty extends PropertyReference`, so the swap is upcast-safe — all the existing `.setName(...)` calls in the test still resolve (inherited from the parent).

## Test plan

- `ConceptExportServiceTest`: 8/8 green (was 7 pass / 1 fail)
- Full `:terminology` test suite: 0 failures, 0 errors

## Out of scope

The production code at `ConceptExportService.java:271` could *also* be relaxed to iterate over `PropertyReference` (only `.getName()` is used in that block), avoiding the cast entirely. That's a wider refactor with no behaviour change; keeping this PR surgical.