### PR TITLE
feature/TERMX-166

### DIFF
--- a/modeler/src/main/java/org/termx/modeler/ApiError.java
+++ b/modeler/src/main/java/org/termx/modeler/ApiError.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 public enum ApiError {
   MO101("MO101", "FHIR object is not accessible by the URL. Please validate URL(s)."),
-  MO102("MO102", "StructureDefinition is missing or invalid."),
+  MO102("MO102", "StructureDefinition could not be resolved."),
   ;
 
   private String code;

--- a/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformerService.java
+++ b/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformerService.java
@@ -148,7 +148,7 @@ public class TransformerService {
     } catch (IOException | FHIRException e) {
       if (e instanceof FHIRException err && err.getCause() instanceof NullPointerException) {
         // fixme: is there better way to detect 'StructureDefinition.getSnapshot()" because "sd" is null' error
-        return new TransformationResult().setError("Transformation error: " + ApiError.MO102.getMessage());
+        return new TransformationResult().setError("Transformation error: " + ApiError.MO102.getMessage() + " " + e.getMessage() + ".");
       }
       return new TransformationResult().setError("Transformation error: " + e.getMessage());
     }

--- a/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformerService.java
+++ b/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformerService.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -155,6 +156,8 @@ public class TransformerService {
         return new TransformationResult().setError("Transformation error: " + ApiError.MO102.getMessage() + " " + e.getMessage() + ".");
       }
       return new TransformationResult().setError("Transformation error: " + e.getMessage());
+    } catch (NoSuchElementException e) {
+      return new TransformationResult().setError("Transformation error: " + e.getMessage());
     }
   }
 
@@ -194,7 +197,9 @@ public class TransformerService {
     // this should not be needed. ValidationEngine#getSourceResourceFromStructureMap searches for definition by alias, however alias is nullable. workaround.
     sm.getStructure().stream().filter(s -> s.getAlias() == null)
         .forEach(s -> s.setAlias(eng.getContext().listStructures().stream()
-            .filter(sd -> sd.getUrl().equals(s.getUrl())).findFirst().orElseThrow().getName()));
+            .filter(sd -> sd.getUrl().equals(s.getUrl())).findFirst()
+            .orElseThrow(() -> new NoSuchElementException("StructureDefinition '" + s.getUrl() + "' was not found."))
+            .getName()));
 
     //fix snapshots?
     ContextUtilities cu = new ContextUtilities(eng.getContext());
@@ -217,7 +222,8 @@ public class TransformerService {
       case url -> queryResource(res.getReference().getResourceUrl(), res.getReference().getResourceServerId());
       case local -> switch (res.getType()) {
         case definition -> {
-          var sd = structureDefinitionService.load(Long.valueOf(res.getReference().getLocalId())).orElseThrow();
+          var sd = structureDefinitionService.load(Long.valueOf(res.getReference().getLocalId()))
+                  .orElseThrow(() -> new NoSuchElementException("StructureDefinition '" + res.getName() + "' was not found."));
           if ("fsh".equals(sd.getContentFormat())) {
             yield fshConverter.orElseThrow().toFhir(sd.getContent()).join();
           }

--- a/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformerService.java
+++ b/modeler/src/main/java/org/termx/modeler/transformationdefinition/TransformerService.java
@@ -116,6 +116,10 @@ public class TransformerService {
   }
 
   public TransformationResult transform(String source, TransformationDefinition def) {
+    if (StringUtils.isBlank(source)) {
+      return new TransformationResult().setResult("");
+    }
+
     try {
       ValidationEngine eng = new ValidationEngine(getEngine());
 


### PR DESCRIPTION
Improve FML transformation development DX by providing more informative error messages on executing transformations.

Internal server error fixed when running transformation with 'null' in input.

NoSuchElement pathways explicitly handled with an error message instead of generic 500 error.

Issue #166 