### PR TITLE
Use one common supported-language extension URL across CS/VS/MS

### DIFF
--- a/docs/features/value-set-expand.md
+++ b/docs/features/value-set-expand.md
@@ -260,15 +260,16 @@ and any language-qualified read overwrote the canonical snapshot.
 - **(d) Snapshot carries all VS languages.** `decorate` populates each concept's
   `additionalDesignations` with the designations for every language in `supportedLanguages`, so the
   canonical snapshot is language-complete.
-- **(e) Resources advertise their languages (round-trip).** The FHIR resource carries one repeated
-  extension per language the version declares (`version.supportedLanguages`):
-  `{url: "https://termx.org/fhir/StructureDefinition/<resource>-language", valueCode: <lang>}` for
-  `valueset` / `codesystem` / `conceptmap` — added in each `*FhirMapper.toFhir` (ValueSet on both
-  read and `$expand`). Preferred over `expansion.parameter`, which is meant to echo *applied*
-  parameters. **Import reads it back**: `*FhirMapper.fromFhir*` unions these extension `valueCode`s
-  into the imported version's `supportedLanguages` (via `BaseFhirMapper.fromFhirLanguageExtensions`),
-  so export→import round-trips. (MapSet gained a `supportedLanguages` column —
-  `map_set_version.supported_languages` — to store this.)
+- **(e) Resources advertise their languages (round-trip).** The FHIR resource (CodeSystem /
+  ValueSet / ConceptMap) carries one repeated extension per language the version declares
+  (`version.supportedLanguages`):
+  `{url: "https://termx.org/fhir/StructureDefinition/supported-language", valueCode: <lang>}` —
+  a single common URL (`BaseFhirMapper.SUPPORTED_LANGUAGE_EXTENSION_URL`) added in each
+  `*FhirMapper.toFhir` (ValueSet on both read and `$expand`). Preferred over `expansion.parameter`,
+  which is meant to echo *applied* parameters. **Import reads it back**: `*FhirMapper.fromFhir*`
+  unions these extension `valueCode`s into the imported version's `supportedLanguages` (via
+  `BaseFhirMapper.fromFhirLanguageExtensions`), so export→import round-trips. (MapSet gained a
+  `supportedLanguages` column — `map_set_version.supported_languages` — to store this.)
 - **(f) Native display language ⇒ no DB.** When the requested `displayLanguage` **is** one of the
   version's `supportedLanguages`, the display is re-picked from the designations already in the
   snapshot (`ConceptUtil.getDisplay`) — **no DB query and no snapshot rewrite**.

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -60,8 +60,6 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
   private static final Set<String> IMPLICIT_PROPERTY_DEFINITIONS = Set.of(DISPLAY, DEFINITION);
   private static final String PROPERTY_VALUE_SET_EXTENSION_URL = "http://hl7.org/fhir/StructureDefinition/codesystem-property-valueset";
   private static final String PROPERTY_CODE_SYSTEM_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/codesystem-property-codesystem";
-  // One repeated extension per language the code system version provides designations in.
-  private static final String CS_LANGUAGE_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/codesystem-language";
 
   public CodeSystemFhirMapper(ConceptService conceptService,
                               CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
@@ -107,7 +105,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
       fhirCodeSystem.addExtension(toFhirVersionDescriptionExtension(versionDescription));
     }
     Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of())
-        .forEach(language -> fhirCodeSystem.addExtension(new Extension(CS_LANGUAGE_EXTENSION_URL).setValueCode(language)));
+        .forEach(language -> fhirCodeSystem.addExtension(new Extension(SUPPORTED_LANGUAGE_EXTENSION_URL).setValueCode(language)));
     fhirCodeSystem.setPurpose(toFhirName(codeSystem.getPurpose(), version.getPreferredLanguage()));
     fhirCodeSystem.setTopic(toFhirTopic(codeSystem.getTopic()));
     fhirCodeSystem.setUseContext(toFhirUseContext(codeSystem.getUseContext()));
@@ -552,9 +550,9 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
         .map(CodeSystemConcept::getDesignation)
         .filter(Objects::nonNull).flatMap(List::stream)
         .map(CodeSystemConceptDesignation::getLanguage);
