### PR TITLE
SNOMED: map Czech/Belgian/Finnish/Swedish edition modules

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/ts/SnomedCodeSystemProvider.java
+++ b/snomed/src/main/java/org/termx/snomed/ts/SnomedCodeSystemProvider.java
@@ -63,6 +63,16 @@ public class SnomedCodeSystemProvider extends CodeSystemExternalProvider {
 
   private List<Concept> searchConcepts(SnomedConceptSearchParams params) {
     if (CollectionUtils.isNotEmpty(params.getConceptIds()) && params.getTerm() == null) {
+      // TODO: this loads concepts via Snowstorm's /concepts SEARCH endpoint, which only returns the
+      // language-resolved pt + fsn (SnomedMapper.toConceptVersion then maps just those two). So a
+      // CodeSystem/$lookup with properties=designation returns the preferred term + FSN, NOT every
+      // designation of the concept (e.g. for a SNOMED edition it yields the edition PT but misses the
+      // edition's additional synonyms in the same language).
+      // If full designations are ever required here: fetch them per concept from the browser endpoint
+      // and let SnomedMapper.toConceptVersion map snomedConcept.getDescriptions() (it already prefers
+      // descriptions when present). SnomedService.loadDescriptions(branch, conceptIds) +
+      // SnowstormClient already do this for the value-set expand path (see SnomedValueSetExpandProvider
+      // .getDescriptions / findDesignations) — reuse that to populate descriptions before mapping.
       return snomedService.loadConcepts(params.getConceptIds(), params.getBranch()).stream().map(snomedMapper::toConcept).toList();
     }
     return snomedService.searchConcepts(params).stream().map(snomedMapper::toConcept).toList();

--- a/snomed/src/main/resources/snomed/changelog/data/codesystem/changelog-data-codesystem.xml
+++ b/snomed/src/main/resources/snomed/changelog/data/codesystem/changelog-data-codesystem.xml
@@ -11,6 +11,17 @@
     </customChange>
   </changeSet>
 
+  <!-- Re-import after adding national edition modules (bel/cze/fin/swe). The FHIR-import custom
+       change checksums the changeset definition (file path), not the file content, so editing
+       snomed-module.json does not re-trigger the original changeset — a fresh id is needed.
+       CodeSystemFhirImport is idempotent (upsert by code), so re-importing the full file is safe. -->
+  <changeSet id="snomed-module-national-editions" author="termx">
+    <validCheckSum>ANY</validCheckSum>
+    <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">
+      <param name="files" value="snomed/changelog/data/codesystem/snomed-module.json"/>
+    </customChange>
+  </changeSet>
+
   <changeSet id="concept-status" author="termx">
     <validCheckSum>ANY</validCheckSum>
     <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">

--- a/snomed/src/main/resources/snomed/changelog/data/codesystem/snomed-module.json
+++ b/snomed/src/main/resources/snomed/changelog/data/codesystem/snomed-module.json
@@ -115,6 +115,106 @@
           "valueString": "21000092105"
         }
       ]
+    },
+    {
+      "code": "cze",
+      "display": "Czech module",
+      "property": [
+        {
+          "code": "branchPath",
+          "valueString": "MAIN/SNOMEDCT-CZ"
+        },
+        {
+          "code": "language",
+          "valueCoding": {
+            "system": "v3-ietf3066",
+            "code": "cs"
+          }
+        },
+        {
+          "code": "moduleId",
+          "valueString": "11000279109"
+        },
+        {
+          "code": "refsetId",
+          "valueString": "41000279108"
+        }
+      ]
+    },
+    {
+      "code": "bel",
+      "display": "Belgian module",
+      "property": [
+        {
+          "code": "branchPath",
+          "valueString": "MAIN/SNOMEDCT-BE"
+        },
+        {
+          "code": "language",
+          "valueCoding": {
+            "system": "v3-ietf3066",
+            "code": "nl"
+          }
+        },
+        {
+          "code": "moduleId",
+          "valueString": "11000172109"
+        },
+        {
+          "code": "refsetId",
+          "valueString": "31000172101"
+        }
+      ]
+    },
+    {
+      "code": "fin",
+      "display": "Finnish module",
+      "property": [
+        {
+          "code": "branchPath",
+          "valueString": "MAIN/SNOMEDCT-FI"
+        },
+        {
+          "code": "language",
+          "valueCoding": {
+            "system": "v3-ietf3066",
+            "code": "fi"
+          }
+        },
+        {
+          "code": "moduleId",
+          "valueString": "11000229106"
+        },
+        {
+          "code": "refsetId",
+          "valueString": "41000229102"
+        }
+      ]
+    },
+    {
+      "code": "swe",
+      "display": "Swedish module",
+      "property": [
+        {
+          "code": "branchPath",
+          "valueString": "MAIN/SNOMEDCT-SE"
+        },
+        {
+          "code": "language",
+          "valueCoding": {
+            "system": "v3-ietf3066",
+            "code": "sv"
+          }
+        },
+        {
+          "code": "moduleId",
+          "valueString": "45991000052106"
+        },
+        {
+          "code": "refsetId",
+          "valueString": "46011000052107"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds national edition module mappings to the `snomed-module` seed so SNOMED concept lookups route to the correct Snowstorm branch and language. Without a mapping, the version URI's module resolves to no branch and falls back to International (English only) — e.g. a Czech `$lookup` returned the English `Carbaryl` instead of `karbaryl` (cs).

### Changes
- **`snomed-module.json`** — add:
  | code | module | branch | lang | source |
  |------|--------|--------|------|--------|
  | `cze` | 11000279109 | MAIN/SNOMEDCT-CZ | cs | verified on Snowstorm |
  | `bel` | 11000172109 | MAIN/SNOMEDCT-BE | nl | verified on Snowstorm |
  | `fin` | 11000229106 | MAIN/SNOMEDCT-FI | fi | standard public id |
  | `swe` | 45991000052106 | MAIN/SNOMEDCT-SE | sv | standard public id |
- **changelog** — `snomed-module-national-editions` changeset re-imports the seed (the FHIR-import custom change checksums the file path, not contents, so editing the JSON doesn't re-trigger the original changeset; the import is idempotent).
- **`SnomedCodeSystemProvider`** — TODO documenting that `$lookup` loads via Snowstorm's search endpoint (pt + fsn only) and how to fetch full designations if ever needed.

### Notes
- FI/SE aren't installed in our Snowstorm, so their ids couldn't be verified live; module ids + branch convention are the standard public ones. The `refsetId` only affects the translation feature, not lookups.
- Belgian is bilingual — `nl` set as primary (refset `31000172101`); French refset is `21000172104`.
- Malta has no SNOMED CT national edition (only the geographic concept), so it was not added.
- Applies on backend restart (Liquibase runs the new changeset).