### PR TITLE
ops(jvm): fail fast on OOM with heap dump for postmortem

### DIFF
--- a/termx-app/Dockerfile
+++ b/termx-app/Dockerfile
@@ -8,5 +8,24 @@ ENV APP_VERSION=${APP_VERSION:-latest}
 ARG BUILD_TIME
 ENV BUILD_TIME=$BUILD_TIME
 
+# Fail-fast on OutOfMemoryError instead of letting the JVM limp on with
+# a depleted heap. The previous behaviour (no flag) caused the May 2026
+# dev-server incident where a single OOM cascaded into every concurrent
+# request, the Netty selector, AND the SnomedImportPollingService — all
+# died with their own OOMs over several minutes while the container
+# kept running. ExitOnOutOfMemoryError makes the JVM exit immediately;
+# Docker's `restart: unless-stopped` brings it back clean within seconds.
+# HeapDumpOnOutOfMemoryError + HeapDumpPath leave a postmortem .hprof so
+# the next incident can be diagnosed without re-OOMing dev-server to
+# capture a heap dump live.
+#
+# /app/logs is the standard volume-mount path the deploy compose files
+# already export to /opt/.../logs on the host, so dumps survive container
+# recreation. Create it eagerly so the JVM doesn't error if the volume
+# isn't bound (dev runs without a mount).
+RUN mkdir -p /app/logs
+
+ENV JVM_OOM_OPTS="-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/"
+
 COPY build/libs/*-all.jar terminology.jar
-CMD java ${JAVA_OPTS} -jar terminology.jar
+CMD java ${JVM_OOM_OPTS} ${JAVA_OPTS} -jar terminology.jar


### PR DESCRIPTION
Adds `-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/` to the termx-app Dockerfile's java invocation.

## Why

The May 2026 dev-server incident (the same one #157 fixed at the code level) showed why: a single FHIR read OOM'd the heap, then over the next ~3 minutes **every other in-flight request, the Netty selector manager, the HttpClient threads, and the unrelated SnomedImportPollingService** died with their own OOMs. The JVM never exited — Docker's `restart: unless-stopped` policy never fired — and operators got a slow trickle of unrelated errors across the access log instead of one clean restart.

This PR makes the failure mode much better even when the next OOM-trigger bug slips through:
- `ExitOnOutOfMemoryError` → JVM dies on first OOM → Docker restarts the container in seconds → clean fresh process
- `HeapDumpOnOutOfMemoryError` + `HeapDumpPath=/app/logs/` → postmortem .hprof on the host (already volume-mounted in our deployments) so the next incident can be diagnosed offline

Layered with #157: #157 prevents one specific large-load OOM trigger; this PR limits the blast radius for any OOM trigger we haven't found yet.

## Diff

Two lines added, one CMD line tweaked:

```Dockerfile
RUN mkdir -p /app/logs
ENV JVM_OOM_OPTS="-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/"
CMD java ${JVM_OOM_OPTS} ${JAVA_OPTS} -jar terminology.jar
```

JAVA_OPTS still appended (overrides anything in JVM_OOM_OPTS by JVM precedence), so callers retain full override capability.

## Test plan
- [ ] Build the image, start container with a tiny `-Xmx32m` JAVA_OPTS, fire a curl that allocates a big string into a debug endpoint, observe: process exits, .hprof appears in /app/logs/, container restarts.