### PR TITLE
fix(fhir-vs): push SNOMED ?fhir_vs $expand paging down to Snowstorm (OOM fix)

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedService.java
@@ -87,6 +87,20 @@ public class SnomedService {
     return snowstormClient.queryConcepts(params).join().getItems();
   }
 
+  /**
+   * Single-page variant of {@link #searchConcepts(SnomedConceptSearchParams)} that
+   * preserves the full {@link SnomedSearchResult} (notably {@code total}). Use this
+   * when the caller has a real page size to honour — the {@code setAll(true)} path
+   * iterates Snowstorm at limit=9999 until exhaustion and materialises the entire
+   * matching ECL set, which is fine for narrow filters but OOMs for ECL=*
+   * against an edition. Snowstorm itself honours {@code limit}/{@code offset}/
+   * {@code term} natively, so push the page down rather than slicing in memory.
+   * Caller must set limit and offset on {@code params}; {@code all} is ignored.
+   */
+  public SnomedSearchResult<SnomedConcept> searchConceptsPage(SnomedConceptSearchParams params) {
+    return snowstormClient.queryConcepts(params).join();
+  }
+
   public List<SnomedDescription> loadDescriptions(List<String> conceptIds) {
     return loadDescriptions(null, conceptIds);
   }

--- a/snomed/src/main/java/org/termx/snomed/ts/SnomedValueSetExpandProvider.java
+++ b/snomed/src/main/java/org/termx/snomed/ts/SnomedValueSetExpandProvider.java
@@ -1,11 +1,13 @@
 package org.termx.snomed.ts;
 
+import com.kodality.commons.model.QueryResult;
 import org.termx.core.ts.CodeSystemProvider;
 import org.termx.core.ts.ValueSetExternalExpandProvider;
 import org.termx.snomed.concept.SnomedConcept;
 import org.termx.snomed.concept.SnomedConceptSearchParams;
 import org.termx.snomed.description.SnomedDescription;
 import org.termx.snomed.integration.SnomedService;
+import org.termx.snomed.search.SnomedSearchResult;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
 import org.termx.ts.codesystem.ConceptQueryParams;
 import org.termx.ts.codesystem.Designation;
@@ -38,6 +40,11 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
   private static final String SNOMED_DESCENDENT_OF = "descendent-of";
   private static final String SNOMED_IN = "in";
 
+  // Snowstorm caps single-page `limit` at 10_000 (Elasticsearch from+size).
+  // A null `count` from the caller means "no client-side cap"; honour Snowstorm's
+  // ceiling rather than throwing.
+  private static final int SNOWSTORM_MAX_PAGE = 9999;
+
   public SnomedValueSetExpandProvider(SnomedMapper snomedMapper, SnomedService snomedService, CodeSystemProvider codeSystemProvider) {
     this.snomedMapper = snomedMapper;
     this.snomedService = snomedService;
@@ -62,6 +69,82 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
       concepts.forEach(c -> c.getConcept().setCodeSystemVersions(List.of(rule.getCodeSystemVersion().getVersion())));
     }
     return concepts;
