### PR TITLE
ValueSet expansion: snapshot reuse + display languages, and language extensions across CS/VS/MS

### DIFF
--- a/docs/features/value-set-expand.md
+++ b/docs/features/value-set-expand.md
@@ -230,7 +230,58 @@ Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/op
 - `expand with url + valueSetVersion param pins the include version`
 - `expand with url matching neither stored ValueSet nor stored CodeSystem returns 404`
 
-## 8. Limitations & known gaps
+## 8. Snapshot reuse & display-language rendering
+
+**Problem this solves.** Opening a value set in the FHIR view (e.g. the classifier's
+`/fhir/ValueSet/<id>--<version>`, which calls `$expand`, typically with a `displayLanguage`)
+used to **recompute and overwrite the stored snapshot on every read** — even for `active` and
+`retired` versions. Symptoms: the "concept snapshot" date in the author view kept jumping to the
+current date, frozen (published/retired) expansions were silently replaced, and every
+language-qualified read re-ran the full expansion.
+
+Root cause: `ValueSetVersionConceptService.expand(...)` reused the stored snapshot **only** when the
+version was `active` **and** no `displayLanguage`/`includeDesignations` was requested; otherwise it
+recomputed **and** persisted (`createSnapshot`, which stamps `createdAt = now`). So retired versions
+and any language-qualified read overwrote the canonical snapshot.
+
+**Design (implemented in `ValueSetVersionConceptService`).**
+
+- **(a) Reuse for any published version.** `draft` is the only status that is (re)expanded on demand
+  while authoring. `active` **and** `retired` are frozen and served from the stored snapshot (when
+  current — see `isSnapshotCurrent`, which revalidates dynamic-rule dependencies).
+- **(b) Foreign display language ⇒ designations only.** When a published version is asked for a
+  `displayLanguage` that is **not** among the version's `supportedLanguages`, only the *display
+  designations* for that language are loaded (`loadDisplayDesignations`, an entity-version lookup —
+  **no** rule re-expansion), overlaid onto the snapshot's concepts. The concepts and the stored
+  snapshot are left unchanged.
+- **(c) Only writers persist.** A snapshot is (over)written **only** when the caller holds
+  `ValueSet.write` or `ValueSet.maintain` on that value set (`canPersistSnapshot`). A public /
+  read-only FHIR `$expand` therefore never mutates the stored snapshot.
+- **(d) Snapshot carries all VS languages.** `decorate` populates each concept's
+  `additionalDesignations` with the designations for every language in `supportedLanguages`, so the
+  canonical snapshot is language-complete.
+- **(e) Resources advertise their languages (round-trip).** The FHIR resource carries one repeated
+  extension per language the version declares (`version.supportedLanguages`):
+  `{url: "https://termx.org/fhir/StructureDefinition/<resource>-language", valueCode: <lang>}` for
+  `valueset` / `codesystem` / `conceptmap` — added in each `*FhirMapper.toFhir` (ValueSet on both
+  read and `$expand`). Preferred over `expansion.parameter`, which is meant to echo *applied*
+  parameters. **Import reads it back**: `*FhirMapper.fromFhir*` unions these extension `valueCode`s
+  into the imported version's `supportedLanguages` (via `BaseFhirMapper.fromFhirLanguageExtensions`),
+  so export→import round-trips. (MapSet gained a `supportedLanguages` column —
+  `map_set_version.supported_languages` — to store this.)
+- **(f) Native display language ⇒ no DB.** When the requested `displayLanguage` **is** one of the
+  version's `supportedLanguages`, the display is re-picked from the designations already in the
+  snapshot (`ConceptUtil.getDisplay`) — **no DB query and no snapshot rewrite**.
+
+**Net effect.** The FHIR path now matches the author view: published versions are read-only with
+respect to their snapshot; only a `draft` (saved by a user with write/maintain) refreshes it. The
+snapshot date no longer churns on reads.
+
+**Follow-up (not yet done).** For `draft` versions a language-qualified `$expand` still recomputes
+the full expansion rather than reusing concepts + loading designations only; the (b) optimisation
+could be extended to draft once authoring semantics are confirmed.
+
+## 9. Limitations & known gaps
 
 - **SNOMED "all concepts" materialises the full result** before client-side paging. `SnomedValueSetExpandProvider.filterConcepts()` uses `SnomedConceptSearchParams.setAll(true)`, which is fine for hundreds of concepts but expensive for the international edition (~350k). The fix is to push `offset`/`count` down into `SnomedService.searchConcepts`; left as a separate optimisation.
 - **`filter` on the SNOMED path is client-side**. Snowstorm's ECL doesn't carry a free-text filter parameter, so TermX applies the substring match after the provider returns. Functionally correct, less efficient than letting Snowstorm filter.

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -60,6 +60,8 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
   private static final Set<String> IMPLICIT_PROPERTY_DEFINITIONS = Set.of(DISPLAY, DEFINITION);
   private static final String PROPERTY_VALUE_SET_EXTENSION_URL = "http://hl7.org/fhir/StructureDefinition/codesystem-property-valueset";
   private static final String PROPERTY_CODE_SYSTEM_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/codesystem-property-codesystem";
