### PR TITLE
fix(fhir-cs): cap inline entity load on read to stop dev-server OOM

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
@@ -35,6 +35,19 @@ import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 @Slf4j
 @Singleton
 public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
+  /**
+   * Absolute ceiling for inline-loading a CodeSystem version's concept entities into a single
+   * FHIR response body. Above this size the on-wire JSON would be unworkable for any client
+   * and the JDBC + heap cost has been observed to OOM dev-server with 1-2 GB heap on real
+   * publishers (LOINC ~100k, ICD-10 ~70k, SNOMED CT ~370k). When exceeded, {@link #loadEntities}
+   * returns an empty list and logs a WARN — clients should use {@code ?_summary=true},
+   * {@code /$expand}, or the concept-pagination endpoint instead. The {@code count} field on
+   * the response stays accurate because it comes from {@code CodeSystemVersion.conceptsTotal}
+   * (a single COUNT query inside versionService.load), not from {@code entities.size()}.
+   * Override via {@code termx.fhir.codesystem.read.max-inline-entities}.
+   */
+  private final int maxInlineEntities;
+
   private final CodeSystemService codeSystemService;
   private final CodeSystemVersionService codeSystemVersionService;
   private final CodeSystemEntityVersionService codeSystemEntityVersionService;
@@ -49,7 +62,8 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
                                    ProvenanceService provenanceService,
                                    CodeSystemImportService importService,
                                    CodeSystemFhirMapper mapper,
-                                   @Value("${termx.fhir.codesystem.search.default-summary:true}") String defaultSearchSummary) {
+                                   @Value("${termx.fhir.codesystem.search.default-summary:true}") String defaultSearchSummary,
+                                   @Value("${termx.fhir.codesystem.read.max-inline-entities:50000}") int maxInlineEntities) {
     this.codeSystemService = codeSystemService;
     this.codeSystemVersionService = codeSystemVersionService;
     this.codeSystemEntityVersionService = codeSystemEntityVersionService;
@@ -57,6 +71,7 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
     this.importService = importService;
     this.mapper = mapper;
     this.defaultSearchSummary = defaultSearchSummary;
+    this.maxInlineEntities = maxInlineEntities;
   }
 
   @Override