+  }
+
+  /**
+   * Single-page expansion that pushes paging and the free-text typeahead filter
+   * down to Snowstorm — issues exactly one {@code concepts?ecl=…&limit=…&offset=…&term=…}
+   * call and loads descriptions only for the returned page. Compare with
+   * {@link #ruleExpand} which uses {@code SnomedService.searchConcepts(setAll(true))},
+   * looping Snowstorm at limit=9999 until the full ECL result is materialised in
+   * heap — fine for narrow filters (a refset of 100 codes), an OOM for
+   * {@code ECL=*} against a SNOMED edition.
+   *
+   * <p>Only the "single filter, no concept list" shape is paged here — that's the
+   * shape the SNOMED implicit-VS ({@code ?fhir_vs[=…]}) operation builds.
+   * Anything richer falls back to the default {@link #ruleExpandPaged}, which
+   * goes through {@link #ruleExpand} and slices in memory.
+   *
+   * <p>{@code QueryResult.meta.total} is the post-ECL total from Snowstorm's
+   * response, so FHIR {@code expansion.total} is correct without a second probe.
+   */
+  @Override
+  public QueryResult<ValueSetVersionConcept> ruleExpandPaged(ValueSetVersionRule rule, ValueSetVersion version,
+                                                             String preferredLanguage, String textFilter,
+                                                             Integer offset, Integer count) {
+    if (rule == null
+        || CollectionUtils.isNotEmpty(rule.getConcepts())
+        || rule.getFilters() == null
+        || rule.getFilters().size() != 1) {
+      return super.ruleExpandPaged(rule, version, preferredLanguage, textFilter, offset, count);
+    }
+
+    List<String> supportedLanguages = Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of());
+    List<String> preferredLanguages = preferredLanguage != null ? List.of(preferredLanguage) :
+        version.getPreferredLanguage() != null ? List.of(version.getPreferredLanguage()) : List.of();
+
+    String branch = getBranch(rule.getCodeSystemVersion());
+    String ecl = composeEcl(rule.getFilters().get(0));
+
+    int pageOffset = offset == null ? 0 : Math.max(0, offset);
+    int pageLimit = count == null ? SNOWSTORM_MAX_PAGE : Math.min(Math.max(0, count), SNOWSTORM_MAX_PAGE);
+
+    SnomedConceptSearchParams params = new SnomedConceptSearchParams()
+        .setEcl(ecl)
+        .setBranch(branch);
+    params.setLimit(pageLimit);
+    params.setOffset(pageOffset);
+    if (textFilter != null && !textFilter.isBlank()) {
+      params.setTerm(textFilter);
+    }
+
+    SnomedSearchResult<SnomedConcept> page = snomedService.searchConceptsPage(params);
+    List<SnomedConcept> snomedConcepts = page.getItems() != null ? page.getItems() : List.of();
+    Integer total = page.getTotal();
+
+    Map<String, List<SnomedDescription>> snomedDescriptions = getDescriptions(
+        snomedConcepts.stream().map(SnomedConcept::getConceptId).toList(), branch);
+
+    List<ValueSetVersionConcept> concepts = snomedConcepts.stream().map(sc -> {
+      ValueSetVersionConcept c = new ValueSetVersionConcept();
+      c.setConcept(snomedMapper.toVSConcept(sc));
+      c.setActive(sc.isActive());
+      c.setDisplay(findDisplay(snomedDescriptions.get(sc.getConceptId()), preferredLanguages));
+      c.setAdditionalDesignations(
+          findDesignations(snomedDescriptions.get(sc.getConceptId()), supportedLanguages,
+              c.getDisplay() != null ? c.getDisplay().getDesignationType() : null));
+      return c;
+    }).toList();
+
+    if (rule.getCodeSystemVersion() != null && rule.getCodeSystemVersion().getVersion() != null) {
+      concepts.forEach(c -> c.getConcept().setCodeSystemVersions(List.of(rule.getCodeSystemVersion().getVersion())));
+    }
+
+    QueryResult<ValueSetVersionConcept> result = new QueryResult<>(concepts);
+    result.getMeta().setTotal(total != null ? total : concepts.size());
+    result.getMeta().setOffset(pageOffset);
+    result.getMeta().setItemsPerPage(pageLimit);
+    return result;
   }
 
   private List<ValueSetVersionConcept> filterConcepts(ValueSetRuleFilter filter, List<String> preferredLanguages, List<String> supportedLanguages, String branch) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -396,37 +396,24 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // and preferredLanguage from it, both nullable.
     ValueSetVersion stubVersion = new ValueSetVersion();
 
-    List<ValueSetVersionConcept> concepts = provider.ruleExpand(rule, stubVersion, displayLanguage);
-    if (concepts == null) {
-      concepts = Collections.emptyList();
-    }
-
-    // Filter (free-text typeahead) — applied client-side because the underlying
-    // Snowstorm ECL doesn't carry a free-text filter.
     String textFilter = req == null ? null : req.findParameter("filter")
         .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
-    if (textFilter != null && !textFilter.isBlank()) {
-      String needle = textFilter.toLowerCase();
-      concepts = concepts.stream().filter(c -> {
-        String code = c.getConcept() != null ? c.getConcept().getCode() : null;
-        String display = c.getDisplay() != null ? c.getDisplay().getName() : null;
-        return (code != null && code.toLowerCase().contains(needle))
-            || (display != null && display.toLowerCase().contains(needle));
-      }).toList();
-    }
-
-    int totalBeforePaging = concepts.size();
-
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
-    if (offset != null) {
-      concepts = offset >= concepts.size() ? List.of() : concepts.subList(offset, concepts.size());
-    }
     Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("count").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
