### PR TITLE
CS import: compare concept content in canonical order (follow-up to #176)

### DIFF
--- a/docs/features/codesystem-import.md
+++ b/docs/features/codesystem-import.md
@@ -80,8 +80,10 @@ reloaded from the database — only a genuine content change creates a version.
 - **By code, not id:** designation type is compared by its code (`designationType`), property by its
   name, association by `associationType|targetCode|orderNumber` — internal DB ids never enter the
   fingerprint (the import file only carries codes).
-- **Order is significant** (the file defines the order); designation/property/association lists are
-  compared in order, not as unordered sets.
+- **Canonical order** (not list order): the DB load order is not guaranteed (designations and
+  associations have no `ORDER BY`), so the lists are sorted before comparison — designations by
+  **language then text**, properties/associations by their identity — and the order a file happens to
+  list them in does not matter.
 - **Value normalization** (identical on both sides): decimal by value ignoring scale
   (`2.5` = `2.50`), integer (`5` = `"5"` = `5.0`), boolean (`true` = `"1"`), dateTime as a UTC
   instant (`java.util.Date` = epoch millis = `2026-06-08` = `…T00:00:00Z`), coding by `code|system`.

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/ConceptContentSignature.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/ConceptContentSignature.java
@@ -55,11 +55,14 @@ public final class ConceptContentSignature {
     }
     Map<Long, EntityProperty> props = propertiesById == null ? Map.of() : propertiesById;
 
-    // Order is significant and preserved (the import file defines the order). Identity uses CODES,
-    // never internal DB ids (the file only carries codes).
+    // Compared in a CANONICAL order, not the list order: the DB load order is not guaranteed
+    // (designations/associations have no ORDER BY), so relying on it would make unchanged concepts
+    // look changed. Designations are ordered by language then text; properties/associations by their
+    // identity. Identity uses CODES, never internal DB ids (the file only carries codes).
     List<String> designations = Optional.ofNullable(version.getDesignations()).orElse(List.of()).stream()
         .filter(d -> d != null && !PublicationStatus.retired.equals(d.getStatus()))
-        .map(d -> "D|" + designationTypeCode(d, props) + "|" + nz(d.getLanguage()) + "|" + bool(d.isPreferred()) + "|" + nz(trim(d.getName())))
+        .map(d -> "D|" + nz(d.getLanguage()) + "|" + nz(trim(d.getName())) + "|" + designationTypeCode(d, props) + "|" + bool(d.isPreferred()))
+        .sorted()
         .toList();
 
     List<String> properties = Optional.ofNullable(version.getPropertyValues()).orElse(List.of()).stream()
@@ -70,11 +73,13 @@ public final class ConceptContentSignature {
           String type = p != null ? p.getType() : pv.getEntityPropertyType();
           return "P|" + code + "|" + normalize(pv.getValue(), type);
         })
+        .sorted()
         .toList();
 
     List<String> associations = Optional.ofNullable(version.getAssociations()).orElse(List.of()).stream()
         .filter(Objects::nonNull)
         .map(a -> "A|" + nz(a.getAssociationType()) + "|" + nz(a.getTargetCode()) + "|" + (a.getOrderNumber() == null ? "" : a.getOrderNumber()))
+        .sorted()
         .toList();
 
     return "code=" + nz(trim(version.getCode()))

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/ConceptContentSignatureTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/ConceptContentSignatureTest.groovy
@@ -96,13 +96,13 @@ class ConceptContentSignatureTest extends Specification {
     ConceptContentSignature.sameContent(imported, stored, [:])
   }
 
-  def "reordering designations IS a change (order is significant)"() {
-    given:
+  def "reordering designations does NOT change the signature (canonical order by language, text)"() {
+    given: "same designations, different list order — DB load order is not guaranteed"
     def a = new CodeSystemEntityVersion().setCode("A").setDesignations([designation("Apple", "en"), designation("Apfel", "de")])
     def b = new CodeSystemEntityVersion().setCode("A").setDesignations([designation("Apfel", "de"), designation("Apple", "en")])
 
     expect:
-    !ConceptContentSignature.sameContent(a, b, [:])
+    ConceptContentSignature.sameContent(a, b, [:])
   }
 
   def "a real change is detected"() {


### PR DESCRIPTION
Follow-up to #176.

The content signature compared designations / properties / associations in **list order**, but the DB load order is **not guaranteed** — `DesignationRepository` and `CodeSystemAssociationRepository` have no `ORDER BY`. So a concept with ≥2 designations could load in a different order than the import produced, making an unchanged concept look changed → a new version would still be created (the churn the fix was meant to stop).

Fix: sort each list canonically before comparing — **designations by language then text**, properties/associations by their identity. The order a file happens to list them in no longer affects the comparison. (Done in the signature, so no repository/UI ordering changes.)

Test `reordering designations …` flipped to assert reordering does **not** change the signature. Doc §5 updated.