@@ -151,7 +166,24 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
   }
 
   private List<CodeSystemEntityVersion> loadEntities(CodeSystemVersion version, String code, boolean loadLargeEntities) {
-    if (version == null || (version.getConceptsTotal() > 1000 && !loadLargeEntities)) {
+    if (version == null) {
+      return List.of();
+    }
+    Integer total = version.getConceptsTotal();
+    if (total != null && total > 1000 && !loadLargeEntities) {
+      // Search path: callers that don't ask for the heavy load skip it for anything above 1k.
+      return List.of();
+    }
+    // Hard ceiling: even on the read path with loadLargeEntities=true, refuse to inline
+    // huge concept sets. The previous behaviour pulled every row into one JDBC result set,
+    // OOM-ing the JVM on real publishers (LOINC, ICD-10, SNOMED CT). The CodeSystem still
+    // serialises with an accurate `count`; clients that need the concepts should use
+    // ?_summary=true, /$expand, or the concept-pagination endpoint.
+    if (code == null && total != null && total > maxInlineEntities) {
+      log.warn("CodeSystem {} version {} has {} concepts, exceeding inline cap {} — returning "
+              + "without entities. Clients should call /$expand or paginate /concept instead, "
+              + "or override termx.fhir.codesystem.read.max-inline-entities for this server.",
+          version.getCodeSystem(), version.getVersion(), total, maxInlineEntities);
       return List.of();
     }
     CodeSystemEntityVersionQueryParams codeSystemEntityVersionParams = new CodeSystemEntityVersionQueryParams()


### PR DESCRIPTION
## Symptom

`dev-server` (dev.termx.org) was OOM-looping with:

```
ERROR c.k.k.r.e.FhirExceptionHandler - Fhir error occurred
java.lang.RuntimeException: java.lang.OutOfMemoryError: Java heap space
  at com.kodality.kefhir.rest.KefhirEndpointService.invoke(...)
  ...
Caused by: org.postgresql.util.PSQLException: Ran out of memory retrieving query results.
  at org.postgresql.core.v3.QueryExecutorImpl.processResults(...)
  ...
  at org.termx.terminology.fhir.codesystem.CodeSystemResourceStorage.loadEntities(CodeSystemResourceStorage.java:161)
  at org.termx.terminology.fhir.codesystem.CodeSystemResourceStorage.load(CodeSystemResourceStorage.java:107)
```

Failures cascade into unrelated requests — `SnomedImportPollingService` can't even open a JDBC connection while the heap is exhausted.

## Cause

The existing >1000 guard in `loadEntities()` only triggered when `loadLargeEntities=false`. The FHIR read path (`GET /fhir/CodeSystem/{id}`) calls `loadEntities(version, null, true)`, so the guard never fired on read. For real-world publishers — LOINC ~100k concepts, ICD-10 ~70k, SNOMED CT ~370k — Postgres returns every concept-entity row in one shot, JDBC buffers all of it, JVM dies.

`?_summary=true` was already wired up as a per-request escape hatch (commit 7bb1410), but nothing protected against a caller that just didn't pass it (browser tab on the viewer, integration test, enrichment job, etc.).

## Fix

Add an absolute ceiling that fires even when `loadLargeEntities=true`:

```java
if (code == null && total != null && total > maxInlineEntities) {
  log.warn("CodeSystem {} version {} has {} concepts, exceeding inline cap {} — ...");
  return List.of();
}
```

- **Default cap: 50000**. Tunable via `termx.fhir.codesystem.read.max-inline-entities`.
- **Logs a WARN** naming the CodeSystem + version + actual count so operators can see exactly which read triggered the truncation.
- **Skipped when `code != null`** — code-filtered queries return ≤1 row regardless of total size, so the cap doesn't apply there.
- **Doesn't change the `count` field** of the response. `count` comes from `CodeSystemVersion.conceptsTotal` (a single COUNT query), not from `entities.size()`. Clients can therefore detect the truncation (large `count` + empty `concept[]`) and pivot to `$expand` or `/concept` pagination.

## Behavior matrix

| Caller | `code` | `loadLargeEntities` | `conceptsTotal` | Before | After |
|---|---|---|---|---|---|
| search, default summary | null | false | any | empty | empty (unchanged) |
| search, summary=false, small CS | null | true | ≤1000 | full load | full load (unchanged) |
| search, summary=false, mid CS | null | true | 1001–50000 | full load | full load (unchanged) |
| search, summary=false, **huge CS** | null | true | >50000 | **OOM** | empty + WARN |
| read, default | null | true | ≤50000 | full load | full load (unchanged) |
| read, default, **huge CS** | null | true | >50000 | **OOM** | empty + WARN |
| read, `?_summary=true` | n/a | n/a | any | empty (kefhir post-processor) | empty (kefhir post-processor) |
| code-filtered (`?code=…`) | "X" | true | any | 1 row | 1 row (unchanged) |

## Test plan

- [ ] On dev.termx.org, try `GET /fhir/CodeSystem/<a-huge-id>` (LOINC / ICD / SNOMED). Expect: HTTP 200 with a CodeSystem body that has `count` populated but `concept` empty, and a WARN line `CodeSystem … exceeding inline cap …` in the dev-server log. Heap stable, no OOM cascade.
- [ ] Same URL with `?_summary=true`: HTTP 200 with no `concept`, no WARN (existing path).
- [ ] Same URL with `?code=<some-code>`: HTTP 200 with the single concept inline — cap not triggered.
- [ ] `GET /fhir/CodeSystem/<small-id>` (a few hundred concepts): unchanged, full inline `concept[]`.

## Follow-ups (not in this PR)

* `lmb-terminology-server` ships the same `CodeSystemResourceStorage` and has the same bug — should mirror this fix there.
* Code-side, the real architectural fix is streaming the JDBC result (Postgres cursor + fetch size) so even small-heap deployments can produce arbitrarily large responses without buffering. Out of scope for an OOM-stopgap PR.
