### PR TITLE
fix(fhir-cs): round-trip dateTime precision + Coding display + unstored systems

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -383,32 +383,59 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
           case EntityPropertyType.decimal -> fhir.setValueDecimal(new BigDecimal(String.valueOf(pv.getValue())));
           case EntityPropertyType.integer -> fhir.setValueInteger(Integer.valueOf(String.valueOf(pv.getValue())));
           case EntityPropertyType.coding -> {
-            Concept concept = JsonUtil.getObjectMapper().convertValue(pv.getValue(), Concept.class);
-            if (concept.getCodeSystem() == null || concept.getCode() == null) {
+            // Read the canonical EntityPropertyValueCodingValue shape (codeSystem +
+            // code + display + version). The import path normalises every Coding
+            // to this shape, so display survives Coding→Concept resolution.
+            // `asCodingValue()` round-trips via JSON, so it also handles the
+            // legacy stored shapes (raw FHIR Coding with `system` would fail
+            // here but is no longer produced; raw Concept lacks display and
+            // would round-trip without it — acceptable for legacy data).
+            EntityPropertyValue.EntityPropertyValueCodingValue coding = pv.asCodingValue();
+            if (coding == null || coding.getCodeSystem() == null || coding.getCode() == null) {
               return null;
             }
 
-            var coding = new Coding(
-                    propertySystemUri.getOrDefault(concept.getCodeSystem(), concept.getCodeSystem()),
-                    concept.getCode());
+            var fhirCoding = new Coding(
+                    propertySystemUri.getOrDefault(coding.getCodeSystem(), coding.getCodeSystem()),
+                    coding.getCode());
 
-            snapshotCodings.stream()
-                    .filter(propertyCoding -> concept.getCode().equals(propertyCoding.code())
-                            && concept.getCodeSystem().equals(propertyCoding.system()))
-                    .findFirst()
-                    .ifPresent(propertyCoding -> {
-                      coding.setDisplay(getDisplay(propertyCoding.display(), language));
-                      coding.setVersion(propertyCoding.version());
-                    });
+            // Prefer the user-supplied display from the stored value. Fall back
+            // to the per-language snapshot lookup (used when the import didn't
+            // carry a display, e.g. file imports that resolve by code only).
+            // EPVCV.display is typed `Object` to accommodate either a plain
+            // String (FHIR import) or a serialised localised name (file import);
+            // route both through `getDisplay` which is JSON-tolerant.
+            if (coding.getDisplay() != null) {
+              String displayStr = coding.getDisplay() instanceof String s ? s : JsonUtil.toJson(coding.getDisplay());
+              fhirCoding.setDisplay(getDisplay(displayStr, language));
+            } else {
+              snapshotCodings.stream()
+                      .filter(propertyCoding -> coding.getCode().equals(propertyCoding.code())
+                              && coding.getCodeSystem().equals(propertyCoding.system()))
+                      .findFirst()
+                      .ifPresent(propertyCoding -> fhirCoding.setDisplay(getDisplay(propertyCoding.display(), language)));
+            }
+            if (coding.getVersion() != null) {
+              fhirCoding.setVersion(coding.getVersion());
+            } else {
+              snapshotCodings.stream()
+                      .filter(propertyCoding -> coding.getCode().equals(propertyCoding.code())
+                              && coding.getCodeSystem().equals(propertyCoding.system()))
+                      .findFirst()
+                      .ifPresent(propertyCoding -> fhirCoding.setVersion(propertyCoding.version()));
+            }
 
-            fhir.setValueCoding(coding);
+            fhir.setValueCoding(fhirCoding);
           }
           case EntityPropertyType.dateTime -> {
             if (pv.getValue() instanceof OffsetDateTime odt) {
               fhir.setValueDateTime(odt);
             } else {
-              OffsetDateTime dateTime = DateUtil.parseOffsetDateTime(pv.getValue() instanceof String s ? s : String.valueOf(pv.getValue()));
-              fhir.setValueDateTime(dateTime.withHour(0).withMinute(0).withSecond(0).withNano(0));
+              // JSONB rehydrates OffsetDateTime as an ISO string. Parse and pass
+              // through verbatim — preserve full precision (hour/minute/second/nano).
+              // The previous code zeroed the time-of-day, which made every dateTime
+              // round-trip lossy.
+              fhir.setValueDateTime(DateUtil.parseOffsetDateTime(pv.getValue() instanceof String s ? s : String.valueOf(pv.getValue())));
             }
           }
         }
