### PR TITLE
SNOMED edition routing + FHIR operation display/version fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ out/
 *.swo
 *.swp
 application-local.yml
+# Env-specific local overrides (e.g. application-local-dev.termx.org.yml) — hold
+# secrets; never commit. Does not match the tracked application-local.sample.yml.
+application-local-*.yml
 CLAUDE.md
 .codex

--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,13 @@ out/
 *.ipr
 *.swo
 *.swp
-application-local.yml
-# Env-specific local overrides (e.g. application-local-dev.termx.org.yml) — hold
-# secrets; never commit. Does not match the tracked application-local.sample.yml.
-application-local-*.yml
+# Personal/local config overrides (hold secrets) — ignore every application-<env>.yml
+# (application-local.yml, application-devremote.yml, …) EXCEPT the tracked base configs
+# below. `application.yml` has no dash so it is never matched.
+application-*.yml
+!application-dev.yml
+!application-demo.yml
+!application-test.yml
+!application-local.sample.yml
 CLAUDE.md
 .codex

--- a/docs/features/snomed-import-management.md
+++ b/docs/features/snomed-import-management.md
@@ -66,6 +66,68 @@ After scanning a new release the manager copies the JSON of `SnomedRF2ScanResult
 
 The manager uploads several national-extension zips with different `meta.shortName` (e.g. `SNOMED-US`, `SNOMED-UK-CLINICAL`). The Bob list endpoint with a JSONB containment filter (`meta=...`) keeps the *Stored archives* card scoped per code-system, so each CodeSystem edit page only shows its own uploads.
 
+## Command-line runbook: importing/updating editions against Snowstorm
+
+The UI flows above are plain HTTP calls, which is handy for scripting bulk or repeated
+imports (e.g. onboarding several national extensions in one sitting). The same three
+primitives apply — **upload to Bob → (optionally) compute a delta → push to Snowstorm** —
+plus a read-only/write toggle on the Snowstorm deployment itself.
+
+> **Snowstorm runs read-only by default.** Content changes require Snowstorm to be started
+> in write mode (drop `--snowstorm.rest-api.readonly=true`) for the duration of the import,
+> then switched back. Snowstorm's native basic-auth is all-or-nothing (it gates reads too),
+> so there is no "read-open / write-keyed" mode — keep the write window short. The full
+> toggle commands live in `snowstorm-edition-runbook.md` at the workspace root.
+>
+> **Snowstorm ≥ 10.11.2 is required for delta imports.** Older builds (e.g. 10.2.1) throw a
+> `ConcurrentModificationException` in elasticvc's `endOldVersions` during concurrent
+> refset/description persistence, surfaced as a misleading `search_phase_execution_exception:
+> all shards failed`. Keep Elasticsearch at the certified **8.11.1**.
+
+```bash
+A='Authorization: Bearer yupi'; APP=http://localhost:8200; SNOW=<snowstorm-base-url>
+
+# 1. Upload an edition archive to Bob (tag shortName + branchPath) -> returns NEW_UUID
+curl -sX POST $APP/bob/objects -H "$A" -F file=@<EDITION.zip> -F container=snomed \
+  -F 'meta={"shortName":"<SHORTNAME>","branchPath":"<BRANCH>"}'
+
+# 2. UPDATE of an existing edition — compute a delta vs the current baseline -> DELTA_UUID in Bob
+curl -sX POST $APP/snomed/archives/<NEW_UUID>/delta -H "$A" -H 'Content-Type: application/json' \
+  -d '{"baselineUuid":"<BASELINE_UUID>","latestState":true}'
+curl -s  -H "$A" $APP/lorque-processes/<PID>/status          # poll until completed
+
+# 3. NEW extension only — create the code system first (dependent on International MAIN)
+curl -sX POST $SNOW/codesystems -H 'Content-Type: application/json' \
+  -d '{"shortName":"<SHORTNAME>","branchPath":"<BRANCH>","name":"<NAME>","dependantVersionEffectiveTime":<INTL_YYYYMMDD>}'
+
+# 4. Push to Snowstorm — apply the delta (update) or a SNAPSHOT (new edition)
+curl -sX POST $APP/snomed/imports/from-archive -H "$A" -H 'Content-Type: application/json' \
+  -d '{"archiveUuid":"<DELTA_OR_EDITION_UUID>","branchPath":"<BRANCH>","type":"DELTA","createCodeSystemVersion":false}'
+
+# 5. Poll the Snowstorm import job (jobId from the termx-server log / sys.snomed_import_tracking)
+curl -s $SNOW/imports/<JOBID>                                # RUNNING -> COMPLETED / FAILED
+curl -s $SNOW/<BRANCH>/concepts?limit=1                      # verify concept count
+```
+
+### Worked examples
+
+Editions processed against the public Snowstorm in one batch (local app driving dev Bob → public Snowstorm):
+
+| Edition | shortName | branch | action | rows |
+|---|---|---|---|---|
+| International | `SNOMEDCT` | `MAIN` | delta 2024-05-01 → 2026-06-01 | 1,204,812 |
+| Estonia | `SNOMEDCT-EE` | `MAIN/SNOMEDCT-EE` | delta 2024-05-30 → 2026-05-30 | 9,915 |
+| Czech (Simplex) | `SNOMEDCT-CZ` | `MAIN/SNOMEDCT-CZ` | new edition — SNAPSHOT 2026-04-14 | — |
+| LOINC extension | `SNOMEDCT-LOINC` | `MAIN/LOINC` | new edition — SNAPSHOT 2026-03-21 | — |
+
+Notes from these runs:
+- A ~553 MB edition uploads to Bob in ~40 s; the `DeltaGeneratorTool` diffs two full editions in
+  ~40 s; a 1.2M-row delta imports into Snowstorm 10.11.2 in ~15–25 min.
+- `latestState: true` produces a latest-state delta between two SNAPSHOT editions.
+- A self-contained "Simplex/Edition" package bundles the International core; importing it as a
+  *dependent* extension can duplicate International components on the branch — decide standalone
+  vs dependent before import.
+
 ## Implementation Highlights
 
 ### Backend
@@ -96,7 +158,7 @@ The manager uploads several national-extension zips with different `meta.shortNa
 ## Operational Notes
 
 - **Heap-safe end-to-end** — neither the dry-run scan, the delta tool, nor the Snowstorm push ever buffers the full RF2 archive in JVM heap. The legacy `POST /snomed/imports` path (which does buffer) is kept only for backwards-compatible callers.