+  // One repeated extension per language the code system version provides designations in.
+  private static final String CS_LANGUAGE_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/codesystem-language";
 
   public CodeSystemFhirMapper(ConceptService conceptService,
                               CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
@@ -104,6 +106,8 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     if (StringUtils.isNotEmpty(versionDescription)) {
       fhirCodeSystem.addExtension(toFhirVersionDescriptionExtension(versionDescription));
     }
+    Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of())
+        .forEach(language -> fhirCodeSystem.addExtension(new Extension(CS_LANGUAGE_EXTENSION_URL).setValueCode(language)));
     fhirCodeSystem.setPurpose(toFhirName(codeSystem.getPurpose(), version.getPreferredLanguage()));
     fhirCodeSystem.setTopic(toFhirTopic(codeSystem.getTopic()));
     fhirCodeSystem.setUseContext(toFhirUseContext(codeSystem.getUseContext()));
@@ -548,8 +552,12 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
         .map(CodeSystemConcept::getDesignation)
         .filter(Objects::nonNull).flatMap(List::stream)
         .map(CodeSystemConceptDesignation::getLanguage);
-    version.setSupportedLanguages(Stream.concat(
-          supportedLanguages,
+    // Declared languages come from the codesystem-language extensions; union them with the languages
+    // observed on designations and the preferred language so nothing is lost on round-trip.
+    Stream<String> declaredLanguages = fromFhirLanguageExtensions(fhirCodeSystem.getExtension(), CS_LANGUAGE_EXTENSION_URL).stream();
+    version.setSupportedLanguages(Stream.concat(Stream.concat(
+          declaredLanguages,
+          supportedLanguages),
           Stream.of(version.getPreferredLanguage()))
         .filter(Objects::nonNull)
         .distinct().toList());

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
@@ -59,6 +59,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import com.kodality.zmei.fhir.Extension;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -80,6 +81,9 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
   private final ValueSetVersionService valueSetVersionService;
   private final ValueSetVersionConceptService valueSetVersionConceptService;
   private final MapSetRelatedArtifactService relatedArtifactService;
+
+  // One repeated extension per language the map set version declares.
+  private static final String CM_LANGUAGE_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/conceptmap-language";
 
   public ConceptMapFhirMapper(ConceptService conceptService,
                               CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
@@ -127,6 +131,8 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
     if (StringUtils.isNotEmpty(versionDescription)) {
       fhirConceptMap.addExtension(toFhirVersionDescriptionExtension(versionDescription));
     }
+    Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of())
+        .forEach(language -> fhirConceptMap.addExtension(new Extension(CM_LANGUAGE_EXTENSION_URL).setValueCode(language)));
     fhirConceptMap.setPurpose(toFhirName(mapSet.getPurpose(), version.getPreferredLanguage()));
     fhirConceptMap.setTopic(toFhirTopic(mapSet.getTopic()));
     fhirConceptMap.setUseContext(toFhirUseContext(mapSet.getUseContext()));
@@ -376,6 +382,11 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
     version.setScope(fromFhirScope(conceptMap));
     version.setAssociations(fromFhirAssociations(conceptMap));
     version.setIdentifiers(fromFhirVersionIdentifiers(conceptMap.getIdentifier()));
+    // Declared languages come from the conceptmap-language extensions; union with the preferred language.
+    version.setSupportedLanguages(Stream.concat(
+            fromFhirLanguageExtensions(conceptMap.getExtension(), CM_LANGUAGE_EXTENSION_URL).stream(),
+            Stream.ofNullable(version.getPreferredLanguage()))
+        .filter(Objects::nonNull).distinct().toList());
     return version;
   }
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 
 import static java.util.stream.Collectors.toList;
@@ -88,6 +89,9 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   private final ValueSetRelatedArtifactService relatedArtifactService;
   private static final String concept_definition = "http://hl7.org/fhir/StructureDefinition/valueset-concept-definition";
   private static final String concept_order = "http://hl7.org/fhir/StructureDefinition/valueset-conceptOrder";
+  // One repeated extension per language the value set version provides designations in. Present on
+  // both the plain read and $expand so clients can discover available languages without expanding.
+  private static final String vs_language = "https://termx.org/fhir/StructureDefinition/valueset-language";
 
   public ValueSetFhirMapper(ConceptService conceptService,
                             CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
@@ -166,6 +170,8 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     fhirValueSet.setExperimental(valueSet.getExperimental() != null && valueSet.getExperimental());
     Optional.ofNullable(valueSet.getSourceReference()).ifPresent(ref -> fhirValueSet.addExtension(toFhirSourceReferenceExtension("http://hl7.org/fhir/StructureDefinition/valueset-sourceReference", ref)));
     Optional.ofNullable(valueSet.getReplaces()).flatMap(id -> Optional.ofNullable(valueSetService.load(id)).map(ValueSet::getUri)).ifPresent(uri -> fhirValueSet.addExtension(toFhirReplacesExtension(uri)));
+    Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of())
+        .forEach(language -> fhirValueSet.addExtension(new Extension(vs_language).setValueCode(language)));
     fhirValueSet.setDate(toFhirOffsetDateTime(provenances));
     fhirValueSet.setLastReviewDate(toFhirDate(provenances, "reviewed"));
     fhirValueSet.setApprovalDate(toFhirDate(provenances, "approved"));
@@ -323,6 +329,8 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
 
   public com.kodality.zmei.fhir.resource.terminology.ValueSet toFhir(ValueSet valueSet, ValueSetVersion version, List<Provenance> provenances, ValueSetSnapshot snapshot, Parameters param) {
     com.kodality.zmei.fhir.resource.terminology.ValueSet fhirValueSet = toFhir(valueSet, version, provenances);
+    // The set of languages carried by the expansion is advertised as repeated `valueset-language`
+    // extensions on the resource (added in the base toFhir from version.supportedLanguages).
     fhirValueSet.setExpansion(toFhirExpansion(snapshot, fhirValueSet.getCompose().getProperty(), param));
     return fhirValueSet;
   }
@@ -634,6 +642,11 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     if (description != null) {
       version.setDescription(new LocalizedName(Map.of(Optional.ofNullable(version.getPreferredLanguage()).orElse(Language.en), description)));
     }
+    // Declared languages come from the valueset-language extensions; union with the preferred language.
+    version.setSupportedLanguages(Stream.concat(
+            fromFhirLanguageExtensions(valueSet.getExtension(), vs_language).stream(),
+            Stream.ofNullable(version.getPreferredLanguage()))
+        .filter(Objects::nonNull).distinct().toList());
     return version;
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/version/MapSetVersionRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/version/MapSetVersionRepository.java
@@ -3,6 +3,7 @@ package org.termx.terminology.terminology.mapset.version;
 import com.kodality.commons.db.bean.PgBeanProcessor;
 import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
+import com.kodality.commons.db.util.PgUtil;
 import com.kodality.commons.db.sql.SqlBuilder;
 import com.kodality.commons.model.Identifier;
 import com.kodality.commons.model.QueryResult;
@@ -15,6 +16,7 @@ import jakarta.inject.Singleton;
 @Singleton
 public class MapSetVersionRepository extends BaseRepository {
   private final PgBeanProcessor bp = new PgBeanProcessor(MapSetVersion.class, bp -> {
+    bp.addColumnProcessor("supported_languages", PgBeanProcessor.fromArray());
     bp.addColumnProcessor("description", PgBeanProcessor.fromJson());
     bp.addColumnProcessor("scope", PgBeanProcessor.fromJson());
     bp.addColumnProcessor("statistics", PgBeanProcessor.fromJson());
@@ -43,6 +45,7 @@ public class MapSetVersionRepository extends BaseRepository {
     ssb.property("version", version.getVersion());
     ssb.property("status", version.getStatus());
     ssb.property("preferred_language", version.getPreferredLanguage());
+    ssb.property("supported_languages", "?::text[]", PgUtil.array(version.getSupportedLanguages()));
     ssb.jsonProperty("description", version.getDescription());
     ssb.property("algorithm", version.getAlgorithm());
     ssb.property("release_date", version.getReleaseDate());

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -1,6 +1,8 @@
 package org.termx.terminology.terminology.valueset.expansion;
 
 import com.kodality.commons.util.DateUtil;
+import org.termx.core.auth.SessionStore;
+import org.termx.terminology.Privilege;
 import org.termx.terminology.terminology.codesystem.concept.ConceptUtil;
 import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService;
 import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropertyService;
@@ -19,6 +21,7 @@ import org.termx.ts.codesystem.EntityPropertyType;
 import org.termx.ts.codesystem.EntityPropertyValue;
 import org.termx.ts.property.PropertyReference;
 import org.termx.ts.valueset.ValueSetSnapshot;
+import org.termx.ts.valueset.ValueSetVersionReference;
 import org.termx.ts.valueset.ValueSetSnapshotDependency;
 import org.termx.ts.valueset.ValueSetVersion;
 import org.termx.ts.valueset.ValueSetVersionConcept;
@@ -32,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,19 +78,126 @@ public class ValueSetVersionConceptService {
     if (version == null) {
       return null;
     }
+    // "Default rendering" = no caller-specific language/designations. Only this view is stored as the
+    // canonical snapshot; a request for a specific displayLanguage is a read-only view that must
+    // never overwrite the stored snapshot.
+    boolean draft = PublicationStatus.draft.equals(version.getStatus());
+    boolean defaultView = !includeDesignations && StringUtils.isEmpty(preferredLanguage);
     ValueSetSnapshot snapshot = version.getSnapshot();
-    if (!includeDesignations &&
-        StringUtils.isEmpty(preferredLanguage) &&
-        PublicationStatus.active.equals(version.getStatus()) &&
-        snapshot != null && snapshot.getExpansion() != null &&
-        isSnapshotCurrent(version, snapshot)) {
-      return snapshot;
-    }
-    
-    List<ValueSetVersionConcept> expansion = expand(version, preferredLanguage, includeDesignations);
-    snapshot = valueSetSnapshotService.createSnapshot(vs, version.getId(), expansion, resolveDependencies(version));
+    boolean snapshotUsable = snapshot != null && snapshot.getExpansion() != null && isSnapshotCurrent(version, snapshot);
 
-    return snapshot;
+    // (a) Published versions (active or retired) are frozen — serve from the stored snapshot; only a
+    // draft is (re)expanded on demand while authoring.
+    if (!draft && snapshotUsable) {
+      if (defaultView) {
+        return snapshot;
+      }
+      // (b)/(f) Render the requested displayLanguage WITHOUT recomputing concepts or rewriting the snapshot.
+      return renderLanguage(version, snapshot, preferredLanguage);
+    }
+
+    List<ValueSetVersionConcept> expansion = expand(version, preferredLanguage, includeDesignations);
+
+    // (c) Persist (overwrite) the canonical snapshot only for the default rendering AND only when the
+    // caller may write the value set. A public / read-only FHIR $expand never overwrites the stored
+    // snapshot — previously every $expand with a displayLanguage, or against a retired version,
+    // recreated it, replacing the frozen content and bumping its date on each read.
+    if (defaultView && canPersistSnapshot(vs)) {
+      return valueSetSnapshotService.createSnapshot(vs, version.getId(), expansion, resolveDependencies(version));
+    }
+    return transientSnapshot(vs, version.getId(), expansion);
+  }
+
+  /**
+   * Render a stored snapshot for a specific displayLanguage without recomputing the concepts or
+   * rewriting the snapshot. (f) When the language is one the value set version declares
+   * ({@code supportedLanguages}), the snapshot already carries its designations, so the display is
+   * re-picked from the snapshot with no DB access. (b) Otherwise only the display designations for
+   * that language are loaded (no rule re-expansion), overlaid onto the existing concepts.
+   */
+  private ValueSetSnapshot renderLanguage(ValueSetVersion version, ValueSetSnapshot snapshot, String displayLanguage) {
+    List<ValueSetVersionConcept> source = Optional.ofNullable(snapshot.getExpansion()).orElse(List.of());
+    List<String> supportedLanguages = Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of());
+    List<String> preferredLanguages = version.getPreferredLanguage() != null ? List.of(version.getPreferredLanguage()) : List.of();
+    Map<Long, Designation> loaded = supportedLanguages.contains(displayLanguage) ? Map.of() : loadDisplayDesignations(source, displayLanguage);
+
+    List<ValueSetVersionConcept> rendered = source.stream().map(c -> {
+      List<Designation> all = new ArrayList<>();
+      if (c.getDisplay() != null) {
+        all.add(c.getDisplay());
+      }
+      if (c.getAdditionalDesignations() != null) {
+        all.addAll(c.getAdditionalDesignations());
+      }
+      Long conceptVersionId = c.getConcept() == null ? null : c.getConcept().getConceptVersionId();
+      Designation extra = conceptVersionId == null ? null : loaded.get(conceptVersionId);
+      if (extra != null) {
+        all.add(extra);
+      }
+      Designation display = ConceptUtil.getDisplay(all, displayLanguage, preferredLanguages);
+      if (display == null) {
+        return c;
+      }
+      List<Designation> additional = extra == null ? c.getAdditionalDesignations()
+          : Stream.concat(Optional.ofNullable(c.getAdditionalDesignations()).orElse(List.of()).stream(), Stream.of(extra)).toList();
+      return withDisplay(c, display, additional);
+    }).toList();
+    return transientSnapshot(snapshot.getValueSet(), version.getId(), rendered);
+  }
+
+  /** Load ONLY the display designations for {@code language} for the given concepts (no rule expansion). */
+  private Map<Long, Designation> loadDisplayDesignations(List<ValueSetVersionConcept> concepts, String language) {
+    List<String> versionIds = concepts.stream()
+        .map(c -> c.getConcept() == null ? null : c.getConcept().getConceptVersionId())
+        .filter(Objects::nonNull).distinct().map(String::valueOf).toList();
+    if (versionIds.isEmpty()) {
+      return Map.of();
+    }
+    CodeSystemEntityVersionQueryParams params = new CodeSystemEntityVersionQueryParams();
+    params.setIds(String.join(",", versionIds));
+    params.limit(versionIds.size());
+    Map<Long, Designation> result = new HashMap<>();
+    for (CodeSystemEntityVersion v : codeSystemEntityVersionService.query(params).getData()) {
+      if (v.getId() == null || v.getDesignations() == null) {
+        continue;
+      }
+      v.getDesignations().stream()
+          .filter(d -> "display".equals(d.getDesignationType()) && !PublicationStatus.retired.equals(d.getStatus()))
+          .filter(d -> d.getLanguage() != null && (d.getLanguage().equals(language) || d.getLanguage().startsWith(language)))
+          .min(Comparator.comparing(Designation::isPreferred).reversed())
+          .ifPresent(d -> result.putIfAbsent(v.getId(), d));
+    }
+    return result;
+  }
+
+  /** Shallow copy of a snapshot concept overriding only its display (and optionally additionalDesignations). */
+  private static ValueSetVersionConcept withDisplay(ValueSetVersionConcept c, Designation display, List<Designation> additionalDesignations) {
+    return new ValueSetVersionConcept()
+        .setId(c.getId())
+        .setConcept(c.getConcept())
+        .setDisplay(display)
+        .setAdditionalDesignations(additionalDesignations)
+        .setOrderNumber(c.getOrderNumber())
+        .setEnumerated(c.isEnumerated())
+        .setActive(c.isActive())
+        .setStatus(c.getStatus())
+        .setAssociations(c.getAssociations())
+        .setPropertyValues(c.getPropertyValues());
+  }
+
+  private static ValueSetSnapshot transientSnapshot(String vs, Long versionId, List<ValueSetVersionConcept> expansion) {
+    return new ValueSetSnapshot()
+        .setValueSet(vs)
+        .setValueSetVersion(new ValueSetVersionReference().setId(versionId))
+        .setExpansion(expansion)
+        .setConceptsTotal(expansion.size());
+  }
+
+  /** A snapshot may be (over)written only by a caller with write/maintain rights on the value set. */
+  private static boolean canPersistSnapshot(String valueSet) {
+    return SessionStore.get()
+        .map(s -> s.hasPrivilege(valueSet + "." + Privilege.VS_WRITE) || s.hasPrivilege(valueSet + "." + Privilege.VS_MAINTAIN))
+        .orElse(false);
   }
 
   public List<ValueSetVersionConcept> expand(ValueSetVersion version, String preferredLanguage) {
@@ -100,7 +211,7 @@ public class ValueSetVersionConceptService {
 
     if (!includeDesignations &&
         StringUtils.isEmpty(preferredLanguage) &&
-        PublicationStatus.active.equals(version.getStatus()) &&
+        !PublicationStatus.draft.equals(version.getStatus()) &&
         version.getSnapshot() != null && version.getSnapshot().getExpansion() != null &&
         isSnapshotCurrent(version, version.getSnapshot())) {
       return version.getSnapshot().getExpansion();

--- a/terminology/src/main/resources/terminology/changelog/terminology/06-map_set.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/06-map_set.sql
@@ -151,3 +151,7 @@ add column external_web_source text;
 --rollback  drop column if exists external_web_source,
 --rollback  add column external_web_source boolean;
 --
+
+--changeset termx:map_set_version-supported_languages
+alter table terminology.map_set_version add column if not exists supported_languages text[];
+--rollback alter table terminology.map_set_version drop column if exists supported_languages;

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
@@ -118,4 +118,37 @@ class CodeSystemFhirMapperSpec extends Specification {
     property.rule.valueSet == "vs-1"
     property.rule.codeSystems == ["cs-1", "cs-2"]
   }
+
+  def "toFhir exports codesystem-language extensions from supportedLanguages"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    def codeSystem = new CodeSystem().setId("cs").setUri("http://fhir.ee/CodeSystem/cs").setName("cs")
+        .setTitle(new LocalizedName([en: "cs"])).setContent("not-present")
+    def version = new CodeSystemVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-03-18")).setStatus(PublicationStatus.draft)
+        .setSupportedLanguages(["et", "en"])
+
+    when:
+    def fhir = mapper.toFhir(codeSystem, version, [])
+    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/codesystem-language" }.collect { it.valueCode }
+
+    then:
+    languages == ["et", "en"]
+  }
+
+  def "fromFhir imports codesystem-language extensions into the version supportedLanguages"() {
+    given:
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.CodeSystem()
+        .setId("cs").setUrl("http://fhir.ee/CodeSystem/cs").setName("cs").setTitle("cs").setContent("not-present")
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/codesystem-language").setValueCode("et"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/codesystem-language").setValueCode("ru"))
+
+    when:
+    def imported = mapper.fromFhirCodeSystem(fhir)
+    def languages = imported.versions.first().supportedLanguages
+
+    then:
+    languages.contains("et")
+    languages.contains("ru")
+  }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapperLanguageSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapperLanguageSpec.groovy
@@ -1,0 +1,67 @@
+package org.termx.terminology.fhir.conceptmap
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.Extension
+import com.kodality.zmei.fhir.resource.terminology.ConceptMap
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService
+import org.termx.terminology.terminology.mapset.MapSetService
+import org.termx.terminology.terminology.relatedartifacts.MapSetRelatedArtifactService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.mapset.MapSet
+import org.termx.ts.mapset.MapSetVersion
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+class ConceptMapFhirMapperLanguageSpec extends Specification {
+  def conceptService = Mock(ConceptService)
+  def codeSystemService = Mock(CodeSystemService)
+  def valueSetService = Mock(ValueSetService)
+  def mapSetService = Mock(MapSetService)
+  def codeSystemVersionService = Mock(CodeSystemVersionService)
+  def valueSetVersionService = Mock(ValueSetVersionService)
+  def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
+  def relatedArtifactService = Mock(MapSetRelatedArtifactService)
+
+  def mapper = new ConceptMapFhirMapper(conceptService, codeSystemService, valueSetService, mapSetService,
+      codeSystemVersionService, valueSetVersionService, valueSetVersionConceptService, relatedArtifactService)
+
+  def "toFhir exports conceptmap-language extensions from supportedLanguages"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def mapSet = new MapSet().setId("ms").setUri("http://fhir.ee/ConceptMap/ms").setName("ms").setTitle(new LocalizedName([en: "ms"]))
+    def version = new MapSetVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-03-18")).setStatus(PublicationStatus.draft)
+        .setScope(new MapSetVersion.MapSetVersionScope())
+        .setSupportedLanguages(["et", "en"])
+
+    when:
+    def fhir = mapper.toFhir(mapSet, version, [])
+    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/conceptmap-language" }.collect { it.valueCode }
+
+    then:
+    languages == ["et", "en"]
+  }
+
+  def "fromFhir imports conceptmap-language extensions into the version supportedLanguages"() {
+    given:
+    def fhir = new ConceptMap()
+        .setId("ms").setUrl("http://fhir.ee/ConceptMap/ms").setName("ms").setLanguage("en")
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/conceptmap-language").setValueCode("et"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/conceptmap-language").setValueCode("ru"))
+
+    when:
+    def imported = mapper.fromFhir(fhir)
+    def languages = imported.versions.first().supportedLanguages
+
+    then:
+    languages.contains("et")
+    languages.contains("ru")
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperLanguageSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperLanguageSpec.groovy
@@ -1,0 +1,60 @@
+package org.termx.terminology.fhir.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.Extension
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.mapset.MapSetService
+import org.termx.terminology.terminology.relatedartifacts.ValueSetRelatedArtifactService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+class ValueSetFhirMapperLanguageSpec extends Specification {
+  def conceptService = Mock(ConceptService)
+  def codeSystemService = Mock(CodeSystemService)
+  def valueSetService = Mock(ValueSetService)
+  def mapSetService = Mock(MapSetService)
+  def relatedArtifactService = Mock(ValueSetRelatedArtifactService)
+
+  def mapper = new ValueSetFhirMapper(conceptService, codeSystemService, valueSetService, mapSetService, relatedArtifactService)
+
+  def "toFhir exports valueset-language extensions from supportedLanguages"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def version = new ValueSetVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-03-18")).setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([]))
+        .setSupportedLanguages(["et", "en"])
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [])
+    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/valueset-language" }.collect { it.valueCode }
+
+    then:
+    languages == ["et", "en"]
+  }
+
+  def "fromFhir imports valueset-language extensions into the version supportedLanguages"() {
+    given:
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+        .setId("vs").setUrl("http://fhir.ee/ValueSet/vs").setName("vs").setLanguage("en")
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/valueset-language").setValueCode("et"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/valueset-language").setValueCode("ru"))
+
+    when:
+    def imported = ValueSetFhirMapper.fromFhirValueSet(fhir)
+    def languages = imported.versions.first().supportedLanguages
+
+    then:
+    languages.contains("et")
+    languages.contains("ru")
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptServiceTest.groovy
@@ -1,11 +1,14 @@
 package org.termx.terminology.terminology.valueset.expansion
 
 import com.kodality.commons.model.QueryResult
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
 import org.termx.core.ts.ValueSetExternalExpandProvider
 import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService
 import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropertyService
 import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotService
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionRepository
+import org.termx.ts.codesystem.CodeSystemEntityVersion
 import org.termx.ts.codesystem.Designation
 import org.termx.ts.valueset.ValueSetSnapshot
 import org.termx.ts.valueset.ValueSetVersion
@@ -21,6 +24,10 @@ class ValueSetVersionConceptServiceTest extends Specification {
   def codeSystemEntityVersionService = Mock(CodeSystemEntityVersionService)
   def entityPropertyService = Mock(EntityPropertyService)
   def codeSystemVersionResolver = Mock(ValueSetCodeSystemVersionResolver)
+
+  def cleanup() {
+    SessionStore.clearLocal()
+  }
 
   def "expand returns external provider concepts with preferred language"() {
     given:
@@ -72,6 +79,106 @@ class ValueSetVersionConceptServiceTest extends Specification {
     expanded.first().additionalDesignations.find { it.language == "lt" && it.designationType == "abbreviation" }?.name == "ml"
   }
 
+  def "reuses the stored snapshot for a published (retired) version without recomputing or overwriting"() {
+    given:
+    def snapshot = new ValueSetSnapshot().setExpansion([vsConcept("mL", [])])
+    def version = valueSetVersion().setStatus("retired").setSnapshot(snapshot)
+    valueSetVersionRepository.load("vs", "1.0.0") >> version
+    codeSystemVersionResolver.isDynamic(_) >> false
+
+    when:
+    def result = newService().expand("vs", "1.0.0", null, false)
+
+    then: "the frozen snapshot is returned as-is and never re-created"
+    result.is(snapshot)
+    0 * valueSetSnapshotService.createSnapshot(_, _, _, _)
+  }
+
+  def "(f) renders a displayLanguage from the snapshot without a DB query or rewrite when it is a VS language"() {
+    given: "an active version that supports et/en with a snapshot carrying both displays"
+    def concept = vsConcept("9021002", 100L,
+        designation("display", "en", "Carbaryl"),
+        [designation("display", "et", "karbarüül")])
+    def version = valueSetVersion().setStatus("active").setSupportedLanguages(["et", "en"])
+        .setSnapshot(new ValueSetSnapshot().setValueSet("vs").setExpansion([concept]))
+    valueSetVersionRepository.load("vs", "1.0.0") >> version
+    codeSystemVersionResolver.isDynamic(_) >> false
+
+    when: "et is requested"
+    def result = newService().expand("vs", "1.0.0", "et", false)
+
+    then: "display is re-picked from the snapshot — no DB query, no rewrite"
+    result.expansion.first().display.name == "karbarüül"
+    0 * codeSystemEntityVersionService.query(_)
+    0 * valueSetSnapshotService.createSnapshot(_, _, _, _)
+  }
+
+  def "(b) loads only designations for a non-VS language and does not rewrite the snapshot"() {
+    given: "an active version that supports only en"
+    def concept = vsConcept("9021002", 100L, designation("display", "en", "Carbaryl"), [])
+    def version = valueSetVersion().setStatus("active").setSupportedLanguages(["en"])
+        .setSnapshot(new ValueSetSnapshot().setValueSet("vs").setExpansion([concept]))
+    valueSetVersionRepository.load("vs", "1.0.0") >> version
+    codeSystemVersionResolver.isDynamic(_) >> false
+
+    when: "et (not a VS language) is requested"
+    def result = newService().expand("vs", "1.0.0", "et", false)
+
+    then: "only the et display designation is loaded; concepts/snapshot untouched"
+    1 * codeSystemEntityVersionService.query(_) >> new QueryResult([
+        new CodeSystemEntityVersion().setId(100L).setDesignations([designation("display", "et", "karbarüül")])])
+    result.expansion.first().display.name == "karbarüül"
+    0 * valueSetSnapshotService.createSnapshot(_, _, _, _)
+  }
+
+  def "(c) persists the snapshot for a draft only when the caller has write permission"() {
+    given:
+    repository.expand(1L) >> []
+    codeSystemEntityVersionService.query(_) >> QueryResult.empty()
+    entityPropertyService.query(_) >> QueryResult.empty()
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["vs.ValueSet.write"] as Set))
+    def version = valueSetVersion().setStatus("draft")
+    valueSetVersionRepository.load("vs", "1.0.0") >> version
+    codeSystemVersionResolver.isDynamic(_) >> false
+
+    when:
+    def result = newService().expand("vs", "1.0.0", null, false)
+
+    then:
+    1 * valueSetSnapshotService.createSnapshot("vs", 1L, _, _) >> { args -> new ValueSetSnapshot().setExpansion(args[2]) }
+    result != null
+  }
+
+  def "(c) does not persist the snapshot when the caller lacks write permission"() {
+    given:
+    repository.expand(1L) >> []
+    codeSystemEntityVersionService.query(_) >> QueryResult.empty()
+    entityPropertyService.query(_) >> QueryResult.empty()
+    def version = valueSetVersion().setStatus("draft")
+    valueSetVersionRepository.load("vs", "1.0.0") >> version
+    codeSystemVersionResolver.isDynamic(_) >> false
+
+    when: "a read-only caller (no session) expands a draft"
+    def result = newService().expand("vs", "1.0.0", null, false)
+
+    then: "a transient expansion is returned and nothing is written"
+    result != null
+    result.expansion != null
+    0 * valueSetSnapshotService.createSnapshot(_, _, _, _)
+  }
+
+  private ValueSetVersionConceptService newService() {
+    return new ValueSetVersionConceptService(
+        [ucumProvider(vsConcept("mL", [designation("display", "et", "milliliiter")]))],
+        repository,
+        valueSetVersionRepository,
+        valueSetSnapshotService,
+        codeSystemEntityVersionService,
+        entityPropertyService,
+        codeSystemVersionResolver
+    )
+  }
+
   private static ValueSetVersion valueSetVersion() {
     return new ValueSetVersion()
         .setId(1L)
@@ -88,6 +195,18 @@ class ValueSetVersionConceptServiceTest extends Specification {
             .setCodeSystem("ucum")
             .setCodeSystemUri("http://unitsofmeasure.org"))
         .setAdditionalDesignations(designations)
+        .setActive(true)
+  }
+
+  private static ValueSetVersionConcept vsConcept(String code, Long conceptVersionId, Designation display, List<Designation> additionalDesignations) {
+    return new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConcept.ValueSetVersionConceptValue()
+            .setCode(code)
+            .setConceptVersionId(conceptVersionId)
+            .setCodeSystem("ucum")
+            .setCodeSystemUri("http://unitsofmeasure.org"))
+        .setDisplay(display)
+        .setAdditionalDesignations(additionalDesignations)
         .setActive(true)
   }
 