-    if (count != null) {
-      concepts = concepts.stream().limit(count).toList();
-    }
+
+    // Push paging + free-text filter down to Snowstorm. The previous implementation
+    // called provider.ruleExpand (which uses setAll(true) → loops Snowstorm at
+    // limit=9999) and sliced in memory — for `?fhir_vs` (ECL=*) against a
+    // SNOMED edition that materialised the entire concept set into heap before
+    // discarding all but `count` items. Real-world OOM, fixed by paging at the
+    // source.
+    QueryResult<ValueSetVersionConcept> page = provider.ruleExpandPaged(rule, stubVersion, displayLanguage, textFilter, offset, count);
+    List<ValueSetVersionConcept> concepts = page.getData() != null ? page.getData() : Collections.emptyList();
+    Integer totalBeforePaging = page.getMeta() != null && page.getMeta().getTotal() != null
+        ? page.getMeta().getTotal()
+        : concepts.size();
 
     com.kodality.zmei.fhir.resource.terminology.ValueSet response = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
     response.setUrl(url);

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -590,11 +590,11 @@ class ValueSetExpandOperationTest extends Specification {
   def "SNOMED ?fhir_vs (all concepts) delegates to provider with ECL `*`"() {
     given:
     ValueSetVersionRule capturedRule = null
-    snomedProvider.ruleExpand(_, _, _) >> { args ->
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
       capturedRule = args[0] as ValueSetVersionRule
-      return [snomedConcept("404684003", "Clinical finding"),
-              snomedConcept("123037004", "Body structure"),
-              snomedConcept("71388002", "Procedure")]
+      return pagedResult([snomedConcept("404684003", "Clinical finding"),
+                          snomedConcept("123037004", "Body structure"),
+                          snomedConcept("71388002", "Procedure")])
     }
 
     def req = new Parameters()
@@ -622,12 +622,12 @@ class ValueSetExpandOperationTest extends Specification {
     // descendant-or-self semantics, so the anchor is included by Snowstorm.
     given:
     ValueSetVersionRule capturedRule = null
-    snomedProvider.ruleExpand(_, _, _) >> { args ->
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
       capturedRule = args[0] as ValueSetVersionRule
-      return [snomedConcept("409822003", "Domain bacteria"),
-              snomedConcept("1052801005", "Domain bacteria isolate"),
-              snomedConcept("78239009",   "Gram-positive bacterium"),
-              snomedConcept("87172008",   "Gram-negative bacterium")]
+      return pagedResult([snomedConcept("409822003", "Domain bacteria"),
+                          snomedConcept("1052801005", "Domain bacteria isolate"),
+                          snomedConcept("78239009",   "Gram-positive bacterium"),
+                          snomedConcept("87172008",   "Gram-negative bacterium")])
     }
 
     def req = new Parameters()
@@ -649,11 +649,11 @@ class ValueSetExpandOperationTest extends Specification {
   def "SNOMED ?fhir_vs=refset delegates with is-a 900000000000455006 (Reference set foundation)"() {
     given:
     ValueSetVersionRule capturedRule = null
-    snomedProvider.ruleExpand(_, _, _) >> { args ->
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
       capturedRule = args[0] as ValueSetVersionRule
-      return [snomedConcept("733073007", "OWL axiom reference set"),
-              snomedConcept("900000000000497000", "CTV3 simple map reference set"),
-              snomedConcept("447562003", "ICD-10 complex map reference set")]
+      return pagedResult([snomedConcept("733073007", "OWL axiom reference set"),
+                          snomedConcept("900000000000497000", "CTV3 simple map reference set"),
+                          snomedConcept("447562003", "ICD-10 complex map reference set")])
     }
 
     def req = new Parameters()
@@ -674,10 +674,10 @@ class ValueSetExpandOperationTest extends Specification {
   def "SNOMED ?fhir_vs=refset/<code> delegates with `in` filter (refset members)"() {
     given:
     ValueSetVersionRule capturedRule = null
-    snomedProvider.ruleExpand(_, _, _) >> { args ->
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
       capturedRule = args[0] as ValueSetVersionRule
-      return [snomedConcept("404684003", "Clinical finding (axiom)"),
-              snomedConcept("71388002",  "Procedure (axiom)")]
+      return pagedResult([snomedConcept("404684003", "Clinical finding (axiom)"),
+                          snomedConcept("71388002",  "Procedure (axiom)")])
     }
 
     // 733073007 = OWL axiom reference set
@@ -699,10 +699,10 @@ class ValueSetExpandOperationTest extends Specification {
   def "SNOMED ?fhir_vs=ecl/<expr> URL-decodes and passes the expression through"() {
     given:
     ValueSetVersionRule capturedRule = null
-    snomedProvider.ruleExpand(_, _, _) >> { args ->
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
       capturedRule = args[0] as ValueSetVersionRule
-      return [snomedConcept("363698007", "Finding site"),
-              snomedConcept("116676008", "Associated morphology")]
+      return pagedResult([snomedConcept("363698007", "Finding site"),
+                          snomedConcept("116676008", "Associated morphology")])
     }
 
     // ECL "<< 363787002" — descendants-or-self of 363787002 (Observable entity).
@@ -721,6 +721,50 @@ class ValueSetExpandOperationTest extends Specification {
     result.expansion.contains.size() == 2
   }
 
+  def "SNOMED ?fhir_vs passes offset+count+filter to ruleExpandPaged and reports the upstream total"() {
+    // Regression test for an OOM in production: the previous implementation
+    // called ruleExpand (which loops Snowstorm at limit=9999 via setAll(true))
+    // and sliced in memory — for ECL=* on a SNOMED edition this materialised the
+    // entire concept set into heap before discarding all but `count` items.
+    //
+    // The contract now is: offset, count, and filter are forwarded to
+    // ruleExpandPaged; total comes from the QueryResult (so FHIR
+    // expansion.total reflects the real post-ECL count even though only a page
+    // of items is materialised).
+    given:
+    Integer capturedOffset = null
+    Integer capturedCount = null
+    String capturedFilter = null
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
+      capturedFilter = args[3] as String
+      capturedOffset = args[4] as Integer
+      capturedCount = args[5] as Integer
+      def page = [snomedConcept("404684003", "Clinical finding"),
+                  snomedConcept("123037004", "Body structure")]
+      def result = new QueryResult<>(page)
+      result.getMeta().setTotal(372656)
+      return result
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://snomed.info/sct?fhir_vs"))
+        .addParameter(new Parameters.ParametersParameter("offset").setValueInteger(40))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(2))
+        .addParameter(new Parameters.ParametersParameter("filter").setValueString("clin"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    capturedOffset == 40
+    capturedCount == 2
+    capturedFilter == "clin"
+
+    result.expansion.total == 372656
+    result.expansion.offset == 40
+    result.expansion.contains.size() == 2
+  }
+
   def "SNOMED versioned URL passes the edition/version URI on the rule"() {
     // IG: implementations populating the version element SHOULD use the URI
     // form `http://snomed.info/sct/<sctid>/version/<YYYYMMDD>`. The provider's
@@ -728,10 +772,10 @@ class ValueSetExpandOperationTest extends Specification {
     // must carry it through on rule.codeSystemVersion.
     given:
     ValueSetVersionRule capturedRule = null
-    snomedProvider.ruleExpand(_, _, _) >> { args ->
+    snomedProvider.ruleExpandPaged(_, _, _, _, _, _) >> { args ->
       capturedRule = args[0] as ValueSetVersionRule
-      return [snomedConcept("409822003", "Domain bacteria"),
-              snomedConcept("78239009",  "Gram-positive bacterium")]
+      return pagedResult([snomedConcept("409822003", "Domain bacteria"),
+                          snomedConcept("78239009",  "Gram-positive bacterium")])
     }
 
     // 900000000000207008 = SNOMED International Edition
@@ -807,6 +851,17 @@ class ValueSetExpandOperationTest extends Specification {
           new Designation().setName(displayName).setLanguage("en").setDesignationType("display")
       ])])
     }
+  }
+
+  /**
+   * Wrap a list as a QueryResult whose total matches the list size. Use for SNOMED
+   * provider stubs where the test doesn't care about the upstream-vs-page-size
+   * distinction (one-page result, total = items in that page).
+   */
+  private static QueryResult<ValueSetVersionConcept> pagedResult(List<ValueSetVersionConcept> concepts) {
+    def r = new QueryResult<ValueSetVersionConcept>(concepts)
+    r.getMeta().setTotal(concepts.size())
+    return r
   }
 
   private static ValueSetVersionConcept snomedConcept(String code, String display) {

--- a/termx-core/src/main/java/org/termx/core/ts/ValueSetExternalExpandProvider.java
+++ b/termx-core/src/main/java/org/termx/core/ts/ValueSetExternalExpandProvider.java
@@ -1,5 +1,6 @@
 package org.termx.core.ts;
 
+import com.kodality.commons.model.QueryResult;
 import org.termx.ts.valueset.ValueSetVersion;
 import org.termx.ts.valueset.ValueSetVersionConcept;
 import org.termx.ts.valueset.ValueSetVersionRuleSet;
@@ -28,6 +29,49 @@ public abstract class ValueSetExternalExpandProvider {
   }
 
   public abstract List<ValueSetVersionConcept> ruleExpand(ValueSetVersionRule rule, ValueSetVersion version, String preferredLanguage);
+
+  /**
+   * Paged expansion of a single rule. Providers SHOULD override this to push
+   * paging and free-text filtering down to the upstream terminology server —
+   * the default falls back to {@link #ruleExpand} + in-memory filter+slice,
+   * which materialises the full rule before slicing (fine for small code
+   * systems, an OOM risk for large external sources like SNOMED).
+   *
+   * <p>The returned {@code QueryResult.meta.total} is the post-filter,
+   * pre-pagination count; callers (e.g. FHIR {@code $expand}) use it as
+   * {@code expansion.total}.
+   *
+   * @param textFilter  free-text typeahead filter (FHIR R5 {@code filter}); applied
+   *                    against code+display, case-insensitive substring, before paging.
+   *                    {@code null}/blank = no filter.
+   * @param offset      0-based offset into the post-filter result; {@code null} = 0.
+   * @param count       page size; {@code null} = unbounded (caller assumes responsibility).
+   */
+  public QueryResult<ValueSetVersionConcept> ruleExpandPaged(ValueSetVersionRule rule, ValueSetVersion version,
+                                                             String preferredLanguage, String textFilter,
+                                                             Integer offset, Integer count) {
+    List<ValueSetVersionConcept> all = ruleExpand(rule, version, preferredLanguage);
+    if (all == null) {
+      all = List.of();
+    }
+    if (textFilter != null && !textFilter.isBlank()) {
+      String needle = textFilter.toLowerCase();
+      all = all.stream().filter(c -> {
+        String code = c.getConcept() != null ? c.getConcept().getCode() : null;
+        String display = c.getDisplay() != null ? c.getDisplay().getName() : null;
+        return (code != null && code.toLowerCase().contains(needle))
+            || (display != null && display.toLowerCase().contains(needle));
+      }).toList();
+    }
+    int total = all.size();
+    int from = offset == null ? 0 : Math.min(offset, total);
+    int to = count == null ? total : Math.min(from + count, total);
+    List<ValueSetVersionConcept> page = all.subList(from, to);
+    QueryResult<ValueSetVersionConcept> result = new QueryResult<>(page);
+    result.getMeta().setTotal(total);
+    result.getMeta().setOffset(from);
+    return result;
+  }
 
   public abstract String getCodeSystemId();
 }


### PR DESCRIPTION
## Summary
- `$expand?url=http://snomed.info/sct?fhir_vs` (bare → `ECL=*`) was OOM-ing dev-server. The implicit-VS path added in #145 called `provider.ruleExpand`, which loops Snowstorm at `limit=9999` until the full ECL result is materialised in heap, *then* slices in memory. For a SNOMED edition (370k+ concepts) the first response body alone OOMed `BodySubscribers.ofString`.
- Same pattern as #147's implicit-CS fix: push paging down to the source. New `ruleExpandPaged(rule, version, lang, textFilter, offset, count)` returning `QueryResult<ValueSetVersionConcept>` on `ValueSetExternalExpandProvider`. SNOMED override issues one Snowstorm `concepts?ecl=…&limit=…&offset=…&term=…` call and loads descriptions only for that page. Default base-class impl preserves UCUM/ObservationDefinition behaviour by falling back to `ruleExpand` + in-memory slice.
- `ValueSetExpandOperation.tryExpandSnomedImplicit` now forwards `offset`/`count`/`filter` to the paged API and uses the provider-returned total directly — `expansion.total` stays correct without materialising the whole edition.

## Test plan
- [x] `:terminology:test ValueSetExpandOperationTest` — 26/26 green (25 existing + 1 new spec pinning offset/count/filter forwarding and upstream-total semantics).
- [x] `:terminology:compileJava` / `:snomed:compileJava` / `:termx-core:compileJava` clean.
- [ ] Manual smoke against dev-server: `GET /fhir/ValueSet/$expand?url=http://snomed.info/sct?fhir_vs&count=20` returns a page without OOM and reports the real upstream `expansion.total`.