### PR TITLE
fix(test): unbreak EcosystemServiceTest (missing byte-buddy + bad QueryResult ctor)

### DIFF
--- a/termx-core/build.gradle.kts
+++ b/termx-core/build.gradle.kts
@@ -44,4 +44,9 @@ dependencies {
     testImplementation("org.spockframework:spock-core") {
         exclude(group = "org.codehaus.groovy", module = "groovy-all")
     }
+    // Spock falls back to byte-buddy/cglib/mockito to mock concrete classes
+    // (the JDK proxy only handles interfaces). EcosystemServiceTest mocks
+    // EcosystemRepository, which extends BaseRepository — without this the
+    // suite dies with CannotCreateMockException. :terminology already has it.
+    testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")
 }

--- a/termx-core/src/test/groovy/org/termx/core/sys/ecosystem/EcosystemServiceTest.groovy
+++ b/termx-core/src/test/groovy/org/termx/core/sys/ecosystem/EcosystemServiceTest.groovy
@@ -112,7 +112,7 @@ class EcosystemServiceTest extends Specification {
     def result = service.query(params)
 
     then:
-    1 * repository.query(params) >> new QueryResult<>([], 0)
+    1 * repository.query(params) >> new QueryResult<>([])
     result.meta.total == 0
   }
 }


### PR DESCRIPTION
## Summary
- `EcosystemServiceTest` has been red on `main` since the original Ecosystem API commit (b18a207b) — two bugs shipped together:
  - **Missing class-mocking dep.** `Mock(EcosystemRepository)` died with `CannotCreateMockException` because `EcosystemRepository` is concrete (extends `BaseRepository`) and `:termx-core`'s test classpath has no byte-buddy/cglib/mockito to subclass at runtime. `:terminology` already carries `testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")`; added the same line here. 8 tests recovered.
  - **Wrong `QueryResult` constructor.** `new QueryResult<>([], 0)` in *should query ecosystems* matches no constructor — there's `(List<T>)` and `(Integer, QueryParams)`, no `(List, Integer)`. Switched to `new QueryResult<>([])`, which already sets `total` = `data.size()` = 0.
- Both bugs noticed while running the full test suite during PR #150's review prep.

## Test plan
- [x] `:termx-core:test` — 46/46 green.