--- a/termx-api/src/main/java/org/termx/ts/mapset/MapSetVersion.java
+++ b/termx-api/src/main/java/org/termx/ts/mapset/MapSetVersion.java
@@ -17,6 +17,7 @@ import lombok.experimental.Accessors;
 public class MapSetVersion extends MapSetVersionReference {
   private String mapSet;
   private String preferredLanguage;
+  private List<String> supportedLanguages;
   private LocalizedName description;
   private String algorithm;
   private LocalDate releaseDate;

--- a/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
@@ -261,4 +261,17 @@ public abstract class BaseFhirMapper {
     }
     return extensions.stream().filter(e -> "https://fhir.ee/StructureDefinition/version-description".equals(e.getUrl())).findFirst().map(Extension::getValueString).orElse(null);
   }
+
+  /** Reads the {@code valueCode}s of the repeated language extensions ({@code url}) into a distinct list. */
+  protected static List<String> fromFhirLanguageExtensions(List<Extension> extensions, String url) {
+    if (extensions == null) {
+      return List.of();
+    }
+    return extensions.stream()
+        .filter(e -> url.equals(e.getUrl()))
+        .map(Extension::getValueCode)
+        .filter(java.util.Objects::nonNull)
+        .distinct()
+        .toList();
+  }
 }


