### PR TITLE
chore(commons-http-client): migrate to wiremock 3.x + drop stale Spock pin

### DIFF
--- a/kodality-commons/commons-http-client/build.gradle
+++ b/kodality-commons/commons-http-client/build.gradle
@@ -7,11 +7,17 @@ dependencies {
   api project(":kodality-commons:commons-util")
   api project(":kodality-commons:commons-model")
 
-  testImplementation "junit:junit:4.13"
-  testImplementation("org.spockframework:spock-core:2.2-M1-groovy-3.0") {
-    exclude group: "org.codehaus.groovy", module: "groovy-all"
-  }
-  testImplementation "com.github.tomakehurst:wiremock-jre8:2.33.1"
+  testImplementation "junit:junit:4.13.2"
+  // Versions come from the root build.gradle.kts BOMs (groovy-bom:5.0.3 /
+  // spock-bom:2.4-groovy-5.0). spock-junit4 lets Spock 2.x honour the JUnit 4
+  // @Rule WireMockRule used in HttpClientSpec.
+  testImplementation "org.spockframework:spock-core"
+  testImplementation "org.spockframework:spock-junit4"
+  // WireMock 2.x line (wiremock-jre8) is unmaintained and pulls jetty-alpn
+  // shims without versions, breaking root-level dependency resolution. The
+  // maintained successor is org.wiremock:wiremock 3.x; API for WireMockRule
+  // and WireMock.* statics is preserved.
+  testImplementation "org.wiremock:wiremock:3.13.1"
 }
 
 test {


### PR DESCRIPTION
## Summary

- `com.github.tomakehurst:wiremock-jre8:2.33.1` is the unmaintained 2.x line and pulls `org.eclipse.jetty:jetty-alpn-openjdk8-{server,client}` without versions — those aren't in any configured repository, so root-level \`./gradlew test\` blew up at dep resolution before any test could run.
- Migrated to the maintained successor `org.wiremock:wiremock:3.13.1`. Package layout for `WireMockRule` and the `WireMock.*` statics is preserved, so `HttpClientSpec` compiles unchanged.
- While here, dropped the same stale `spock-core:2.2-M1-groovy-3.0` pin we just cleared from commons-csv/db/util in #153 and added `spock-junit4` (Spock 2.x doesn't honour JUnit 4 `@Rule` without it; the test uses `@Rule WireMockRule`).

## Test plan
- [x] \`:kodality-commons:commons-http-client:test\` — 21/21 green (HttpClientSpec 13 + UrlUtilTest 8)
- [x] Confirmed root-level \`./gradlew test\` no longer fails at dep resolution

## Remaining work for root \`gradle test\` to run end-to-end

Five more vendored / project modules surface different pre-existing infra problems (each its own thing, not related to this fix). Tackled per-module in a follow-up; chip spawned with the catalog:

- `kodality-commons/commons-model` — JUnit 4 tests without `useJUnit()` declaration
- `ucum`, `uam` — Spock test sources but no `spock-core` testImplementation
- `zmei/zmei-fhir`, `zmei/zmei-fhir-jackson` — vendored modules with test sources but no runner config