### PR TITLE
info endpoint: expose build time, commit, and PR number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,6 +115,17 @@ jobs:
         run: echo "LATEST_TAG=latest" >> $GITHUB_ENV
 
 
+      - name: Build metadata
+        id: bmeta
+        env:
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          echo "build_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "commit=${GITHUB_SHA::8}" >> "$GITHUB_OUTPUT"
+          # On a merge to main the commit subject is "Merge pull request #NNN from ..."
+          pr=$(printf '%s' "$HEAD_MSG" | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)
+          echo "pr=$pr" >> "$GITHUB_OUTPUT"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -135,3 +146,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_TIME=${{ steps.bmeta.outputs.build_time }}
+            GIT_COMMIT=${{ steps.bmeta.outputs.commit }}
+            PR_NUMBER=${{ steps.bmeta.outputs.pr }}

--- a/termx-app/Dockerfile
+++ b/termx-app/Dockerfile
@@ -8,6 +8,14 @@ ENV APP_VERSION=${APP_VERSION:-latest}
 ARG BUILD_TIME
 ENV BUILD_TIME=$BUILD_TIME
 
+# Short commit sha and the merged PR number, surfaced on /info so a running
+# container can be traced back to an exact build (version is just the image tag,
+# e.g. "latest", which isn't enough on dev).
+ARG GIT_COMMIT
+ENV GIT_COMMIT=$GIT_COMMIT
+ARG PR_NUMBER
+ENV PR_NUMBER=$PR_NUMBER
+
 # Fail-fast on OutOfMemoryError instead of letting the JVM limp on with
 # a depleted heap. The previous behaviour (no flag) caused the May 2026
 # dev-server incident where a single OOM cascaded into every concurrent

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -37,6 +37,9 @@ endpoints:
 
 info:
   version: ${APP_VERSION:dev}
+  build-time: ${BUILD_TIME:}
+  commit: ${GIT_COMMIT:}
+  pr: ${PR_NUMBER:}
 
 datasources:
   default:


### PR DESCRIPTION
## Summary

`GET /api/info` returned only `version`, which on dev is just the image tag (`latest`) — not enough to identify the running build. This adds three build-stamped fields:

```json
{ "version": "latest", "build-time": "2026-06-08T09:12:30Z", "commit": "7226dc85", "pr": "173" }
```

- **application.yml** — `info.build-time/commit/pr` mapped from `BUILD_TIME` / `GIT_COMMIT` / `PR_NUMBER` (empty when unset, e.g. local runs).
- **Dockerfile** — already had `BUILD_TIME`; added `GIT_COMMIT` and `PR_NUMBER` ARG/ENV.
- **build.yml** — a `Build metadata` step computes build time (UTC), short SHA, and the PR number (parsed from the merge-commit subject `Merge pull request #NNN`, read via an env var to avoid script injection), then passes all three as docker `build-args`.

Takes effect on the next image build/deploy. Empty strings until then / on local runs (`version` unchanged).