@@ -736,11 +763,26 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     return propertyValues.stream().filter(v -> !List.of("status", "is-a", "parent", "partOf", "groupedBy", "classifiedWith", "child").contains(v.getCode()))
         .map(v -> {
           EntityPropertyValue value = new EntityPropertyValue();
-          value.setValue(Stream.of(
+          // Normalise FHIR Coding to TermX's canonical EntityPropertyValueCodingValue
+          // shape at import time. FHIR uses `system`, TermX uses `codeSystem` —
+          // storing the raw FHIR Coding leaves downstream readers (every existing
+          // call site that does `pv.asCodingValue()`) with codeSystem=null, and
+          // FHIR re-export then silently dropped the property. Normalising here
+          // also gives us a place to preserve the user-supplied `display`, which
+          // the subsequent Coding→Concept resolution step would otherwise discard.
+          Object rawValue = Stream.of(
               v.getValueCode(), v.getValueCoding(),
               v.getValueString(), v.getValueInteger(),
               v.getValueBoolean(), v.getValueDateTime(), v.getValueDecimal()
-          ).filter(Objects::nonNull).findFirst().orElse(null));
+          ).filter(Objects::nonNull).findFirst().orElse(null);
+          if (rawValue instanceof Coding c) {
+            EntityPropertyValue.EntityPropertyValueCodingValue coding =
+                new EntityPropertyValue.EntityPropertyValueCodingValue(c.getCode(), c.getSystem());
+            coding.setDisplay(c.getDisplay());
+            coding.setVersion(c.getVersion());
+            rawValue = coding;
+          }
+          value.setValue(rawValue);
           value.setEntityProperty(v.getCode());
           // Round-trip arbitrary per-value extensions (e.g. customer IG fields
           // that decompose a pipe-string into typed sub-values). Stored verbatim

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
@@ -286,13 +286,34 @@ public class CodeSystemImportService {
         pv.setEntityPropertyId(property.get().getId());
         if (property.get().getType().equals(EntityPropertyType.coding)) {
           try {
-            Coding coding = (Coding) pv.getValue();
-            String key = coding.getSystem() + "|" + coding.getCode();
-            Optional<Concept> conceptOpt = conceptCache.computeIfAbsent(key, k ->
-                conceptService.load(coding.getSystem(), coding.getCode())
-                    .or(() -> conceptService.loadByUri(coding.getSystem(), coding.getCode()))
-            );
-            conceptOpt.ifPresent(pv::setValue);
+            // CodeSystemFhirMapper normalises imported FHIR Codings to
+            // EntityPropertyValueCodingValue at the boundary; FileImporter and
+            // similar paths may still hand us a raw FHIR Coding, so accept both.
+            // Whichever shape we receive, store as EPVCV — the canonical TermX
+            // shape that preserves `display` through later round-trips (a bare
+            // Concept doesn't carry display, so the previous Concept-replacement
+            // was lossy).
+            EntityPropertyValue.EntityPropertyValueCodingValue coding;
+            if (pv.getValue() instanceof Coding c) {
+              coding = new EntityPropertyValue.EntityPropertyValueCodingValue(c.getCode(), c.getSystem());
+              coding.setDisplay(c.getDisplay());
+              coding.setVersion(c.getVersion());
+            } else {
+              coding = pv.asCodingValue();
+            }
+            // Resolution: if the Coding refers to a stored TermX concept, fine —
+            // the lookup is still useful for callers that want the internal id,
+            // but we don't replace the stored value (which would drop display).
+            // Unresolvable Codings (e.g. external systems we don't host) round-
+            // trip verbatim instead of being silently dropped on export.
+            if (coding != null && coding.getCodeSystem() != null && coding.getCode() != null) {
+              String key = coding.getCodeSystem() + "|" + coding.getCode();
+              conceptCache.computeIfAbsent(key, k ->
+                  conceptService.load(coding.getCodeSystem(), coding.getCode())
+                      .or(() -> conceptService.loadByUri(coding.getCodeSystem(), coding.getCode()))
+              );
+            }
+            pv.setValue(coding);
           } catch (RuntimeException ignored) {
           }
         }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/CodeSystemRoundTripTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/CodeSystemRoundTripTest.groovy
@@ -89,16 +89,22 @@ class CodeSystemRoundTripTest extends TermxIntegTest {
     and: "CS1 property definitions round-trip"
     propertyDefs(cs1Out) == propertyDefs(cs1In)
 
-    and: "CS1 concept `a` keeps its six scalar datatype property values"
-    // Coding-value round-trip is exercised on CS2 (where the property definition
-    // carries a `codesystem-property-codesystem` binding extension — the only
-    // shape under which TermX preserves the canonical URL and display).
+    and: "CS1 concept `a` keeps all seven FHIR datatype property values"
+    // p-datetime tests full timestamp precision (12:30:45Z) — not midnight.
+    // p-coding here points to a *stored* CS (rt-cs0) so resolution succeeds;
+    // the user-supplied `display` must still come back on the round-trip.
     conceptProps(cs1Out, "a") == conceptProps(cs1In, "a")
+
+    and: "CS1 concept `c` keeps Coding values whose system is NOT a stored CodeSystem"
+    // Tests the silent-drop bug: import sees an unresolvable Coding (the URL
+    // isn't a CS we know about), stores it, and the export must still emit it
+    // verbatim — not silently drop it because Concept-style field lookup fails.
+    conceptProps(cs1Out, "c") == conceptProps(cs1In, "c")
 
     and: "CS1 concept `b` keeps repeated p-string values AND the per-value extension cluster"
     // The repetition itself ("first" / "second" / pipe-string) is preserved
     // by the existing repository. The extension[] sibling on the pipe-string
-    // entry is what this PR adds — verified by this assertion.
+    // entry is what PR #152 added — still green here.
     conceptProps(cs1Out, "b") == conceptProps(cs1In, "b")
 
     and: "CS2: property-definition binding extensions (codesystem-property-codesystem / -valueset) round-trip"
@@ -106,12 +112,10 @@ class CodeSystemRoundTripTest extends TermxIntegTest {
     def cs2Out = normalise(cs2Output)
     propertyDefs(cs2Out) == propertyDefs(cs2In)
 
-    and: "CS2 per-concept Coding values for refs to CS1 and VS1 survive (system + code)"
-    // `display` is intentionally omitted from these Coding values in the
-    // fixture — it's a known separate bug: on successful Coding→Concept
-    // resolution at import time the user-supplied `display` is dropped (the
-    // TermX Concept doesn't carry it). The export then can't recover it from
-    // the empty snapshot. Tracked separately.
+    and: "CS2 per-concept Coding values keep system + code + display"
+    // The `display` round-trip on Coding-typed property values exercises the
+    // fix for the import-time normalization that previously discarded display
+    // when Coding successfully resolved to a stored TermX Concept.
     conceptProps(cs2Out, "x") == conceptProps(cs2In, "x")
     conceptProps(cs2Out, "y") == conceptProps(cs2In, "y")
 

--- a/termx-integtest/src/test/resources/fhir/round-trip/cs1.json
+++ b/termx-integtest/src/test/resources/fhir/round-trip/cs1.json
@@ -24,11 +24,19 @@
       "display": "Alpha",
       "property": [
         {"code": "p-code",     "valueCode":    "x"},
+        {"code": "p-coding",   "valueCoding":  {"system": "http://termx-test.local/CodeSystem/rt-cs0", "code": "ec1", "display": "External 1"}},
         {"code": "p-string",   "valueString":  "hello"},
         {"code": "p-integer",  "valueInteger": 42},
         {"code": "p-boolean",  "valueBoolean": true},
-        {"code": "p-datetime", "valueDateTime": "2025-06-01T00:00:00Z"},
+        {"code": "p-datetime", "valueDateTime": "2025-06-01T12:30:45Z"},
         {"code": "p-decimal",  "valueDecimal": 3.14}
+      ]
+    },
+    {
+      "code": "c",
+      "display": "Gamma (unstored Coding target)",
+      "property": [
+        {"code": "p-coding", "valueCoding": {"system": "http://unstored.invalid/CodeSystem/external", "code": "u1", "display": "Unstored 1"}}
       ]
     },
     {

--- a/termx-integtest/src/test/resources/fhir/round-trip/cs2.json
+++ b/termx-integtest/src/test/resources/fhir/round-trip/cs2.json
@@ -38,16 +38,16 @@
       "code": "x",
       "display": "X (refs Alpha)",
       "property": [
-        {"code": "ref-cs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "a"}},
-        {"code": "ref-vs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "a"}}
+        {"code": "ref-cs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "a", "display": "Alpha"}},
+        {"code": "ref-vs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "a", "display": "Alpha"}}
       ]
     },
     {
       "code": "y",
       "display": "Y (refs Beta)",
       "property": [
-        {"code": "ref-cs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "b"}},
-        {"code": "ref-vs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "b"}}
+        {"code": "ref-cs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "b", "display": "Beta"}},
+        {"code": "ref-vs", "valueCoding": {"system": "http://termx-test.local/CodeSystem/rt-cs1", "code": "b", "display": "Beta"}}
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Three bugs surfaced by `CodeSystemRoundTripTest` in #152, sidestepped in the fixtures at the time and tracked as separate chips. Fixed together because the two Coding bugs share root cause.

### 1. dateTime precision loss
\`valueDateTime: "2025-06-01T12:30:45Z"\` round-tripped as \`"2025-06-01T00:00:00Z"\` — the export's else-branch (used when JSONB rehydrates to String rather than OffsetDateTime) explicitly zeroed the time-of-day. Likely a legacy workaround. **One-line fix**: drop the \`.withHour(0).withMinute(0).withSecond(0).withNano(0)\` truncation.

### 2. Coding silent-drop when system isn't a stored TermX CodeSystem
### 3. Coding display lost on successful import-time resolution

Both bugs share root cause — inconsistent stored shape. Import stored raw FHIR Coding (system/code/display) when resolution failed, and replaced with a TermX Concept (codeSystem/code, **no display**) when it succeeded. Export's \`convertValue(pv.getValue(), Concept.class)\` produced a Concept with null codeSystem for the first case (silent drop) and a Concept with no display for the second (display loss).

**Fix**: normalise to \`EntityPropertyValueCodingValue\` at import. EPVCV has codeSystem + code + display + version — the canonical TermX shape already used by every other call site (\`grep "asCodingValue"\`).

- \`CodeSystemFhirMapper.fromFhirProperties\`: FHIR Coding → EPVCV at the boundary, display preserved.
- \`CodeSystemImportService.prepareEntityVersionProperties\`: look up the Concept for the cache side-effect but do NOT replace \`pv.value\` with the Concept (which would drop display).
- \`CodeSystemFhirMapper.toFhirConceptProperties\`: read EPVCV via \`pv.asCodingValue()\` instead of \`convertValue(Concept.class)\`. Emits display from the stored value; falls back to per-language snapshot lookup when no display was supplied (preserves existing file-importer behaviour).

## Tests

\`CodeSystemRoundTripTest\` — restored the bug-exposing fixtures:
- \`p-datetime\` uses \`12:30:45Z\`
- CS2 Coding values carry \`display\`
- New concept \`c\` has a Coding to an unstored system

Assertions tightened accordingly. All three previously-skipped round-trip cases now pass.

## Test plan
- [x] \`:termx-integtest:test CodeSystemRoundTripTest\` — 1/1 green
- [x] Root \`./gradlew test\` — 72 suites / 427 tests / 0 failures / 0 errors / 2 pre-existing @Ignore'd skips