### PR TITLE
chore: unbreak root ./gradlew test (5 modules)

### DIFF
--- a/kodality-commons/commons-model/build.gradle
+++ b/kodality-commons/commons-model/build.gradle
@@ -7,3 +7,9 @@ dependencies {
 
   testImplementation "junit:junit:4.13.2"
 }
+
+// JUnit 4 tests live in src/test/java; Gradle 9's strict "failOnNoDiscoveredTests"
+// check requires the runner to be declared explicitly.
+test {
+  useJUnit()
+}

--- a/uam/build.gradle.kts
+++ b/uam/build.gradle.kts
@@ -9,6 +9,10 @@ dependencies {
     implementation("com.kodality.commons:commons-micronaut-pg:${rootProject.extra["commonsMicronautVersion"]}")
     implementation("com.kodality.commons:commons-cache:${rootProject.extra["commonsVersion"]}")
 
+    testImplementation("io.micronaut.test:micronaut-test-spock")
+    testImplementation("org.spockframework:spock-core") {
+        exclude(group = "org.codehaus.groovy", module = "groovy-all")
+    }
     testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")
     testRuntimeOnly("org.objenesis:objenesis:3.3")
 }

--- a/ucum/build.gradle.kts
+++ b/ucum/build.gradle.kts
@@ -29,4 +29,10 @@ dependencies {
     implementation("com.kodality.zmei:zmei-fhir-jackson:${rootProject.extra["zmeiVersion"]}") { isChanging = true }
 
     implementation("org.fhir:ucum:1.0.10")
+
+    testImplementation("io.micronaut.test:micronaut-test-spock")
+    testImplementation("org.spockframework:spock-core") {
+        exclude(group = "org.codehaus.groovy", module = "groovy-all")
+    }
+    testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")
 }

--- a/zmei/zmei-fhir-jackson/build.gradle
+++ b/zmei/zmei-fhir-jackson/build.gradle
@@ -10,3 +10,9 @@ dependencies {
   testImplementation 'com.flipkart.zjsonpatch:zjsonpatch:0.4.14'
 }
 
+// JUnit 4 tests live in src/test/java; Gradle 9's strict "failOnNoDiscoveredTests"
+// check requires the runner to be declared explicitly.
+test {
+  useJUnit()
+}
+

--- a/zmei/zmei-fhir/build.gradle
+++ b/zmei/zmei-fhir/build.gradle
@@ -5,4 +5,10 @@ dependencies {
   testImplementation 'junit:junit:4.13.2'
 }
 
+// JUnit 4 tests live in src/test/java; Gradle 9's strict "failOnNoDiscoveredTests"
+// check requires the runner to be declared explicitly.
+test {
+  useJUnit()
+}
+
 


### PR DESCRIPTION
## Summary

After #153 / #154 cleared the upstream dep-resolution blockers, root-level \`./gradlew test\` ran far enough to surface Gradle 9's strict "failOnNoDiscoveredTests" check in five modules — each had a different pre-existing infra gap.

| Module | Problem | Fix |
|---|---|---|
| \`kodality-commons/commons-model\` | JUnit 4 tests in src/test/java, no runner declared | \`test { useJUnit() }\` |
| \`ucum\` | Spock tests in src/test/groovy, no spock-core on test classpath | Added \`micronaut-test-spock\` + \`spock-core\` + \`byte-buddy\` (same trio as \`:terminology\`) |
| \`uam\` | Same as ucum | Same fix |
| \`zmei/zmei-fhir\` (vendored) | JUnit 4 tests in src/test/java, no runner | \`test { useJUnit() }\` |
| \`zmei/zmei-fhir-jackson\` (vendored) | Same as zmei-fhir | Same fix |

## Result

\`./gradlew test\` at the project root now runs end-to-end:

**72 suites, 427 tests, 0 failures, 0 errors, 2 skipped** (both pre-existing \`@Ignore\`d).

Suites added by this change:
- commons-model: 3 suites / 5 tests
- ucum: 3 suites / 10 tests
- uam: 1 suite / 7 tests
- zmei-fhir: 4 suites / 9 tests
- zmei-fhir-jackson: 5 suites / 22 tests

## Test plan
- [x] Each module's test passes individually
- [x] \`./gradlew test\` at root completes green