-- **Snowstorm import status** — `sys.snomed_import_tracking` records the Snowstorm jobId returned by `createImportJob`; admins can poll Snowstorm directly with that jobId for completion / errors. There is no automatic poller yet.
+- **Snowstorm import status** — `sys.snomed_import_tracking` records the Snowstorm jobId returned by `createImportJob`. `SnomedImportPollingService` sweeps pending rows (every 30 s) and, on terminal status, records the result, captures the tail of Snowstorm's own import log via `SnowstormClient.getImportLogTail()` (Snowstorm Actuator `logfile` endpoint, also exposed at `GET /snomed/snowstorm-import-log`), and emails recipients. The poller only runs when `micronaut.email.import.recipients` is set. Admins can also poll Snowstorm directly with the jobId.
 - **Delta tool licensing** — the IHTSDO `delta-generator-tool` is vendored as a jar inside the repo; updates require swapping the file and bumping the path constant in `SnomedDeltaGeneratorRuntime`.
 - **Concept-usage scope** — the lookup walks CodeSystem supplements, ValueSet rules, and stored expansions only. It does not currently flag SNOMED references inside MapSet associations or external StructureDefinitions.
 - **No automatic re-scan on archive replace** — uploading a new zip with the same effective time creates a new Bob row; admins must trigger scan and delta calculation explicitly.

--- a/scripts/run-backend.sh
+++ b/scripts/run-backend.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
-# Run TermX Server in local development mode
-# This script runs the application with dev profile enabled, which:
-# - Enables dev authentication (Bearer token: yupi)
-# - Loads application-dev.yml and application-local.yml configurations
-# - Runs on port 8200 by default
-# - Kills any process already bound to that port so consecutive starts don't
-#   fall back to a different port or wedge gradle on "Address already in use"
+# Run TermX Server in local development mode.
+# - Runs on port 8200 by default (kills any process already bound to it)
+# - Dev authentication (Bearer token: yupi) is enabled automatically when the
+#   `dev` environment is in the list.
+#
+# Usage: ./scripts/run-backend.sh [environments]
+#   [environments] = the FULL comma-separated Micronaut environment list to activate;
+#                    each loads its application-<env>.yml. Default: dev,local
+#   Examples:
+#     ./scripts/run-backend.sh                       # dev,local
+#     ./scripts/run-backend.sh dev,dev.termx.org     # dev + application-dev.termx.org.yml
+#     ./scripts/run-backend.sh dev,local,myflavor    # any combination you want
 
 set -e
 
@@ -15,6 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
 PORT="${TERMX_SERVER_PORT:-8200}"
+ENVS="${1:-dev,local}"
 
 # Helper: kill any process listening on a given TCP port. Pattern lifted from
 # ~/source/emr/repo/scripts/run-backend.sh so termx and emr behave the same way
@@ -36,10 +42,10 @@ kill_port "$PORT"
 echo "=========================================="
 echo "Starting TermX Server (Local Dev Mode)"
 echo "=========================================="
-echo "Profile: dev,local"
-echo "Port:    ${PORT}"
-echo "Dev Token: yupi"
+echo "Environments: ${ENVS}"
+echo "Port:         ${PORT}"
+echo "Dev Token:    yupi (when 'dev' is in the list)"
 echo ""
 
 # Run the application
-./gradlew :termx-app:run -Pdev
+./gradlew :termx-app:run -Penv="${ENVS}"

--- a/snomed/build.gradle.kts
+++ b/snomed/build.gradle.kts
@@ -25,4 +25,10 @@ dependencies {
 
     implementation("commons-validator:commons-validator:1.7")
     implementation("com.univocity:univocity-parsers:2.9.1")
+
+    testImplementation("org.spockframework:spock-core") {
+        exclude(group = "org.codehaus.groovy", module = "groovy-all")
+    }
+    testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")
+    testRuntimeOnly("org.objenesis:objenesis:3.3")
 }