### PR DESCRIPTION
## Summary

Two related changes from reviewing the expansion logic.

### 1. Snapshot reuse & display-language rendering (`ValueSetVersionConceptService`)
Fixes `$expand` overwriting frozen snapshots (the snapshot date kept jumping on every FHIR read).
- **(a)** Reuse the stored snapshot for any **published** version (`active` *and* `retired`); only `draft` re-expands.
- **(f)** A `displayLanguage` that is one of the version's `supportedLanguages` is rendered from the snapshot — **no DB query, no rewrite**.
- **(b)** A foreign `displayLanguage` loads **only** the display designations (no rule re-expansion), overlaid on the snapshot concepts; snapshot untouched.
- **(c)** A snapshot is (over)written **only** by a caller with `ValueSet.write`/`maintain`; public/read-only `$expand` never overwrites.
- **(d)** `decorate` already stores all `supportedLanguages` designations in the snapshot.

### 2. Language extensions across CodeSystem / ValueSet / MapSet (round-trip)
- **Export:** each `*FhirMapper.toFhir` emits one repeated extension per declared language — `{url: ".../{valueset,codesystem,conceptmap}-language", valueCode}` — from `version.supportedLanguages` (ValueSet on read **and** `$expand`).
- **Import:** `*FhirMapper.fromFhir*` unions those extension codes into the version's `supportedLanguages` (shared `BaseFhirMapper.fromFhirLanguageExtensions`), so export→import round-trips.
- **MapSet** gained `supportedLanguages`: model field + `map_set_version.supported_languages text[]` column (Liquibase changeset) + repository read/write.

### Tests
- `ValueSetVersionConceptServiceTest` — snapshot reuse (retired), permission-gated persist, native-language render (no DB), foreign-language designations-only.
- `CodeSystemFhirMapperSpec` / `ValueSetFhirMapperLanguageSpec` / `ConceptMapFhirMapperLanguageSpec` — export emits the extensions and import reads them back (round-trip).

### Notes
- Carries a **Liquibase migration** (new MapSet column) — applies on deploy.
- Docs: `docs/features/value-set-expand.md` section 8.