-    // Declared languages come from the codesystem-language extensions; union them with the languages
+    // Declared languages come from the supported-language extensions; union them with the languages
     // observed on designations and the preferred language so nothing is lost on round-trip.
-    Stream<String> declaredLanguages = fromFhirLanguageExtensions(fhirCodeSystem.getExtension(), CS_LANGUAGE_EXTENSION_URL).stream();
+    Stream<String> declaredLanguages = fromFhirLanguageExtensions(fhirCodeSystem.getExtension(), SUPPORTED_LANGUAGE_EXTENSION_URL).stream();
     version.setSupportedLanguages(Stream.concat(Stream.concat(
           declaredLanguages,
           supportedLanguages),

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
@@ -82,9 +82,6 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
   private final ValueSetVersionConceptService valueSetVersionConceptService;
   private final MapSetRelatedArtifactService relatedArtifactService;
 
-  // One repeated extension per language the map set version declares.
-  private static final String CM_LANGUAGE_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/conceptmap-language";
-
   public ConceptMapFhirMapper(ConceptService conceptService,
                               CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
                               CodeSystemVersionService codeSystemVersionService, ValueSetVersionService valueSetVersionService,
@@ -132,7 +129,7 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
       fhirConceptMap.addExtension(toFhirVersionDescriptionExtension(versionDescription));
     }
     Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of())
-        .forEach(language -> fhirConceptMap.addExtension(new Extension(CM_LANGUAGE_EXTENSION_URL).setValueCode(language)));
+        .forEach(language -> fhirConceptMap.addExtension(new Extension(SUPPORTED_LANGUAGE_EXTENSION_URL).setValueCode(language)));
     fhirConceptMap.setPurpose(toFhirName(mapSet.getPurpose(), version.getPreferredLanguage()));
     fhirConceptMap.setTopic(toFhirTopic(mapSet.getTopic()));
     fhirConceptMap.setUseContext(toFhirUseContext(mapSet.getUseContext()));
@@ -382,9 +379,9 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
     version.setScope(fromFhirScope(conceptMap));
     version.setAssociations(fromFhirAssociations(conceptMap));
     version.setIdentifiers(fromFhirVersionIdentifiers(conceptMap.getIdentifier()));
-    // Declared languages come from the conceptmap-language extensions; union with the preferred language.
+    // Declared languages come from the supported-language extensions; union with the preferred language.
     version.setSupportedLanguages(Stream.concat(
-            fromFhirLanguageExtensions(conceptMap.getExtension(), CM_LANGUAGE_EXTENSION_URL).stream(),
+            fromFhirLanguageExtensions(conceptMap.getExtension(), SUPPORTED_LANGUAGE_EXTENSION_URL).stream(),
             Stream.ofNullable(version.getPreferredLanguage()))
         .filter(Objects::nonNull).distinct().toList());
     return version;

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -89,9 +89,6 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   private final ValueSetRelatedArtifactService relatedArtifactService;
   private static final String concept_definition = "http://hl7.org/fhir/StructureDefinition/valueset-concept-definition";
   private static final String concept_order = "http://hl7.org/fhir/StructureDefinition/valueset-conceptOrder";
-  // One repeated extension per language the value set version provides designations in. Present on
-  // both the plain read and $expand so clients can discover available languages without expanding.
-  private static final String vs_language = "https://termx.org/fhir/StructureDefinition/valueset-language";
 
   public ValueSetFhirMapper(ConceptService conceptService,
                             CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
@@ -171,7 +168,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     Optional.ofNullable(valueSet.getSourceReference()).ifPresent(ref -> fhirValueSet.addExtension(toFhirSourceReferenceExtension("http://hl7.org/fhir/StructureDefinition/valueset-sourceReference", ref)));
     Optional.ofNullable(valueSet.getReplaces()).flatMap(id -> Optional.ofNullable(valueSetService.load(id)).map(ValueSet::getUri)).ifPresent(uri -> fhirValueSet.addExtension(toFhirReplacesExtension(uri)));
     Optional.ofNullable(version.getSupportedLanguages()).orElse(List.of())
-        .forEach(language -> fhirValueSet.addExtension(new Extension(vs_language).setValueCode(language)));
+        .forEach(language -> fhirValueSet.addExtension(new Extension(SUPPORTED_LANGUAGE_EXTENSION_URL).setValueCode(language)));
     fhirValueSet.setDate(toFhirOffsetDateTime(provenances));
     fhirValueSet.setLastReviewDate(toFhirDate(provenances, "reviewed"));
     fhirValueSet.setApprovalDate(toFhirDate(provenances, "approved"));
@@ -329,7 +326,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
 
   public com.kodality.zmei.fhir.resource.terminology.ValueSet toFhir(ValueSet valueSet, ValueSetVersion version, List<Provenance> provenances, ValueSetSnapshot snapshot, Parameters param) {
     com.kodality.zmei.fhir.resource.terminology.ValueSet fhirValueSet = toFhir(valueSet, version, provenances);
-    // The set of languages carried by the expansion is advertised as repeated `valueset-language`
+    // The set of languages carried by the expansion is advertised as repeated `supported-language`
     // extensions on the resource (added in the base toFhir from version.supportedLanguages).
     fhirValueSet.setExpansion(toFhirExpansion(snapshot, fhirValueSet.getCompose().getProperty(), param));
     return fhirValueSet;
@@ -642,9 +639,9 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     if (description != null) {
       version.setDescription(new LocalizedName(Map.of(Optional.ofNullable(version.getPreferredLanguage()).orElse(Language.en), description)));
     }
-    // Declared languages come from the valueset-language extensions; union with the preferred language.
+    // Declared languages come from the supported-language extensions; union with the preferred language.
     version.setSupportedLanguages(Stream.concat(
-            fromFhirLanguageExtensions(valueSet.getExtension(), vs_language).stream(),
+            fromFhirLanguageExtensions(valueSet.getExtension(), SUPPORTED_LANGUAGE_EXTENSION_URL).stream(),
             Stream.ofNullable(version.getPreferredLanguage()))
         .filter(Objects::nonNull).distinct().toList());
     return version;

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
@@ -119,7 +119,7 @@ class CodeSystemFhirMapperSpec extends Specification {
     property.rule.codeSystems == ["cs-1", "cs-2"]
   }
 
-  def "toFhir exports codesystem-language extensions from supportedLanguages"() {
+  def "toFhir exports supported-language extensions from supportedLanguages"() {
     given:
     conceptService.load(_, _) >> Optional.empty()
     def codeSystem = new CodeSystem().setId("cs").setUri("http://fhir.ee/CodeSystem/cs").setName("cs")
@@ -130,18 +130,18 @@ class CodeSystemFhirMapperSpec extends Specification {
 
     when:
     def fhir = mapper.toFhir(codeSystem, version, [])
-    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/codesystem-language" }.collect { it.valueCode }
+    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/supported-language" }.collect { it.valueCode }
 
     then:
     languages == ["et", "en"]
   }
 
-  def "fromFhir imports codesystem-language extensions into the version supportedLanguages"() {
+  def "fromFhir imports supported-language extensions into the version supportedLanguages"() {
     given:
     def fhir = new com.kodality.zmei.fhir.resource.terminology.CodeSystem()
         .setId("cs").setUrl("http://fhir.ee/CodeSystem/cs").setName("cs").setTitle("cs").setContent("not-present")
-        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/codesystem-language").setValueCode("et"))
-        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/codesystem-language").setValueCode("ru"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/supported-language").setValueCode("et"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/supported-language").setValueCode("ru"))
 
     when:
     def imported = mapper.fromFhirCodeSystem(fhir)

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapperLanguageSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapperLanguageSpec.groovy
@@ -31,7 +31,7 @@ class ConceptMapFhirMapperLanguageSpec extends Specification {
   def mapper = new ConceptMapFhirMapper(conceptService, codeSystemService, valueSetService, mapSetService,
       codeSystemVersionService, valueSetVersionService, valueSetVersionConceptService, relatedArtifactService)
 
-  def "toFhir exports conceptmap-language extensions from supportedLanguages"() {
+  def "toFhir exports supported-language extensions from supportedLanguages"() {
     given:
     conceptService.load(_, _) >> Optional.empty()
     relatedArtifactService.findRelatedArtifacts(_) >> []
@@ -43,18 +43,18 @@ class ConceptMapFhirMapperLanguageSpec extends Specification {
 
     when:
     def fhir = mapper.toFhir(mapSet, version, [])
-    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/conceptmap-language" }.collect { it.valueCode }
+    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/supported-language" }.collect { it.valueCode }
 
     then:
     languages == ["et", "en"]
   }
 
-  def "fromFhir imports conceptmap-language extensions into the version supportedLanguages"() {
+  def "fromFhir imports supported-language extensions into the version supportedLanguages"() {
     given:
     def fhir = new ConceptMap()
         .setId("ms").setUrl("http://fhir.ee/ConceptMap/ms").setName("ms").setLanguage("en")
-        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/conceptmap-language").setValueCode("et"))
-        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/conceptmap-language").setValueCode("ru"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/supported-language").setValueCode("et"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/supported-language").setValueCode("ru"))
 
     when:
     def imported = mapper.fromFhir(fhir)

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperLanguageSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperLanguageSpec.groovy
@@ -24,7 +24,7 @@ class ValueSetFhirMapperLanguageSpec extends Specification {
 
   def mapper = new ValueSetFhirMapper(conceptService, codeSystemService, valueSetService, mapSetService, relatedArtifactService)
 
-  def "toFhir exports valueset-language extensions from supportedLanguages"() {
+  def "toFhir exports supported-language extensions from supportedLanguages"() {
     given:
     conceptService.load(_, _) >> Optional.empty()
     relatedArtifactService.findRelatedArtifacts(_) >> []
@@ -36,18 +36,18 @@ class ValueSetFhirMapperLanguageSpec extends Specification {
 
     when:
     def fhir = mapper.toFhir(valueSet, version, [])
-    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/valueset-language" }.collect { it.valueCode }
+    def languages = fhir.extension.findAll { it.url == "https://termx.org/fhir/StructureDefinition/supported-language" }.collect { it.valueCode }
 
     then:
     languages == ["et", "en"]
   }
 
-  def "fromFhir imports valueset-language extensions into the version supportedLanguages"() {
+  def "fromFhir imports supported-language extensions into the version supportedLanguages"() {
     given:
     def fhir = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
         .setId("vs").setUrl("http://fhir.ee/ValueSet/vs").setName("vs").setLanguage("en")
-        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/valueset-language").setValueCode("et"))
-        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/valueset-language").setValueCode("ru"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/supported-language").setValueCode("et"))
+        .addExtension(new Extension("https://termx.org/fhir/StructureDefinition/supported-language").setValueCode("ru"))
 
     when:
     def imported = ValueSetFhirMapper.fromFhirValueSet(fhir)

--- a/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
@@ -262,6 +262,9 @@ public abstract class BaseFhirMapper {
     return extensions.stream().filter(e -> "https://fhir.ee/StructureDefinition/version-description".equals(e.getUrl())).findFirst().map(Extension::getValueString).orElse(null);
   }
 
+  /** Common extension URL: one repeated entry per language a resource version supports. */
+  public static final String SUPPORTED_LANGUAGE_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/supported-language";
+
   /** Reads the {@code valueCode}s of the repeated language extensions ({@code url}) into a distinct list. */
   protected static List<String> fromFhirLanguageExtensions(List<Extension> extensions, String url) {
     if (extensions == null) {


### PR DESCRIPTION
## Summary

Renames the three per-resource language extension URLs to a single common one:

- ~~`.../valueset-language`~~, ~~`.../codesystem-language`~~, ~~`.../conceptmap-language`~~
- → **`https://termx.org/fhir/StructureDefinition/supported-language`**

Defined once as `BaseFhirMapper.SUPPORTED_LANGUAGE_EXTENSION_URL` and reused by the ValueSet / CodeSystem / ConceptMap mappers for both export (`toFhir`) and import (`fromFhir`). Per-mapper constants removed.

Mapper round-trip specs and `docs/features/value-set-expand.md` updated. The extension was introduced in the previous PR and isn't consumed by any client yet, so the rename is safe (no migration impact).