--- a/snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java
+++ b/snomed/src/main/java/org/termx/snomed/client/SnowstormClient.java
@@ -157,14 +157,64 @@ public class SnowstormClient {
   }
 
   public CompletableFuture<String> createImportJob(SnomedImportRequest request) {
-    return client.POST("imports", request).thenApply(resp -> resp.headers().firstValue("location").map(l -> {
-      String[] location = l.split("/");
-      return location[location.length - 1];
-    }).orElseThrow());
+    log.info("snowstorm-client: creating import job (branch={}, type={})", request.getBranchPath(), request.getType());
+    return client.POST("imports", request).thenApply(resp -> {
+      String location = resp.headers().firstValue("location").orElseThrow();
+      String[] parts = location.split("/");
+      String jobId = parts[parts.length - 1];
+      log.info("snowstorm-client: import job created jobId={} (HTTP {}, Location={})", jobId, resp.statusCode(), location);
+      return jobId;
+    });
   }
 
   public CompletableFuture<SnomedImportJob> loadImportJob(String jobId) {
-    return client.GET("imports/" + jobId, SnomedImportJob.class);
+    return client.GET("imports/" + jobId, SnomedImportJob.class).thenApply(job -> {
+      if (job != null) {
+        log.debug("snowstorm-client: import job {} poll -> status={} errorMessage={}", jobId, job.getStatus(), job.getErrorMessage());
+      }
+      return job;
+    });
+  }
+
+  /**
+   * Fetches Snowstorm's own log via the Spring Boot Actuator {@code logfile} endpoint and returns
+   * the tail of import-relevant lines (RF2 import / refset persistence). This surfaces Snowstorm-side
+   * import progress and errors (e.g. Elasticsearch failures during refset persistence) that are NOT
+   * exposed by the import-job status API. Each returned line is also echoed into the termx-server log.
+   *
+   * <p>Requires Snowstorm to be started with {@code --logging.file.name=<path>} and
+   * {@code --management.endpoints.web.exposure.include=health,logfile}; otherwise returns a hint.
+   */
+  public String getImportLogTail(int maxLines) {
+    HttpResponse<String> resp;
+    try {
+      resp = client.executeAsync(client.builder("actuator/logfile").GET().build()).join();
+    } catch (Exception e) {
+      log.warn("snowstorm-client: failed to fetch actuator/logfile: {}", e.getMessage());
+      return "Snowstorm logfile fetch failed: " + e.getMessage();
+    }
+    int sc = resp.statusCode();
+    if (sc != 200 && sc != 206) {
+      return "Snowstorm logfile not available (HTTP " + sc + "). Start Snowstorm with "
+          + "--logging.file.name=<path> and --management.endpoints.web.exposure.include=health,logfile";
+    }
+    String body = resp.body();
+    if (body == null || body.isEmpty()) {
+      return "(Snowstorm logfile empty)";
+    }
+    java.util.List<String> lines = new java.util.ArrayList<>();
+    for (String l : body.split("\n")) {
+      if (l.contains("ReleaseImporter") || l.contains("ImportService")
+          || l.contains("ImportComponentFactory") || l.contains("rf2import")
+          || l.contains("ComponentService")) {
+        lines.add(l);
+      }
+    }
+    int from = Math.max(0, lines.size() - Math.max(1, maxLines));
+    java.util.List<String> tail = lines.subList(from, lines.size());
+    log.info("snowstorm-client: ===== Snowstorm import log tail ({} of {} lines) =====", tail.size(), lines.size());
+    tail.forEach(l -> log.info("snowstorm-log| {}", l));
+    return String.join("\n", tail);
   }
 
   public CompletableFuture<HttpResponse<String>> uploadRF2File(String jobId, byte[] file) throws FileNotFoundException {
@@ -177,12 +227,19 @@ public class SnowstormClient {
    * Minio / file InputStream and the JVM never holds the whole archive in heap.
    */
   public CompletableFuture<HttpResponse<String>> uploadRF2File(String jobId, Supplier<InputStream> file) throws FileNotFoundException {
+    log.info("snowstorm-client: uploading RF2 archive to job {} (streaming multipart)", jobId);
     MultipartBodyPublisher publisher = new MultipartBodyPublisher()
         .addPart("file", file, "file", MediaType.APPLICATION_OCTET_STREAM);
     HttpRequest request = client.builder("imports/" + jobId + "/archive").POST(publisher.build())
         .header("Content-Type", "multipart/form-data; boundary=" + publisher.getBoundary())
         .build();
-    return client.executeAsync(request);
+    return client.executeAsync(request).whenComplete((resp, ex) -> {
+      if (ex != null) {
+        log.error("snowstorm-client: RF2 upload to job {} failed", jobId, ex);
+      } else {
+        log.info("snowstorm-client: RF2 upload to job {} accepted -> HTTP {}", jobId, resp.statusCode());
+      }
+    });
   }
 
   public CompletableFuture<SnomedConcept> loadConcept(String conceptId) {

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -286,6 +286,18 @@ public class SnomedController {
   }
 
   /**
+   * Pulls Snowstorm's own import log (via its Actuator {@code logfile} endpoint) into termx-server.
+   * Surfaces RF2-import progress and Snowstorm/Elasticsearch errors that the import-job status API
+   * does not expose. Returns the tail of import-relevant lines as plain text (also echoed to the
+   * termx-server log). Requires Snowstorm started with the logfile actuator endpoint enabled.
+   */
+  @Authorized(Privilege.SNOMED_READ)
+  @Get(value = "/snowstorm-import-log", produces = MediaType.TEXT_PLAIN)
+  public String snowstormImportLog(@QueryValue @Nullable Integer tail) {
+    return snowstormClient.getImportLogTail(tail == null ? 500 : tail);
+  }
+
+  /**
    * Streaming counterpart of {@link #scanImport}: the archive already lives in the
    * {@code "snomed"} Bob container, so re-running a dry-run scan does not require re-upload.
    */

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
@@ -81,8 +81,24 @@ public class SnomedImportPollingService {
             currentStatus, formatDuration(processed)));
         log.info("snomed-rf2-import: {}", tracking.getDetails().getLast());
 
+        // Pull Snowstorm's own import log (Actuator logfile) into termx-server so the
+        // RF2-import progress / Elasticsearch errors that the job-status API omits are
+        // captured in our logs and the notification email.
+        try {
+          String snowstormLog = snowstormClient.getImportLogTail(60);
+          if (snowstormLog != null && !snowstormLog.isBlank() && !snowstormLog.startsWith("Snowstorm logfile")) {
+            tracking.getDetails().add("--- Snowstorm import log (tail) ---");
+            for (String line : snowstormLog.split("\n")) {
+              tracking.getDetails().add(line);
+            }
+          }
+        } catch (Exception e) {
+          log.warn("snomed-rf2-import: could not capture Snowstorm log for job {}: {}",
+              tracking.getSnowstormJobId(), e.getMessage());
+        }
+
         trackingRepository.save(tracking);
-        
+
         long start = System.currentTimeMillis();
         List<String> recipients = emailService.getImportRecipients();
         log.info("Sending SNOMED import notification ({}) to {} recipient(s)", currentStatus, recipients.size());

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java
@@ -13,6 +13,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -108,6 +109,19 @@ public class SnomedImportPollingService {
         log.info("SNOMED import notification sent ({} sec)", (System.currentTimeMillis() - start) / 1000);
       }
     } catch (Exception e) {
+      // Snowstorm import jobs are ephemeral — after a Snowstorm restart/upgrade the job
+      // is gone and every poll returns 404. Treat that as terminal so we stop retrying
+      // (and spamming the log) forever; the result is simply unknown at that point.
+      String msg = ExceptionUtils.getRootCauseMessage(e);
+      if (msg != null && (msg.contains("returned 404") || msg.contains("Import job not found"))) {
+        log.warn("SNOMED import job {} no longer exists in Snowstorm (404) — marking EXPIRED", tracking.getSnowstormJobId());
+        tracking.setStatus("EXPIRED");
+        tracking.setFinished(OffsetDateTime.now());
+        tracking.setErrorMessage("Import job not found in Snowstorm (job expired after a Snowstorm restart).");
+        tracking.setNotified(true);
+        trackingRepository.save(tracking);
+        return;
+      }
       log.error("Failed to check SNOMED job status for " + tracking.getSnowstormJobId(), e);
     }
   }

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedRF2ImportFromArchiveService.java
@@ -62,6 +62,11 @@ public class SnomedRF2ImportFromArchiveService {
     SnomedImportRequest importRequest = req.toImportRequest();
     Long processId = process.getId();
 
+    log.info("snomed-rf2-import: queued import processId={} archiveUuid={} file={} branch={} type={}",
+        processId, req.getArchiveUuid(),
+        archive.getStorage() == null ? null : archive.getStorage().getFilename(),
+        importRequest.getBranchPath(), importRequest.getType());
+
     CompletableFuture.runAsync(SessionStore.wrap(() -> {
       // Lifecycle log lines for the post-import email — same pattern as LoincService's
       // ImportLog.successes. Captured into SnomedImportTracking.details when we save the

--- a/snomed/src/main/java/org/termx/snomed/ts/SnomedCodeSystemProvider.java
+++ b/snomed/src/main/java/org/termx/snomed/ts/SnomedCodeSystemProvider.java
@@ -5,13 +5,20 @@ import org.termx.snomed.concept.SnomedConcept;
 import org.termx.snomed.concept.SnomedConceptSearchParams;
 import org.termx.snomed.integration.SnomedService;
 import org.termx.core.ts.CodeSystemExternalProvider;
+import org.termx.core.ts.CodeSystemProvider;
 import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.ConceptQueryParams;
 import org.termx.ts.codesystem.Designation;
+import io.micronaut.context.BeanProvider;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +27,11 @@ import lombok.RequiredArgsConstructor;
 public class SnomedCodeSystemProvider extends CodeSystemExternalProvider {
   private final SnomedMapper snomedMapper;
   private final SnomedService snomedService;
+  // Lazy: SnomedCodeSystemProvider is itself a CodeSystemExternalProvider, and the concrete
+  // CodeSystemProvider (TerminologyCodeSystemProvider) depends on ConceptService, which injects
+  // List<CodeSystemExternalProvider> — a direct injection here would form a DI cycle. BeanProvider
+  // defers resolution to call time, breaking the cycle.
+  private final BeanProvider<CodeSystemProvider> codeSystemProvider;
 
   private static final String SNOMED = "snomed-ct";
 
@@ -29,9 +41,14 @@ public class SnomedCodeSystemProvider extends CodeSystemExternalProvider {
       return QueryResult.empty();
     }
 
+    // Route to the requested SNOMED edition branch (derived from the version URI). Without this the
+    // load falls to the default International branch, whose Accept-Language carries only the
+    // International languages — so edition-specific designations (e.g. Estonian) are never returned.
+    String branch = getBranch(params.getCodeSystemVersion());
+
     if (StringUtils.isNotEmpty(params.getDesignationCiEq())) {
       List<Concept> concepts = Arrays.stream(params.getDesignationCiEq().split(",")).filter(term -> term.length() >= 3).distinct().flatMap(term -> {
-        SnomedConceptSearchParams p = snomedMapper.toSnomedParams(params).setTerm(term).limit(1);
+        SnomedConceptSearchParams p = snomedMapper.toSnomedParams(params).setTerm(term).setBranch(branch).limit(1);
         return searchConcepts(p).stream().filter(c -> {
           List<Designation> designations = c.getVersions().getFirst().getDesignations();
           return designations != null && designations.stream().anyMatch(d -> d.getName() != null && params.getDesignationCiEq().equalsIgnoreCase(d.getName()));
@@ -40,15 +57,53 @@ public class SnomedCodeSystemProvider extends CodeSystemExternalProvider {
       return new QueryResult<>(concepts);
     }
 
-    SnomedConceptSearchParams snomedParams = snomedMapper.toSnomedParams(params);
+    SnomedConceptSearchParams snomedParams = snomedMapper.toSnomedParams(params).setBranch(branch);
     return new QueryResult<>(searchConcepts(snomedParams));
   }
 
   private List<Concept> searchConcepts(SnomedConceptSearchParams params) {
     if (CollectionUtils.isNotEmpty(params.getConceptIds()) && params.getTerm() == null) {
-      return snomedService.loadConcepts(params.getConceptIds()).stream().map(snomedMapper::toConcept).toList();
+      return snomedService.loadConcepts(params.getConceptIds(), params.getBranch()).stream().map(snomedMapper::toConcept).toList();
     }
     return snomedService.searchConcepts(params).stream().map(snomedMapper::toConcept).toList();
+  }
+
+  private String getBranch(String versionUri) {
+    if (StringUtils.isEmpty(versionUri)) {
+      return null;
+    }
+
+    String[] uri = versionUri.split("/");
+    if (uri.length < 5) {
+      return null;
+    }
+
+    String moduleId = uri[4];
+    String branchPath = loadModules().get(moduleId);
+    if (branchPath == null) {
+      return null;
+    }
+
+    String version = uri.length < 7 ? null : getBranchVersion(uri[6]);
+    return branchPath + (version == null ? "" : "/" + version);
+  }
+
+  private String getBranchVersion(String yyyyMMdd) {
+    DateTimeFormatter inputFormatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+    DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    try {
+      LocalDate date = LocalDate.parse(yyyyMMdd, inputFormatter);
+      return date.format(outputFormatter);
+    } catch (DateTimeParseException e) {
+      return null;
+    }
+  }
+
+  private Map<String, String> loadModules() {
+    ConceptQueryParams params = new ConceptQueryParams().setCodeSystem("snomed-module").limit(-1);
+    return codeSystemProvider.get().searchConcepts(params).getData().stream()
+        .filter(c -> c.getLastVersion().map(v -> v.getPropertyValue("moduleId").isPresent() && v.getPropertyValue("branchPath").isPresent()).orElse(false))
+        .collect(Collectors.toMap(c -> (String) c.getLastVersion().get().getPropertyValue("moduleId").get(), c -> (String) c.getLastVersion().get().getPropertyValue("branchPath").get()));
   }
 
   @Override

--- a/snomed/src/test/groovy/org/termx/snomed/ts/SnomedCodeSystemProviderSpec.groovy
+++ b/snomed/src/test/groovy/org/termx/snomed/ts/SnomedCodeSystemProviderSpec.groovy
@@ -1,0 +1,116 @@
+package org.termx.snomed.ts
+
+import com.kodality.commons.model.QueryResult
+import io.micronaut.context.BeanProvider
+import org.termx.core.ts.CodeSystemProvider
+import org.termx.ts.codesystem.CodeSystemEntityVersion
+import org.termx.ts.codesystem.Concept
+import org.termx.ts.codesystem.ConceptQueryParams
+import org.termx.ts.codesystem.EntityPropertyValue
+import org.termx.snomed.integration.SnomedService
+import spock.lang.Specification
+
+import java.time.OffsetDateTime
+
+class SnomedCodeSystemProviderSpec extends Specification {
+  SnomedMapper snomedMapper = new SnomedMapper()
+  SnomedService snomedService = Mock()
+  CodeSystemProvider codeSystemProvider = Mock()
+  BeanProvider<CodeSystemProvider> codeSystemProviderBean = Mock()
+
+  SnomedCodeSystemProvider provider
+
+  def setup() {
+    codeSystemProviderBean.get() >> codeSystemProvider
+    // snomed-module code system maps SNOMED moduleIds to Snowstorm branch paths.
+    codeSystemProvider.searchConcepts(_ as ConceptQueryParams) >> new QueryResult([
+        module("900000000000207008", "MAIN"),
+        module("11000181102", "MAIN/SNOMEDCT-EE")
+    ])
+    provider = new SnomedCodeSystemProvider(snomedMapper, snomedService, codeSystemProviderBean)
+  }
+
+  def "derives the edition branch from the version URI and loads the concept from it"() {
+    given:
+    def params = new ConceptQueryParams()
+        .setCodeSystem("snomed-ct")
+        .setCode("404684003")
+        .setCodeSystemVersion("http://snomed.info/sct/11000181102")
+
+    when:
+    provider.searchConcepts(params)
+
+    then: "the EE edition branch is passed to the load"
+    1 * snomedService.loadConcepts(["404684003"], "MAIN/SNOMEDCT-EE") >> []
+  }
+
+  def "appends the dated branch version when the version URI carries an effectiveTime"() {
+    given:
+    def params = new ConceptQueryParams()
+        .setCodeSystem("snomed-ct")
+        .setCode("404684003")
+        .setCodeSystemVersion("http://snomed.info/sct/11000181102/version/20260601")
+
+    when:
+    provider.searchConcepts(params)
+
+    then:
+    1 * snomedService.loadConcepts(["404684003"], "MAIN/SNOMEDCT-EE/2026-06-01") >> []
+  }
+
+  def "falls back to the default branch when the version is not a SNOMED edition URI"() {
+    given:
+    def params = new ConceptQueryParams()
+        .setCodeSystem("snomed-ct")
+        .setCode("404684003")
+        .setCodeSystemVersion(version)
+
+    when:
+    provider.searchConcepts(params)
+
+    then: "no branch is derived, so the load uses the default branch"
+    1 * snomedService.loadConcepts(["404684003"], null) >> []
+
+    where:
+    version << [null, "11000181102", "international-edition"]
+  }
+
+  def "falls back to the default branch when the module is unknown"() {
+    given:
+    def params = new ConceptQueryParams()
+        .setCodeSystem("snomed-ct")
+        .setCode("404684003")
+        .setCodeSystemVersion("http://snomed.info/sct/999999999999")
+
+    when:
+    provider.searchConcepts(params)
+
+    then:
+    1 * snomedService.loadConcepts(["404684003"], null) >> []
+  }
+
+  def "ignores non-SNOMED code systems"() {
+    given:
+    def params = new ConceptQueryParams().setCodeSystem("loinc").setCode("1234-5")
+
+    when:
+    def result = provider.searchConcepts(params)
+
+    then:
+    result.data.isEmpty()
+    0 * snomedService.loadConcepts(_, _)
+  }
+
+  private static Concept module(String moduleId, String branchPath) {
+    def version = new CodeSystemEntityVersion()
+        .setStatus("active")
+        .setCreated(OffsetDateTime.now())
+        .setPropertyValues([
+            new EntityPropertyValue().setEntityProperty("moduleId").setValue(moduleId),
+            new EntityPropertyValue().setEntityProperty("branchPath").setValue(branchPath)
+        ])
+    def concept = new Concept()
+    concept.setVersions([version])
+    return concept
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
@@ -31,6 +31,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -131,7 +132,9 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
       resp.addParameter(new ParametersParameter().setName("version").setValueString(csVersion.map(CodeSystemVersionReference::getVersion).orElse(null)));
     }
 
-    String preferredLanguage = StringUtils.firstNonBlank(displayLanguage, csVersion.map(CodeSystemVersionReference::getPreferredLanguage).orElse(null));
+    // displayLanguage may be a comma-separated list — prefer the FIRST requested language for the display.
+    String firstDisplayLanguage = StringUtils.isBlank(displayLanguage) ? null : displayLanguage.split(",")[0].trim();
+    String preferredLanguage = StringUtils.firstNonBlank(firstDisplayLanguage, csVersion.map(CodeSystemVersionReference::getPreferredLanguage).orElse(null));
     Designation display = ConceptUtil.getDisplay(designations, preferredLanguage, List.of());
     List<Designation> responseDesignations = designations.stream()
         .filter(d -> languageMatches(d.getLanguage(), displayLanguage))
@@ -178,8 +181,18 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
   }
 
   private static boolean languageMatches(String language, String displayLanguage) {
-    return StringUtils.isBlank(displayLanguage) || language != null &&
-        (language.equals(displayLanguage) || language.startsWith(displayLanguage + "-"));
+    // displayLanguage may be a comma-separated list (e.g. "en,et"); a designation matches when
+    // its language equals (or is a regional variant of) ANY of the requested languages.
+    if (StringUtils.isBlank(displayLanguage)) {
+      return true;
+    }
+    if (language == null) {
+      return false;
+    }
+    return Arrays.stream(displayLanguage.split(","))
+        .map(String::trim)
+        .filter(StringUtils::isNotBlank)
+        .anyMatch(dl -> language.equals(dl) || language.startsWith(dl + "-"));
   }
 
   private static ParametersParameter toParameter(String type, Object value, ConceptSnapshot snapshot, String language) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -61,7 +61,7 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     String versionNumber = parts[1];
     CodeSystemVersion csv = codeSystemVersionService.load(csId, versionNumber)
         .orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "Concept version not found"));
-    Parameters resp = run(csv.getCodeSystem(), csv.getId(), req);
+    Parameters resp = run(csv.getCodeSystem(), csv.getId(), null, req);
     return new ResourceContent(FhirMapper.toJson(resp), "json");
   }
 
@@ -98,15 +98,19 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
       csvp.setStatus(PublicationStatus.active);
       csvp.setLimit(1);
       csv = codeSystemVersionService.query(csvp).findFirst().orElse(null);
-      if (csv == null) {
-        return error("CodeSystem active version not found");
-      }
     }
 
-    return run(cs.getId(), csv == null ? null : csv.getId(), req);
+    // When the version doesn't resolve to a stored TermX version, pass it through as-is rather than
+    // failing. External providers — notably SNOMED, whose `version` is the edition URI
+    // (http://snomed.info/sct/<module>[/version/<date>]) and is never a stored TermX version — derive
+    // their branch from this string (see SnomedCodeSystemProvider), mirroring CodeSystem/$lookup. A
+    // genuinely bogus version then simply yields no concept ("code is invalid") downstream.
+    Long versionId = csv == null ? null : csv.getId();
+    String versionUri = csv == null ? version : null;
+    return run(cs.getId(), versionId, versionUri, req);
   }
 
-  private Parameters run(String csId, Long versionId, Parameters req) {
+  private Parameters run(String csId, Long versionId, String versionUri, Parameters req) {
     String code = req.findParameter("code").map(pp -> StringUtils.firstNonBlank(pp.getValueCode(), pp.getValueString()))
         .orElseThrow(() -> new FhirException(400, IssueType.INVALID, "code parameter required"));
     String display = req.findParameter("display").map(ParametersParameter::getValueString).orElse(null);
@@ -119,6 +123,7 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     cp.setCode(code);
     cp.setCodeSystem(csId);
     cp.setCodeSystemVersionId(versionId);
+    cp.setCodeSystemVersion(versionUri);
     cp.setIncludeSupplement(true);
     cp.setDisplayLanguage(displayLanguage);
     cp.setUseSupplement(extractUseSupplement(req));

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -4,12 +4,16 @@ import com.kodality.kefhir.core.api.resource.InstanceOperationDefinition;
 import com.kodality.kefhir.core.api.resource.TypeOperationDefinition;
 import com.kodality.kefhir.core.exception.FhirException;
 import com.kodality.kefhir.core.model.ResourceId;
+import com.kodality.commons.model.QueryResult;
 import com.kodality.kefhir.structure.api.ResourceContent;
 import org.termx.terminology.Privilege;
 import org.termx.core.auth.SessionStore;
 import org.termx.terminology.fhir.valueset.ValueSetFhirMapper;
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService;
+import org.termx.terminology.terminology.codesystem.concept.ConceptService;
+import org.termx.ts.codesystem.Concept;
+import org.termx.ts.codesystem.ConceptQueryParams;
 import org.termx.ts.codesystem.Designation;
 import org.termx.ts.valueset.ValueSetVersion;
 import org.termx.ts.valueset.ValueSetVersionConcept;
@@ -24,6 +28,8 @@ import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +43,7 @@ import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 public class ValueSetValidateCodeOperation implements InstanceOperationDefinition, TypeOperationDefinition {
   private final ValueSetVersionService valueSetVersionService;
   private final ValueSetVersionConceptService valueSetVersionConceptService;
+  private final ConceptService conceptService;
 
   public String getResourceType() {
     return ResourceType.ValueSet.name();
@@ -123,7 +130,8 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
 
     Parameters parameters = new Parameters();
     String conceptDisplay = findDisplay(concept, display, displayLanguage);
-    parameters.addParameter(new ParametersParameter("result").setValueBoolean(display == null || display.equals(conceptDisplay)));
+    boolean displayValid = display == null || isDisplayValid(collectDesignations(concept), display, displayLanguage);
+    parameters.addParameter(new ParametersParameter("result").setValueBoolean(displayValid));
     parameters.addParameter(new ParametersParameter("code").setValueCode(concept.getConcept().getCode()));
     parameters.addParameter(new ParametersParameter("system").setValueUri(concept.getConcept().getCodeSystemUri()));
     parameters.addParameter(new ParametersParameter("display").setValueString(conceptDisplay));
@@ -131,7 +139,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     if (conceptVersion != null) {
       parameters.addParameter(new ParametersParameter("version").setValueString(conceptVersion));
     }
-    if (display != null && !display.equals(conceptDisplay)) {
+    if (!displayValid) {
       parameters.addParameter(new ParametersParameter("message").setValueString(String.format("The display '%s' is incorrect", display)));
     }
     if (!concept.isActive()) {
@@ -140,6 +148,59 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       parameters.addParameter(new ParametersParameter("issues").setResource(outcome));
     }
     return parameters;
+  }
+
+  /**
+   * A provided display is valid when it matches the name of any of the concept's designations
+   * (the preferred display or any additional designation). When a {@code displayLanguage} is
+   * supplied (optionally comma-separated), the match is restricted to designations in one of those
+   * languages; otherwise a match in any language is accepted — mirroring FHIR $validate-code, where
+   * an unconstrained display is valid if it matches the code's designation in any language.
+   */
+  private boolean isDisplayValid(List<Designation> designations, String paramDisplay, String displayLanguage) {
+    if (paramDisplay == null) {
+      return true;
+    }
+    List<String> languages = StringUtils.isEmpty(displayLanguage) ? List.of() :
+        Arrays.stream(displayLanguage.split(",")).map(String::trim).filter(StringUtils::isNotEmpty).toList();
+    return designations.stream()
+        .filter(d -> d != null && paramDisplay.equals(d.getName()))
+        .anyMatch(d -> languages.isEmpty()
+            || (d.getLanguage() != null && languages.stream().anyMatch(l -> d.getLanguage().equals(l) || d.getLanguage().startsWith(l + "-"))));
+  }
+
+  /**
+   * Designations to validate the provided display against: the expansion's surfaced designations
+   * PLUS the concept's full designation set loaded straight from the code system. The expansion
+   * narrows {@code additionalDesignations} to the value set version's supported languages, but a
+   * display is valid if it matches ANY designation of the code (e.g. a Russian term carried by the
+   * concept while the value set only declares et/en) — so we must look past the narrowed expansion.
+   */
+  private List<Designation> collectDesignations(ValueSetVersionConcept c) {
+    List<Designation> all = new ArrayList<>();
+    if (c.getDisplay() != null) {
+      all.add(c.getDisplay());
+    }
+    if (CollectionUtils.isNotEmpty(c.getAdditionalDesignations())) {
+      all.addAll(c.getAdditionalDesignations());
+    }
+    String csId = c.getConcept() == null ? null : c.getConcept().getCodeSystem();
+    String code = c.getConcept() == null ? null : c.getConcept().getCode();
+    if (StringUtils.isNotEmpty(csId) && StringUtils.isNotEmpty(code)) {
+      ConceptQueryParams cp = new ConceptQueryParams();
+      cp.setCode(code);
+      cp.setCodeSystem(csId);
+      cp.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
+      QueryResult<Concept> queryResult = conceptService.query(cp);
+      Concept concept = queryResult == null ? null : queryResult.findFirst().orElse(null);
+      if (concept != null && CollectionUtils.isNotEmpty(concept.getVersions())) {
+        List<Designation> designations = concept.getVersions().getFirst().getDesignations();
+        if (designations != null) {
+          all.addAll(designations);
+        }
+      }
+    }
+    return all;
   }
 
   private String findSystem(Parameters req) {

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -18,8 +18,9 @@
     </customChange>
   </changeSet>
 
-  <changeSet id="languages" author="termx">
-    <validCheckSum>ANY</validCheckSum>
+  <!-- runOnChange: re-imports languages.json whenever it changes, so adding languages
+       (e.g. lt/cs/nl) to the value set propagates to already-migrated databases. -->
+  <changeSet id="languages" author="termx" runOnChange="true">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/languages.json"/>
     </customChange>

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemUcumOperationsTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemUcumOperationsTest.groovy
@@ -319,6 +319,60 @@ class CodeSystemUcumOperationsTest extends Specification {
     parametersWithProperty.parameter.find { it.name == "property" }.part.find { it.name == "code" }.valueString == "status"
   }
 
+  def "lookup honours a comma-separated displayLanguage (designations for each language, display from the first)"() {
+    given:
+    codeSystemService.query(_ as CodeSystemQueryParams) >> new QueryResult([
+        new CodeSystem().setId("ehr-feed-category").setUri("https://helex.org/fhir/CodeSystem/ehr-feed-category")])
+    conceptService.query(_ as ConceptQueryParams) >> new QueryResult([concept("allergy", [
+        designation("display", "en", "Allergy"),
+        designation("synonym", "et", "Allergia"),
+        designation("synonym", "ru", "Аллергия")
+    ])])
+
+    def request = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("system").setValueUri("https://helex.org/fhir/CodeSystem/ehr-feed-category"))
+        .addParameter(new Parameters.ParametersParameter("code").setValueCode("allergy"))
+        .addParameter(new Parameters.ParametersParameter("displayLanguage").setValueCode("en,et"))
+
+    when:
+    def response = lookupOperation.run(new ResourceContent(FhirMapper.toJson(request), "json"))
+    def parameters = FhirMapper.fromJson(response.value, Parameters)
+    def designationLanguages = parameters.parameter.findAll { it.name == "designation" }
+        .collect { it.part.find { p -> p.name == "language" }?.valueString }.toSet()
+
+    then:
+    // display resolves to the FIRST requested language (not the fallback Russian one)
+    parameters.findParameter("display").orElseThrow().valueString == "Allergy"
+    // designations are returned for the requested languages, and only those
+    designationLanguages.contains("et")
+    !designationLanguages.contains("ru")
+  }
+
+  def "lookup with a single displayLanguage returns only that language's designations"() {
+    given:
+    codeSystemService.query(_ as CodeSystemQueryParams) >> new QueryResult([
+        new CodeSystem().setId("ehr-feed-category").setUri("https://helex.org/fhir/CodeSystem/ehr-feed-category")])
+    conceptService.query(_ as ConceptQueryParams) >> new QueryResult([concept("allergy", [
+        designation("display", "en", "Allergy"),
+        designation("synonym", "et", "Allergia"),
+        designation("synonym", "ru", "Аллергия")
+    ])])
+
+    def request = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("system").setValueUri("https://helex.org/fhir/CodeSystem/ehr-feed-category"))
+        .addParameter(new Parameters.ParametersParameter("code").setValueCode("allergy"))
+        .addParameter(new Parameters.ParametersParameter("displayLanguage").setValueCode("et"))
+
+    when:
+    def response = lookupOperation.run(new ResourceContent(FhirMapper.toJson(request), "json"))
+    def parameters = FhirMapper.fromJson(response.value, Parameters)
+    def designationLanguages = parameters.parameter.findAll { it.name == "designation" }
+        .collect { it.part.find { p -> p.name == "language" }?.valueString }.toSet()
+
+    then:
+    designationLanguages == ["et"] as Set
+  }
+
   private static Concept concept(String code, List<Designation> designations, List<EntityPropertyValue> propertyValues = [], ConceptSnapshot snapshot = null) {
     return new Concept()
         .setCode(code)

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperationTest.groovy
@@ -1,0 +1,104 @@
+package org.termx.terminology.fhir.codesystem.operations
+
+import com.kodality.commons.model.QueryResult
+import com.kodality.kefhir.structure.api.ResourceContent
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService
+import org.termx.ts.codesystem.CodeSystem
+import org.termx.ts.codesystem.CodeSystemVersion
+import org.termx.ts.codesystem.Concept
+import spock.lang.Specification
+
+/**
+ * Behaviour tests for {@link CodeSystemValidateCodeOperation} version handling. A `version` that
+ * does not resolve to a stored TermX CodeSystemVersion (e.g. a SNOMED edition URI) must be passed
+ * through to the concept query as `codeSystemVersion` so external providers can derive their branch,
+ * rather than hard-failing with "CodeSystem active version not found".
+ */
+class CodeSystemValidateCodeOperationTest extends Specification {
+  def conceptService = Mock(ConceptService)
+  def codeSystemService = Mock(CodeSystemService)
+  def codeSystemVersionService = Mock(CodeSystemVersionService)
+
+  def operation = new CodeSystemValidateCodeOperation(conceptService, codeSystemService, codeSystemVersionService)
+
+  def setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+    codeSystemService.query(_) >> new QueryResult([new CodeSystem().setId("snomed-ct")])
+  }
+
+  def cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "passes a SNOMED edition URI version through as codeSystemVersion when it is not a stored version"() {
+    given:
+    codeSystemVersionService.query(_) >> new QueryResult([])
+
+    when:
+    def resp = parse(invoke([url: "http://snomed.info/sct", version: "http://snomed.info/sct/11000181102", code: "404684003"]))
+
+    then: "the version URI reaches the concept query (so the SNOMED provider can branch); no internal version id"
+    1 * conceptService.query({
+      it.codeSystem == "snomed-ct" &&
+          it.codeSystemVersion == "http://snomed.info/sct/11000181102" &&
+          it.codeSystemVersionId == null &&
+          it.code == "404684003"
+    }) >> new QueryResult([new Concept().setCode("404684003")])
+    bool(resp, "result")
+  }
+
+  def "validates without a version"() {
+    when:
+    def resp = parse(invoke([url: "http://snomed.info/sct", code: "404684003"]))
+
+    then:
+    0 * codeSystemVersionService.query(_)
+    1 * conceptService.query({ it.codeSystemVersion == null && it.codeSystemVersionId == null }) >> new QueryResult([new Concept()])
+    bool(resp, "result")
+  }
+
+  def "uses the internal version id when the version resolves to a stored TermX version"() {
+    given:
+    codeSystemVersionService.query(_) >> new QueryResult([new CodeSystemVersion().setId(42L)])
+
+    when:
+    def resp = parse(invoke([url: "http://snomed.info/sct", version: "1.0.0", code: "404684003"]))
+
+    then: "the stored version id is used, and the raw version string is not forwarded"
+    1 * conceptService.query({ it.codeSystemVersionId == 42L && it.codeSystemVersion == null }) >> new QueryResult([new Concept()])
+    bool(resp, "result")
+  }
+
+  def "returns invalid code when the concept is not found"() {
+    given:
+    codeSystemVersionService.query(_) >> new QueryResult([])
+
+    when:
+    def resp = parse(invoke([url: "http://snomed.info/sct", version: "http://snomed.info/sct/11000181102", code: "000"]))
+
+    then:
+    1 * conceptService.query(_) >> new QueryResult([])
+    !bool(resp, "result")
+  }
+
+  private ResourceContent invoke(Map<String, String> params) {
+    Parameters req = new Parameters()
+    params.each { k, v -> req.addParameter(new ParametersParameter(k).setValueString(v)) }
+    return operation.run(new ResourceContent(FhirMapper.toJson(req), "json"))
+  }
+
+  private static Parameters parse(ResourceContent rc) {
+    return FhirMapper.fromJson(rc.getValue(), Parameters)
+  }
+
+  private static boolean bool(Parameters resp, String name) {
+    return resp.findParameter(name).map(p -> p.getValueBoolean()).orElse(false)
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
@@ -1,0 +1,161 @@
+package org.termx.terminology.fhir.valueset.operations
+
+import com.kodality.commons.model.QueryResult
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.codesystem.CodeSystemEntityVersion
+import org.termx.ts.codesystem.Concept
+import org.termx.ts.codesystem.Designation
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionConcept
+import org.termx.ts.valueset.ValueSetVersionConcept.ValueSetVersionConceptValue
+import spock.lang.Specification
+
+/**
+ * Behaviour tests for {@link ValueSetValidateCodeOperation} display validation: a provided display
+ * is valid when it matches any of the concept's designations (preferred display or an additional
+ * designation), in any language when no displayLanguage is constrained.
+ */
+class ValueSetValidateCodeOperationTest extends Specification {
+  def valueSetVersionService = Mock(ValueSetVersionService)
+  def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
+  def conceptService = Mock(ConceptService)
+
+  def operation = new ValueSetValidateCodeOperation(valueSetVersionService, valueSetVersionConceptService, conceptService)
+
+  ValueSetVersion vsVersion = new ValueSetVersion().setValueSet("ehr-feed-category").setVersion("1.0.0")
+
+  def setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+  }
+
+  def cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "accepts a display that matches a designation in a different language than the preferred display"() {
+    given: "concept whose preferred display is Estonian 'Allergia' and an additional English designation 'Allergy'"
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+
+    when: "validating display 'Allergy' without a displayLanguage"
+    def resp = operation.run(vsVersion, req("allergy", "Allergy", null))
+
+    then:
+    bool(resp, "result")
+    !resp.findParameter("message").isPresent()
+  }
+
+  def "accepts the preferred display itself"() {
+    given:
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+
+    when:
+    def resp = operation.run(vsVersion, req("allergy", "Allergia", null))
+
+    then:
+    bool(resp, "result")
+  }
+
+  def "rejects a display that matches no designation"() {
+    given:
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+
+    when:
+    def resp = operation.run(vsVersion, req("allergy", "Nonsense", null))
+
+    then:
+    !bool(resp, "result")
+    resp.findParameter("message").get().getValueString() == "The display 'Nonsense' is incorrect"
+  }
+
+  def "restricts the match to the requested displayLanguage"() {
+    given: "'Allergy' is an English designation"
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+
+    when: "validating display 'Allergy' but constrained to Estonian"
+    def resp = operation.run(vsVersion, req("allergy", "Allergy", "et"))
+
+    then: "no Estonian designation reads 'Allergy', so it is invalid"
+    !bool(resp, "result")
+  }
+
+  def "accepts an English display when displayLanguage allows English"() {
+    given:
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+
+    when:
+    def resp = operation.run(vsVersion, req("allergy", "Allergy", "et,en"))
+
+    then:
+    bool(resp, "result")
+  }
+
+  def "a null display is always valid"() {
+    given:
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+
+    when:
+    def resp = operation.run(vsVersion, req("allergy", null, null))
+
+    then:
+    bool(resp, "result")
+  }
+
+  def "accepts a display that matches a code system designation not surfaced in the (language-narrowed) expansion"() {
+    given: "the expansion only carries et/en designations (value set supports et, en)"
+    valueSetVersionConceptService.expand(vsVersion, _) >> [concept()]
+    and: "but the concept in the code system also has a Russian designation"
+    conceptService.query(_) >> new QueryResult([conceptWithDesignations([
+        new Designation().setName("Allergia").setLanguage("et").setDesignationType("display"),
+        new Designation().setName("Allergy").setLanguage("en").setDesignationType("display"),
+        new Designation().setName("Аллергия").setLanguage("ru").setDesignationType("display")
+    ])])
+
+    when: "validating the Russian display without a displayLanguage"
+    def resp = operation.run(vsVersion, req("allergy", "Аллергия", null))
+
+    then:
+    bool(resp, "result")
+    !resp.findParameter("message").isPresent()
+  }
+
+  private static ValueSetVersionConcept concept() {
+    return new ValueSetVersionConcept()
+        .setActive(true)
+        .setConcept(new ValueSetVersionConceptValue()
+            .setCode("allergy")
+            .setCodeSystem("ehr-feed-category")
+            .setCodeSystemUri("https://helex.org/fhir/CodeSystem/ehr-feed-category"))
+        .setDisplay(new Designation().setName("Allergia").setLanguage("et").setDesignationType("display"))
+        .setAdditionalDesignations([
+            new Designation().setName("Allergy").setLanguage("en").setDesignationType("display")
+        ])
+  }
+
+  private static Concept conceptWithDesignations(List<Designation> designations) {
+    Concept c = new Concept()
+    c.setVersions([new CodeSystemEntityVersion().setDesignations(designations)])
+    return c
+  }
+
+  private static Parameters req(String code, String display, String displayLanguage) {
+    Parameters p = new Parameters()
+    p.addParameter(new ParametersParameter("code").setValueCode(code))
+    if (display != null) {
+      p.addParameter(new ParametersParameter("display").setValueString(display))
+    }
+    if (displayLanguage != null) {
+      p.addParameter(new ParametersParameter("displayLanguage").setValueCode(displayLanguage))
+    }
+    return p
+  }
+
+  private static boolean bool(Parameters resp, String name) {
+    return resp.findParameter(name).map(p -> p.getValueBoolean()).orElse(false)
+  }
+}

--- a/termx-app/build.gradle.kts
+++ b/termx-app/build.gradle.kts
@@ -127,8 +127,17 @@ tasks.named<JavaExec>("run") {
     if (project.hasProperty("debug")) {
         jvmArgs = listOf("-Xdebug", "-Xrunjdwp:transport=dt_socket,address=${project.property("debug")},server=y,suspend=n")
     }
-    if (project.hasProperty("dev")) {
-        jvmArgs = (jvmArgs ?: listOf()) + listOf("-Dauth.dev.allowed=true", "-Dmicronaut.environments=dev,local")
+    // Environments: pass the FULL comma-separated list with -Penv=dev,local (preferred).
+    // `-Pdev` is kept as a legacy shorthand for `-Penv=dev,local`.
+    // Dev auth (the `yupi` token) is enabled automatically when `dev` is in the list.
+    val envList = ((project.findProperty("env") as String?)?.takeIf { it.isNotBlank() }
+        ?: if (project.hasProperty("dev")) "dev,local" else null)
+        ?.split(",")?.map { it.trim() }?.filter { it.isNotEmpty() }
+    if (!envList.isNullOrEmpty()) {
+        jvmArgs = (jvmArgs ?: listOf()) + listOf("-Dmicronaut.environments=${envList.joinToString(",")}")
+        if (envList.contains("dev")) {
+            jvmArgs = (jvmArgs ?: listOf()) + listOf("-Dauth.dev.allowed=true")
+        }
     }
     // QA / migration testing: override the yupi default session's privilege set.
     // Example: ./gradlew :termx-app:run -Pdev -PyupiPrivileges='*.*.view'


### PR DESCRIPTION
## Summary

Makes the CodeSystem/ValueSet FHIR operations behave correctly for SNOMED editions and multi-language designations, plus the SNOMED import log-capture work.

### Terminology / FHIR operations
- **SNOMED `$lookup` designations** — `SnomedCodeSystemProvider` now derives the Snowstorm branch from the version URI (`http://snomed.info/sct/<module>[/version/<date>]`) via the module→branch map and loads the concept from that branch, so edition-specific designations (e.g. Estonian) are returned. Uses `BeanProvider<CodeSystemProvider>` to break the DI cycle.
- **CodeSystem `$validate-code`** — a `version` that isn't a stored TermX version (e.g. a SNOMED edition URI) is passed through as `codeSystemVersion` instead of failing with *"CodeSystem active version not found"*, mirroring `$lookup`.
- **CodeSystem `$lookup`** — honours a comma-separated `displayLanguage` and picks the returned display from the first requested language.
- **ValueSet `$validate-code`** — a provided `display` is valid if it matches **any** of the code's designations (in any language when none is requested), including designations not surfaced in the language-narrowed expansion.
- **`languages` value set** — adds `cs`/`lt`/`nl`/`fi` via Liquibase (`runOnChange`).

### SNOMED import
- Logs the Snowstorm import job lifecycle and captures the Snowstorm log tail back into TermX.
- A vanished import job (404) is marked expired instead of being polled forever.

### Build / scripts
- `run-backend.sh` takes a full environment list; openjdk 25; `snomed` module test dependencies (byte-buddy/objenesis).

### Tests
- New: `SnomedCodeSystemProviderSpec`, `CodeSystemValidateCodeOperationTest`, `ValueSetValidateCodeOperationTest`; extended `CodeSystemUcumOperationsTest` for the displayLanguage fix.