### PR TITLE
chore(commons): drop stale groovy-3 / spock-2.2 pinning in csv/db/util

### DIFF
--- a/kodality-commons/commons-csv/build.gradle
+++ b/kodality-commons/commons-csv/build.gradle
@@ -10,10 +10,13 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
-  testImplementation "org.codehaus.groovy:groovy-all:3.0.10"
-  testImplementation("org.spockframework:spock-core:2.2-M1-groovy-3.0") {
-    exclude group: "org.codehaus.groovy", module: "groovy-all"
-  }
+  // Versions come from the root build.gradle.kts BOMs:
+  //   org.apache.groovy:groovy-bom:5.0.3
+  //   org.spockframework:spock-bom:2.4-groovy-5.0
+  // The old stale pinning (groovy-all:3.0.10 + spock-core:2.2-M1-groovy-3.0)
+  // collided with org.apache.groovy:groovy:5.0.3 from the BOM and broke
+  // root-level `./gradlew test` with a capability conflict.
+  testImplementation "org.spockframework:spock-core"
 }
 
 test {

--- a/kodality-commons/commons-db/build.gradle
+++ b/kodality-commons/commons-db/build.gradle
@@ -17,10 +17,10 @@ dependencies {
   api 'commons-dbutils:commons-dbutils:1.8.1'
   implementation 'jakarta.inject:jakarta.inject-api:2.0.1'
 
-  testImplementation "org.codehaus.groovy:groovy-all:3.0.10"
-  testImplementation("org.spockframework:spock-core:2.2-M1-groovy-3.0") {
-    exclude group: "org.codehaus.groovy", module: "groovy-all"
-  }
+  // Versions come from the root build.gradle.kts BOMs
+  // (groovy-bom:5.0.3 / spock-bom:2.4-groovy-5.0); see commons-csv for the
+  // backstory on the old stale pinning that broke root-level gradle test.
+  testImplementation "org.spockframework:spock-core"
 }
 
 test {

--- a/kodality-commons/commons-util/build.gradle
+++ b/kodality-commons/commons-util/build.gradle
@@ -14,10 +14,10 @@ dependencies {
   implementation "org.dmfs:lib-recur:0.17.1"
 
   testImplementation "junit:junit:4.13.2"
-  testImplementation "org.codehaus.groovy:groovy-all:3.0.10"
-  testImplementation("org.spockframework:spock-core:2.2-M1-groovy-3.0") {
-    exclude group: "org.codehaus.groovy", module: "groovy-all"
-  }
+  // Versions come from the root build.gradle.kts BOMs
+  // (groovy-bom:5.0.3 / spock-bom:2.4-groovy-5.0); see commons-csv for the
+  // backstory on the old stale pinning that broke root-level gradle test.
+  testImplementation "org.spockframework:spock-core"
 }
 
 test {


### PR DESCRIPTION
## Summary
- `kodality-commons/commons-csv`, `commons-db`, and `commons-util` each pinned `org.codehaus.groovy:groovy-all:3.0.10` + `org.spockframework:spock-core:2.2-M1-groovy-3.0` as testImplementation. These collide with the root build's `org.apache.groovy:groovy-bom:5.0.3` + `spock-bom:2.4-groovy-5.0` and break root-level \`./gradlew test\` with a capability conflict (`org.codehaus.groovy:groovy:3.0.10` vs `org.apache.groovy:groovy:5.0.3`).
- Dropped the explicit pinning in all three; root BOMs now supply versions. Each module's existing Spock tests still compile and pass.

## Follow-up (separate task)
Sibling `commons-http-client` has the same stale Spock pin AND an unrelated stale `wiremock-jre8:2.33.1` dep that pulls jetty-alpn shims without versions. Once that's fixed, root-level \`./gradlew test\` will run end-to-end. Tracked as a follow-up chip.

## Test plan
- [x] \`:kodality-commons:commons-csv:test\` — 4/4 green
- [x] \`:kodality-commons:commons-util:test\` — green
- [x] \`:kodality-commons:commons-db:test\` — green (no tests in module but compile clean)