### PR TITLE
SNOMED delta: handle empty / non-forward delta instead of a raw crash

### DIFF
--- a/docs/features/large-terminology-import.md
+++ b/docs/features/large-terminology-import.md
@@ -21,6 +21,7 @@ It replaces the previous synchronous upload flow that buffered the entire archiv
 - Generic `/bob/objects` REST API for upload, list, get, patch, delete — built on `BobObjectService`. Per-container authz: `snomed` requires `snomed-ct.CodeSystem.*`, `loinc` requires `loinc.CodeSystem.*`, `wiki` keeps existing Wiki privileges. The UI consumes this directly.
 - *Stored archives* UI component — a new list view in the SNOMED and LOINC pages renders `GET /bob/objects?container={terminology}` with filters (edition, status, effective time), per-row *Trigger import* and *Delete* actions, and a top-of-page *Upload archive (no import)* button for seeding baselines.
 - All failures (Snowstorm unavailable, malformed archive, `delta-generator-tool` non-zero exit) land as `lorqueProcessService.fail(...)` with the underlying error in `result_text`, never as an HTTP 500 or a dropped connection.
+- **Empty / non-forward delta.** If the current archive is not newer than the baseline, the delta is empty and the upstream `delta-generator-tool` crashes (`ArrayIndexOutOfBoundsException` in `createArchive`). TermX guards this on both sides: `startDeltaCalculation` rejects the request up front when `current.effectiveTime <= baseline.effectiveTime` (a clear `IllegalArgumentException`), and `SnomedDeltaGeneratorRuntime` detects the tool's "Latest versions collected for 0 components" log and fails with an actionable message instead of the raw stack trace.
 
 ## Configuration
 

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
@@ -95,6 +95,18 @@ public class SnomedDeltaCalculateService {
     if (currentBranch != null && baselineBranch != null && !currentBranch.equals(baselineBranch)) {
       throw new IllegalArgumentException("Baseline branchPath (" + baselineBranch + ") differs from current (" + currentBranch + ")");
     }
+    // Fail fast on a non-forward delta. If the current edition is not newer than the baseline the
+    // delta is empty, and the upstream delta-generator crashes (ArrayIndexOutOfBounds) instead of
+    // producing an empty archive — so reject it here with a clear message rather than after a
+    // multi-minute subprocess run. effectiveTime is YYYYMMDD, so a lexical compare is chronological.
+    String currentEffectiveTime = metaString(current, "effectiveTime");
+    String baselineEffectiveTime = metaString(baseline, "effectiveTime");
+    if (currentEffectiveTime != null && baselineEffectiveTime != null
+        && currentEffectiveTime.compareTo(baselineEffectiveTime) <= 0) {
+      throw new IllegalArgumentException("Current edition effectiveTime (" + currentEffectiveTime
+          + ") is not newer than the baseline (" + baselineEffectiveTime + "); the delta would be empty. "
+          + "Select a newer edition as the current archive.");
+    }
     // The Stored archives card filters by JSONB containment on {shortName, branchPath}, so
     // the delta has to carry both keys or it disappears from the card it should appear in.
     // Take shortName from the current archive (the new state, which has the meta tags

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaGeneratorRuntime.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaGeneratorRuntime.java
@@ -54,6 +54,7 @@ public class SnomedDeltaGeneratorRuntime {
   private static final String XMS = "-Xms1G";
 
   private static final Pattern ROWS_EXPORTED = Pattern.compile("Rows exported:\\s*(\\d+)");
+  private static final Pattern LATEST_COMPONENTS = Pattern.compile("Latest versions collected for\\s*(\\d+)\\s*components");
 
   private Path extractedJar;
 
@@ -76,6 +77,20 @@ public class SnomedDeltaGeneratorRuntime {
    * row count parsed from stdout, and the trailing log lines for surfacing in Lorque result
    * text.</p>
    */
+  /**
+   * The upstream tool throws {@code ArrayIndexOutOfBoundsException} in {@code createArchive} (instead
+   * of writing an empty archive) when it finds no changed components — i.e. the current archive has
+   * nothing newer than the baseline. Detect that from its "Latest versions collected for 0 components"
+   * line so we can fail with an actionable message instead of the raw stack trace.
+   */
+  static boolean isEmptyDelta(String log) {
+    if (log == null) {
+      return false;
+    }
+    Matcher m = LATEST_COMPONENTS.matcher(log);
+    return m.find() && "0".equals(m.group(1));
+  }
+
   public Result run(Path oldZip, Path newZip, Path workDir, boolean latestState) throws IOException, InterruptedException {
     Path jar = (extractedJar != null) ? extractedJar : ensureJarExtracted();
 
@@ -115,6 +130,12 @@ public class SnomedDeltaGeneratorRuntime {
     SnomedDeltaGeneratorRuntime.log.info("delta-generator exit={} duration={}ms rowsExported={}", exitCode, duration, rowsExported);
 
     if (exitCode != 0) {
+      if (isEmptyDelta(log.toString())) {
+        throw new IOException("delta-generator produced an empty delta: the current archive has no "
+            + "components newer than the baseline, so there is nothing to import. This usually means the "
+            + "selected current edition is not newer than the baseline (same or earlier effectiveTime) — "
+            + "choose a newer edition as the current archive. Tool log tail:\n" + tail(log.toString(), 20));
+      }
       throw new IOException("delta-generator-tool exited with code " + exitCode
           + ". Last log lines:\n" + tail(log.toString(), 40));
     }

--- a/snomed/src/test/groovy/org/termx/snomed/integration/SnomedDeltaGeneratorRuntimeSpec.groovy
+++ b/snomed/src/test/groovy/org/termx/snomed/integration/SnomedDeltaGeneratorRuntimeSpec.groovy
@@ -1,0 +1,40 @@
+package org.termx.snomed.integration
+
+import spock.lang.Specification
+
+/**
+ * The upstream delta-generator-tool crashes with ArrayIndexOutOfBoundsException in createArchive when
+ * the current archive has no components newer than the baseline (an empty delta). We detect that from
+ * its log so the user gets an actionable message instead of the raw stack trace.
+ */
+class SnomedDeltaGeneratorRuntimeSpec extends Specification {
+
+  def "isEmptyDelta detects the upstream 0-component crash (the reported error)"() {
+    given: "the tail of the failing run reported by the user"
+    def log = """Previously seen effective times collected for 12404009 components
+First pass identifying latest state from /tmp/snomed-delta-1234/current.zip
+Latest versions collected for 0 components
+Extracting new rows from /tmp/snomed-delta-1234/current.zip
+Creating archive from /tmp/DeltaGeneratorTool9999
+Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0"""
+
+    expect:
+    SnomedDeltaGeneratorRuntime.isEmptyDelta(log)
+  }
+
+  def "isEmptyDelta is false for a real (non-empty) delta"() {
+    given:
+    def log = """Previously seen effective times collected for 12404009 components
+Latest versions collected for 15342 components
+Rows exported: 15342"""
+
+    expect: "the baseline's '...collected for 12404009 components' line must not trigger a false positive"
+    !SnomedDeltaGeneratorRuntime.isEmptyDelta(log)
+  }
+
+  def "isEmptyDelta is false when the marker line is absent or input is null"() {
+    expect:
+    !SnomedDeltaGeneratorRuntime.isEmptyDelta("some unrelated tool output")
+    !SnomedDeltaGeneratorRuntime.isEmptyDelta(null)
+  }
+}


### PR DESCRIPTION
## Reported error

A SNOMED delta calculation failed with:
```
Latest versions collected for 0 components
...
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
  at org.snomed.otf.delta.DeltaGeneratorTool.createArchive(DeltaGeneratorTool.java:255)
java.io.IOException: delta-generator-tool exited with code 1. Last log lines: …
```

## Root cause
The current archive had **no components newer than the baseline** → an **empty delta**. The IHTSDO `delta-generator-tool` doesn't write an empty archive; it crashes in `createArchive` with `ArrayIndexOutOfBoundsException`. TermX surfaced the raw stack trace in the Lorque process `result_text`.

## Fix (both sides)
- **Fail fast** in `SnomedDeltaCalculateService.startDeltaCalculation`: reject when `current.effectiveTime <= baseline.effectiveTime` (YYYYMMDD ⇒ lexical compare is chronological) with a clear `IllegalArgumentException`, before spooling archives / running the multi-minute subprocess.
- **Graceful failure** in `SnomedDeltaGeneratorRuntime`: on a non-zero exit, detect the tool's `Latest versions collected for 0 components` line and throw an actionable message ("the current archive has no components newer than the baseline … choose a newer edition") instead of the raw crash dump.

## Test
`SnomedDeltaGeneratorRuntimeSpec` — the reported log (empty delta → detected), a real delta (must **not** false-positive on the baseline's `…collected for 12404009 components` line), and absent/null input.

Doc note added to `large-terminology-import.md`.

## Note
This is most likely a **usage/data** condition (the selected current edition isn't newer than the baseline). The fix turns the cryptic crash into a clear message and prevents the wasted run; it does not change what a valid forward delta produces.