### PR TITLE
feat(fhir-cs): round-trip per-value extensions on concept.property[]

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -412,6 +412,17 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
             }
           }
         }
+        // Emit per-value extensions verbatim — the import stored them as the
+        // raw FHIR Extension shape, JSONB rehydrates to Map<String, Object>, and
+        // convertValue marshals back to List<Extension>. URL family is open-ended;
+        // we don't interpret content, just round-trip.
+        if (pv.getExtensions() != null) {
+          List<Extension> extensions = JsonUtil.getObjectMapper()
+              .convertValue(pv.getExtensions(), new com.fasterxml.jackson.core.type.TypeReference<List<Extension>>() {});
+          if (extensions != null && !extensions.isEmpty()) {
+            fhir.setExtension(extensions);
+          }
+        }
         return fhir;
       }).filter(Objects::nonNull).sorted(Comparator.comparing(CodeSystemConceptProperty::getCode)).toList());
     }
@@ -731,6 +742,12 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
               v.getValueBoolean(), v.getValueDateTime(), v.getValueDecimal()
           ).filter(Objects::nonNull).findFirst().orElse(null));
           value.setEntityProperty(v.getCode());
+          // Round-trip arbitrary per-value extensions (e.g. customer IG fields
+          // that decompose a pipe-string into typed sub-values). Stored verbatim
+          // — the URL family is open-ended, not interpreted here.
+          if (v.getExtension() != null && !v.getExtension().isEmpty()) {
+            value.setExtensions(v.getExtension());
+          }
           return value;
         }).toList();
   }

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entitypropertyvalue/EntityPropertyValueRepository.java
@@ -24,7 +24,13 @@ import java.util.stream.Stream;
 @Singleton
 public class EntityPropertyValueRepository extends BaseRepository {
   private static final int INSERT_CHUNK_SIZE = 500;
-  private final PgBeanProcessor bp = new PgBeanProcessor(EntityPropertyValue.class, bp -> bp.addColumnProcessor("value", PgBeanProcessor.fromJson()));
+  private final PgBeanProcessor bp = new PgBeanProcessor(EntityPropertyValue.class, bp -> {
+    bp.addColumnProcessor("value", PgBeanProcessor.fromJson());
+    // `extensions` is jsonb and may be null (column added later — see changelog
+    // 15-entity_property_value_extensions.sql). The fromJson() processor handles
+    // null safely.
+    bp.addColumnProcessor("extensions", PgBeanProcessor.fromJson());
+  });
 
   String select = "select epv.*, ep.name as entity_property, ep.type as entity_property_type ";
   String from = " from terminology.entity_property_value epv " +
@@ -36,6 +42,7 @@ public class EntityPropertyValueRepository extends BaseRepository {
     ssb.property("entity_property_id", value.getEntityPropertyId());
     ssb.property("code_system_entity_version_id", codeSystemEntityVersionId);
     ssb.jsonProperty("value", value.getValue());
+    ssb.jsonProperty("extensions", value.getExtensions());
 
     SqlBuilder sb = ssb.buildSave("terminology.entity_property_value", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());
@@ -111,9 +118,13 @@ public class EntityPropertyValueRepository extends BaseRepository {
   public void save(List<Pair<Long, EntityPropertyValue>> values) {
     List<Pair<Long, EntityPropertyValue>> valuesToInsert = values.stream().filter(p -> p.getValue().getId() == null).toList();
     for (List<Pair<Long, EntityPropertyValue>> chunk : ListUtils.partition(valuesToInsert, INSERT_CHUNK_SIZE)) {
-      SqlBuilder sb = new SqlBuilder("insert into terminology.entity_property_value (code_system_entity_version_id, entity_property_id, value) values ");
+      SqlBuilder sb = new SqlBuilder("insert into terminology.entity_property_value (code_system_entity_version_id, entity_property_id, value, extensions) values ");
       for (Pair<Long, EntityPropertyValue> pair : chunk) {
-        sb.append("(?, ?, ?::jsonb),", pair.getKey(), pair.getValue().getEntityPropertyId(), JsonUtil.toJson(pair.getValue().getValue()));
+        sb.append("(?, ?, ?::jsonb, ?::jsonb),",
+            pair.getKey(),
+            pair.getValue().getEntityPropertyId(),
+            JsonUtil.toJson(pair.getValue().getValue()),
+            pair.getValue().getExtensions() == null ? null : JsonUtil.toJson(pair.getValue().getExtensions()));
       }
       String sql = sb.getSql();
       sql = sql.substring(0, sql.length() - 1) + " returning id";
@@ -124,11 +135,11 @@ public class EntityPropertyValueRepository extends BaseRepository {
     }
 
     List<Pair<Long, EntityPropertyValue>> valuesToUpdate = values.stream().filter(p -> p.getValue().getId() != null).toList();
-    String query = "update terminology.entity_property_value SET code_system_entity_version_id = ?, entity_property_id = ? , value = ?::jsonb where id = ?";
+    String query = "update terminology.entity_property_value SET code_system_entity_version_id = ?, entity_property_id = ?, value = ?::jsonb, extensions = ?::jsonb where id = ?";
     jdbcTemplate.batchUpdate(query, new BatchPreparedStatementSetter() {
       @Override public void setValues(PreparedStatement ps, int i) throws SQLException {
         EntityPropertyValueRepository.this.setValues(ps, i, valuesToUpdate);
-        ps.setLong(4, valuesToUpdate.get(i).getValue().getId());
+        ps.setLong(5, valuesToUpdate.get(i).getValue().getId());
       }
       @Override public int getBatchSize() {return valuesToUpdate.size();}
     });
@@ -179,9 +190,11 @@ public class EntityPropertyValueRepository extends BaseRepository {
   }
 
   private void setValues(PreparedStatement ps, int i, List<Pair<Long, EntityPropertyValue>> values) throws SQLException {
+    EntityPropertyValue v = values.get(i).getValue();
     ps.setLong(1, values.get(i).getKey());
-    ps.setLong(2, values.get(i).getValue().getEntityPropertyId());
-    ps.setString(3, JsonUtil.toJson(values.get(i).getValue().getValue()));
+    ps.setLong(2, v.getEntityPropertyId());
+    ps.setString(3, JsonUtil.toJson(v.getValue()));
+    ps.setString(4, v.getExtensions() == null ? null : JsonUtil.toJson(v.getExtensions()));
   }
 
 }

--- a/terminology/src/main/resources/terminology/changelog/terminology/15-entity_property_value_extensions.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/15-entity_property_value_extensions.sql
@@ -1,0 +1,5 @@
+--liquibase formatted sql
+
+--changeset termx:entity_property_value-extensions
+alter table terminology.entity_property_value add column if not exists extensions jsonb;
+--

--- a/terminology/src/main/resources/terminology/changelog/terminology/changelog.xml
+++ b/terminology/src/main/resources/terminology/changelog/terminology/changelog.xml
@@ -19,6 +19,7 @@
     <include file="12-closure.sql" relativeToChangelogFile="true"/>
     <include file="13-update_queue_allowed_statuses.sql" relativeToChangelogFile="true"/>
     <include file="14-entity_version_effective_time.sql" relativeToChangelogFile="true"/>
+    <include file="15-entity_property_value_extensions.sql" relativeToChangelogFile="true"/>
 
     <include file="views/concept_closure.sql" relativeToChangelogFile="true"/>
     <include file="views/concept_name.sql" relativeToChangelogFile="true"/>

--- a/termx-api/src/main/java/org/termx/ts/codesystem/EntityPropertyValue.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/EntityPropertyValue.java
@@ -16,6 +16,10 @@ import lombok.experimental.Accessors;
 public class EntityPropertyValue {
   private Long id;
   private Object value;
+  // Per-value FHIR extensions — `CodeSystem.concept.property[].extension`. Stored
+  // as raw JSON so the model stays provider-neutral (termx-api has no zmei/FHIR
+  // dep). Mappers cast to/from `List<Extension>` at the FHIR boundary.
+  private Object extensions;
   private Long entityPropertyId;
   private Long codeSystemEntityVersionId;
 

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/CodeSystemRoundTripTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/CodeSystemRoundTripTest.groovy
@@ -1,0 +1,245 @@
+package org.termx.terminology.fhir
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.codesystem.CodeSystemResourceStorage
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetResourceStorage
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+
+/**
+ * End-to-end FHIR round-trip test driven by three coordinated resources.
+ *
+ * Fixtures (under {@code fhir/round-trip/}):
+ * <ul>
+ *   <li>{@code cs1.json} — CodeSystem with all seven FHIR datatype properties
+ *       (code, Coding, string, integer, boolean, dateTime, decimal). One concept
+ *       ("b") carries multiple {@code p-string} occurrences AND a per-value
+ *       extension cluster — the latter is the gap this PR closes.</li>
+ *   <li>{@code vs1.json} — ValueSet enumerating two concepts from CS1.</li>
+ *   <li>{@code cs2.json} — CodeSystem with two Coding properties whose
+ *       {@code CodeSystemProperty.extension[]} bind to CS1 and VS1
+ *       respectively (the {@code codesystem-property-codesystem} and
+ *       {@code codesystem-property-valueset} extensions that already round-trip).</li>
+ * </ul>
+ *
+ * Contract: import all three, fetch each back through the same code path the
+ * FHIR API uses ({@link CodeSystemResourceStorage#load} /
+ * {@link ValueSetResourceStorage#load}), normalise out server-set fields, and
+ * assert the normalised JSON equals the input. The "FHIR API" reads via these
+ * resource-storage loaders — same code path the HTTP controller delegates to,
+ * but without the Netty round-trip; equivalence is the same.
+ *
+ * Expected state at PR open: assertions on the property-definition binding
+ * extensions (CS2) pass. The per-value extension assertion on CS1.b pinpoints
+ * the bug to fix.
+ */
+@MicronautTest(transactional = true)
+class CodeSystemRoundTripTest extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject CodeSystemResourceStorage csStorage
+  @Inject ValueSetResourceStorage vsStorage
+
+  static final ObjectMapper MAPPER = new ObjectMapper()
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "import CS1 + VS1 + CS2, then re-fetch via FHIR API; payload round-trips"() {
+    given: "the coordinated fixtures (CS0 is a tiny preamble so CS1's Coding-typed property values can resolve to a stored Concept)"
+    def cs0Input = readFixture("round-trip/cs0.json")
+    def cs1Input = readFixture("round-trip/cs1.json")
+    def vs1Input = readFixture("round-trip/vs1.json")
+    def cs2Input = readFixture("round-trip/cs2.json")
+
+    when: "imported in dependency order (CS0 → CS1 → VS1 → CS2)"
+    csImportService.importCodeSystem(cs0Input.toString(), cs0Input.get("id").asText())
+    csImportService.importCodeSystem(cs1Input.toString(), cs1Input.get("id").asText())
+    vsImportService.importValueSet(vs1Input.toString(), vs1Input.get("id").asText())
+    csImportService.importCodeSystem(cs2Input.toString(), cs2Input.get("id").asText())
+
+    and: "fetched back via the same code path the FHIR API GET uses"
+    def cs1Output = readBack(csStorage, cs1Input.get("id").asText(), cs1Input.get("version").asText())
+    def vs1Output = readBack(vsStorage, vs1Input.get("id").asText(), vs1Input.get("version").asText())
+    def cs2Output = readBack(csStorage, cs2Input.get("id").asText(), cs2Input.get("version").asText())
+
+    then: "CS1: top-level identity survives"
+    def cs1In = normalise(cs1Input)
+    def cs1Out = normalise(cs1Output)
+    cs1Out.get("url")     == cs1In.get("url")
+    cs1Out.get("version") == cs1In.get("version")
+    cs1Out.get("name")    == cs1In.get("name")
+    cs1Out.get("status")  == cs1In.get("status")
+
+    and: "CS1 property definitions round-trip"
+    propertyDefs(cs1Out) == propertyDefs(cs1In)
+
+    and: "CS1 concept `a` keeps its six scalar datatype property values"
+    // Coding-value round-trip is exercised on CS2 (where the property definition
+    // carries a `codesystem-property-codesystem` binding extension — the only
+    // shape under which TermX preserves the canonical URL and display).
+    conceptProps(cs1Out, "a") == conceptProps(cs1In, "a")
+
+    and: "CS1 concept `b` keeps repeated p-string values AND the per-value extension cluster"
+    // The repetition itself ("first" / "second" / pipe-string) is preserved
+    // by the existing repository. The extension[] sibling on the pipe-string
+    // entry is what this PR adds — verified by this assertion.
+    conceptProps(cs1Out, "b") == conceptProps(cs1In, "b")
+
+    and: "CS2: property-definition binding extensions (codesystem-property-codesystem / -valueset) round-trip"
+    def cs2In = normalise(cs2Input)
+    def cs2Out = normalise(cs2Output)
+    propertyDefs(cs2Out) == propertyDefs(cs2In)
+
+    and: "CS2 per-concept Coding values for refs to CS1 and VS1 survive (system + code)"
+    // `display` is intentionally omitted from these Coding values in the
+    // fixture — it's a known separate bug: on successful Coding→Concept
+    // resolution at import time the user-supplied `display` is dropped (the
+    // TermX Concept doesn't carry it). The export then can't recover it from
+    // the empty snapshot. Tracked separately.
+    conceptProps(cs2Out, "x") == conceptProps(cs2In, "x")
+    conceptProps(cs2Out, "y") == conceptProps(cs2In, "y")
+
+    and: "VS1: identity + compose.include[] survive (tolerate server-added defaults like compose.inactive)"
+    def vs1In = normalise(vs1Input)
+    def vs1Out = normalise(vs1Output)
+    vs1Out.get("url")     == vs1In.get("url")
+    vs1Out.get("version") == vs1In.get("version")
+    vs1Out.get("compose").get("include") == vs1In.get("compose").get("include")
+  }
+
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /** Read a fixture from src/test/resources/fhir/&lt;path&gt; into a mutable JsonNode tree. */
+  private JsonNode readFixture(String relativePath) {
+    def stream = getClass().getClassLoader().getResourceAsStream("fhir/${relativePath}")
+    assert stream != null, "fixture not found: fhir/${relativePath}"
+    return MAPPER.readTree(stream)
+  }
+
+  /**
+   * Re-fetch a resource through the FHIR resource-storage layer (the same code
+   * path the FHIR HTTP GET controller delegates to) and parse to JsonNode.
+   */
+  private JsonNode readBack(Object storage, String id, String version) {
+    def resourceVersion = storage.load(id + "--" + version)
+    assert resourceVersion != null, "resource not found after import: ${id}--${version}"
+    return MAPPER.readTree(resourceVersion.content.value as String)
+  }
+
+  /**
+   * Drop server-set or computed fields that are expected to differ between
+   * input and round-tripped output — these are not part of the round-trip
+   * contract and would otherwise mask real divergences.
+   *
+   * Removed:
+   * <ul>
+   *   <li>{@code id} — the read endpoint uses a composite "id--version" form.</li>
+   *   <li>{@code date}, {@code meta} — server-set on every read.</li>
+   *   <li>{@code count} — derived from concept count, not a round-trip input.</li>
+   *   <li>{@code text} — narrative; not exercised here.</li>
+   * </ul>
+   */
+  private static JsonNode normalise(JsonNode node) {
+    ObjectNode copy = node.deepCopy() as ObjectNode
+    ["id", "date", "meta", "count", "text"].each { copy.remove(it) }
+    return copy
+  }
+
+  /** Extract a stable comparison view of `property[]` (definitions) — sort by code. */
+  private static JsonNode propertyDefs(JsonNode codeSystem) {
+    ArrayNode props = codeSystem.get("property") as ArrayNode
+    if (props == null) {
+      return MAPPER.createArrayNode()
+    }
+    def sorted = MAPPER.createArrayNode()
+    props.toList().sort { it.get("code").asText() }.each { sorted.add(it) }
+    return sorted
+  }
+
+  /**
+   * Extract the `concept[].property[]` list for a given concept code, with
+   * canonical key ordering recursively applied and array elements sorted by
+   * their canonical-string form. Both normalisations are necessary because:
+   *
+   * <ul>
+   *   <li>The export side alphabetises property order
+   *       (see {@code toFhirConceptProperties.sort}), so input and output
+   *       sequences differ unless we sort.</li>
+   *   <li>FHIR POJO serialisation emits object fields in declaration order
+   *       (e.g. {@code extension, code, valueString}) while JSON input
+   *       preserves source order (e.g. {@code code, valueString, extension}).
+   *       Comparing JsonNode-via-{@code equals} is order-insensitive for
+   *       fields but Groovy's {@code ==} on Jackson nodes can be sensitive in
+   *       some cases; recursive key-canonicalisation makes the comparison
+   *       robust regardless.</li>
+   * </ul>
+   *
+   * Returns an empty array when the concept is missing or has no properties.
+   * NOTE: cannot use Groovy elvis ({@code ?:}) on JsonNode — its
+   * {@code asBoolean()} returns false for non-boolean nodes, so a populated
+   * array would be "falsy" to Groovy.
+   */
+  private static JsonNode conceptProps(JsonNode codeSystem, String code) {
+    def concept = findConcept(codeSystem.get("concept"), code)
+    if (concept == null || concept.get("property") == null) {
+      return MAPPER.createArrayNode()
+    }
+    def props = (concept.get("property") as ArrayNode).toList().collect { canonicalise(it) }
+    def sorted = MAPPER.createArrayNode()
+    props.sort { a, b -> a.toString() <=> b.toString() }.each { sorted.add(it) }
+    return sorted
+  }
+
+  /** Recursively sort all ObjectNode field keys alphabetically; preserves array order. */
+  private static JsonNode canonicalise(JsonNode node) {
+    if (node instanceof ObjectNode) {
+      ObjectNode out = MAPPER.createObjectNode()
+      def fields = []
+      node.fieldNames().forEachRemaining { fields << it }
+      fields.sort().each { fname -> out.set(fname, canonicalise(node.get(fname))) }
+      return out
+    }
+    if (node instanceof ArrayNode) {
+      ArrayNode out = MAPPER.createArrayNode()
+      node.forEach { out.add(canonicalise(it)) }
+      return out
+    }
+    return node
+  }
+
+  /** Depth-first concept lookup by code — concepts may be nested. */
+  private static JsonNode findConcept(JsonNode concepts, String code) {
+    if (concepts == null || !concepts.isArray()) {
+      return null
+    }
+    for (def c : concepts) {
+      if (c.get("code")?.asText() == code) {
+        return c
+      }
+      def nested = findConcept(c.get("concept"), code)
+      if (nested != null) {
+        return nested
+      }
+    }
+    return null
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/round-trip/cs0.json
+++ b/termx-integtest/src/test/resources/fhir/round-trip/cs0.json
@@ -1,0 +1,15 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "rt-cs0",
+  "url": "http://termx-test.local/CodeSystem/rt-cs0",
+  "version": "1.0.0",
+  "name": "RoundTripCs0",
+  "title": "Round-Trip CS0 (external lookup target)",
+  "status": "active",
+  "experimental": false,
+  "content": "complete",
+  "caseSensitive": true,
+  "concept": [
+    {"code": "ec1", "display": "External 1"}
+  ]
+}

--- a/termx-integtest/src/test/resources/fhir/round-trip/cs1.json
+++ b/termx-integtest/src/test/resources/fhir/round-trip/cs1.json
@@ -1,0 +1,52 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "rt-cs1",
+  "url": "http://termx-test.local/CodeSystem/rt-cs1",
+  "version": "1.0.0",
+  "name": "RoundTripCs1",
+  "title": "Round-Trip CS1 (all 7 FHIR datatypes)",
+  "status": "active",
+  "experimental": false,
+  "content": "complete",
+  "caseSensitive": true,
+  "property": [
+    {"code": "p-code",     "description": "code value",      "type": "code"},
+    {"code": "p-coding",   "description": "Coding value",    "type": "Coding"},
+    {"code": "p-string",   "description": "string value",    "type": "string"},
+    {"code": "p-integer",  "description": "integer value",   "type": "integer"},
+    {"code": "p-boolean",  "description": "boolean value",   "type": "boolean"},
+    {"code": "p-datetime", "description": "dateTime value",  "type": "dateTime"},
+    {"code": "p-decimal",  "description": "decimal value",   "type": "decimal"}
+  ],
+  "concept": [
+    {
+      "code": "a",
+      "display": "Alpha",
+      "property": [
+        {"code": "p-code",     "valueCode":    "x"},
+        {"code": "p-string",   "valueString":  "hello"},
+        {"code": "p-integer",  "valueInteger": 42},
+        {"code": "p-boolean",  "valueBoolean": true},
+        {"code": "p-datetime", "valueDateTime": "2025-06-01T00:00:00Z"},
+        {"code": "p-decimal",  "valueDecimal": 3.14}
+      ]
+    },
+    {
+      "code": "b",
+      "display": "Beta",
+      "property": [
+        {"code": "p-string", "valueString": "first"},
+        {"code": "p-string", "valueString": "second"},
+        {
+          "code": "p-string",
+          "valueString": "H:9811 | S:420 | B:3",
+          "extension": [
+            {"url": "http://termx-test.local/StructureDefinition/iccc-histology", "valueString": "9811"},
+            {"url": "http://termx-test.local/StructureDefinition/iccc-site",      "valueString": "420"},
+            {"url": "http://termx-test.local/StructureDefinition/iccc-behavior",  "valueString": "3"}
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/termx-integtest/src/test/resources/fhir/round-trip/cs2.json
+++ b/termx-integtest/src/test/resources/fhir/round-trip/cs2.json
@@ -1,0 +1,54 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "rt-cs2",
+  "url": "http://termx-test.local/CodeSystem/rt-cs2",
+  "version": "1.0.0",
+  "name": "RoundTripCs2",
+  "title": "Round-Trip CS2 (property bindings to CS1 and VS1)",
+  "status": "active",
+  "experimental": false,
+  "content": "complete",
+  "caseSensitive": true,
+  "property": [
+    {
+      "code": "ref-cs",
+      "description": "Reference to a CS1 concept",
+      "type": "Coding",
+      "extension": [
+        {
+          "url": "https://termx.org/fhir/StructureDefinition/codesystem-property-codesystem",
+          "valueCanonical": "http://termx-test.local/CodeSystem/rt-cs1"
+        }
+      ]
+    },
+    {
+      "code": "ref-vs",
+      "description": "Reference to a VS1 concept",
+      "type": "Coding",
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/codesystem-property-valueset",
+          "valueCanonical": "http://termx-test.local/ValueSet/rt-vs1"
+        }
+      ]
+    }
+  ],
+  "concept": [
+    {
+      "code": "x",
+      "display": "X (refs Alpha)",
+      "property": [
+        {"code": "ref-cs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "a"}},
+        {"code": "ref-vs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "a"}}
+      ]
+    },
+    {
+      "code": "y",
+      "display": "Y (refs Beta)",
+      "property": [
+        {"code": "ref-cs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "b"}},
+        {"code": "ref-vs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "b"}}
+      ]
+    }
+  ]
+}

--- a/termx-integtest/src/test/resources/fhir/round-trip/vs1.json
+++ b/termx-integtest/src/test/resources/fhir/round-trip/vs1.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "ValueSet",
+  "id": "rt-vs1",
+  "url": "http://termx-test.local/ValueSet/rt-vs1",
+  "version": "1.0.0",
+  "name": "RoundTripVs1",
+  "title": "Round-Trip VS1 over CS1",
+  "status": "active",
+  "experimental": false,
+  "compose": {
+    "include": [
+      {
+        "system": "http://termx-test.local/CodeSystem/rt-cs1",
+        "version": "1.0.0",
+        "concept": [
+          {"code": "a", "display": "Alpha"},
+          {"code": "b", "display": "Beta"}
+        ]
+      }
+    ]
+  }
+}

--- a/termx-integtest/src/test/resources/termx-integtest-changelog.xml
+++ b/termx-integtest/src/test/resources/termx-integtest-changelog.xml
@@ -11,5 +11,12 @@
   <include file="sys/changelog/changelog.xml" relativeToChangelogFile="false"/>
   <include file="terminology/changelog/changelog.xml" relativeToChangelogFile="false"/>
   <include file="uam/changelog/changelog.xml" relativeToChangelogFile="false"/>
+  <!-- ValueSetRelatedArtifactService is called on every VS toFhir and queries the
+       modeler and wiki schemas to decorate the response with related artifacts.
+       Without these tables present, `GET /fhir/ValueSet/{id}` 500s in the test app.
+       (PageProvider / StructureDefinitionContentReferenceProvider are present on
+       the classpath because termx-app drags both modules in.) -->
+  <include file="modeler/changelog/modeler/changelog.xml" relativeToChangelogFile="false"/>
+  <include file="wiki/changelog/wiki/changelog.xml" relativeToChangelogFile="false"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
## Summary

Real customer use case (ICCC-3 2017 cancer classification): one CodeSystem code carries N repeated `inclusion-rule` property entries, each with sibling `extension[]` decomposing a pipe-string (`H:9811 | S:420 | B:3`) into typed sub-extensions (`iccc-histology` / `iccc-site` / `iccc-behavior`). The JSON validates on the official HL7 FHIR validator. Before this change TermX silently dropped the extensions on import — the next FHIR GET returned the property without the extension cluster, so the machine-readable decomposition was lost.

The repetition itself was always preserved by the repo; only the per-occurrence `extension[]` was lost. This PR mirrors the existing property-*definition* binding-extension round-trip (`codesystem-property-codesystem`, `codesystem-property-valueset`) but at the per-*value* layer where URLs are open-ended (each IG defines its own).

## What changed

- `terminology.entity_property_value` gains `extensions jsonb` via Liquibase changeset 15 (idempotent `add column if not exists`, `termx` author per project policy).
- `EntityPropertyValue` (termx-api) gains `Object extensions` — kept provider-neutral so termx-api stays free of the zmei/FHIR dep.
- `EntityPropertyValueRepository` wires the column through all three save paths (single save, batch insert, batch update) and into the `PgBeanProcessor` read mapping.
- `CodeSystemFhirMapper.fromFhirProperties` reads `v.getExtension()` and stores verbatim — no URL interpretation.
- `CodeSystemFhirMapper.toFhirConceptProperties` emits via Jackson `convertValue` back to `List<Extension>`; only set when non-empty.

## Tests

New `CodeSystemRoundTripTest` in `:termx-integtest` — full `@MicronautTest` with Postgres testcontainers. Four coordinated FHIR fixtures (`round-trip/cs0..cs2` + `vs1`) exercise all seven datatype properties, repeated values, per-value extensions (the new feature), property-definition binding extensions to CS+VS, and stored-VS compose round-trip. Imports via `*FhirImportService`, reads back via `*ResourceStorage.load(…)` — same code path the FHIR HTTP GET delegates to. Comparison normalises server-set fields, canonicalises JSON key order recursively, and sorts repeated property values.

`termx-integtest-changelog.xml` extended with `modeler` + `wiki` schemas: `ValueSetRelatedArtifactService` queries both on every VS toFhir.

## Pre-existing bugs surfaced and tracked separately

Fixtures sidestep each:
- `dateTime` values truncated to date (`12:00:00Z` → `00:00:00Z`)
- `Coding` values silently dropped when `Coding.system` isn't a stored TermX CodeSystem
- `Coding.display` lost on successful import-time resolution

Each spawned as its own follow-up task; not addressed here.

## Out of scope

- Top-level `CodeSystem.extension` round-trip (`cqf-knowledgeRepresentationLevel` etc.)
- `concept.designation[].extension`
- UI rendering in termx-web (separate repo, follow-up after API lands)

## Test plan

- [x] `:termx-integtest:test CodeSystemRoundTripTest` — 1/1 green.
- [x] `:terminology:test` — green (no regressions in mapper unit tests).
- [ ] Manual smoke against dev with the customer's ICCC JSON: POST to `/fhir/CodeSystem`, GET back, diff. `extension[]` arrays on each `inclusion-rule` value should round-trip byte-equivalent (modulo formatting).