### PR TITLE
SNOMED delta: reject non-RF2 archives before running the delta tool

### DIFF
--- a/docs/features/deployment-configuration.md
+++ b/docs/features/deployment-configuration.md
@@ -284,6 +284,10 @@ credentials (`minio`/`minio123`).
   `micronaut.server.max-request-size` (default 1.5 GB) and the reverse-proxy body limit or uploads fail.
 - **OOM ⇒ container restart by design.** The image runs with `-XX:+ExitOnOutOfMemoryError` and dumps
   to `/app/logs`, so Docker's restart policy recovers it — size `JAVA_OPTS -Xmx` for your workload.
+  **Set a container memory limit** (`mem_limit` / `--memory`) at least as large as `-Xmx` plus
+  headroom: with no cap the JVM's effective ceiling is the host's physical RAM, so the heap can grow
+  well past `-Xmx` under heavy load (large Snowstorm RF2 imports running alongside FHIR CodeSystem
+  caching) before the flag trips. A cap makes the restart predictable and protects co-located services.
 - **Server listens on `:8200`** in the container; the dev script's `TERMX_SERVER_PORT` does not apply
   to the published image.
 

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
@@ -260,7 +260,22 @@ public class SnomedDeltaCalculateService {
     if (o.getStorage() == null || !SnomedBobContainerAuthorizer.CONTAINER.equals(o.getStorage().getContainer())) {
       throw new IllegalArgumentException("Archive '" + uuid + "' is not in the SNOMED container");
     }
+    // The delta-generator expects RF2 zips. Without this check a non-RF2 object in the SNOMED
+    // container (e.g. a JSON nomenclature file) reaches the tool, which then finds 0 components and
+    // crashes in createArchive. Reject it here with the offending filename/content-type.
+    if (!isRf2Archive(o.getStorage().getFilename(), o.getContentType())) {
+      throw new IllegalArgumentException("Archive '" + uuid + "' is not an RF2 zip (filename='"
+          + o.getStorage().getFilename() + "', contentType='" + o.getContentType()
+          + "'). The SNOMED delta requires RF2 .zip archives for both the baseline and the current edition.");
+    }
     return o;
+  }
+
+  /** An RF2 archive is a zip — accept when either the filename ends in .zip or the content-type says zip. */
+  static boolean isRf2Archive(String filename, String contentType) {
+    boolean zipName = filename != null && filename.toLowerCase().endsWith(".zip");
+    boolean zipType = contentType != null && contentType.toLowerCase().contains("zip");
+    return zipName || zipType;
   }
 
   private static String metaString(BobObject o, String key) {

--- a/snomed/src/test/groovy/org/termx/snomed/integration/SnomedDeltaCalculateServiceSpec.groovy
+++ b/snomed/src/test/groovy/org/termx/snomed/integration/SnomedDeltaCalculateServiceSpec.groovy
@@ -1,0 +1,28 @@
+package org.termx.snomed.integration
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * The SNOMED delta requires RF2 zips. A non-RF2 object in the SNOMED container (e.g. the JSON
+ * nomenclature file that triggered the reported crash) must be rejected before the delta-generator
+ * subprocess is spawned.
+ */
+class SnomedDeltaCalculateServiceSpec extends Specification {
+
+  @Unroll
+  def "isRf2Archive(#filename, #contentType) == #expected"() {
+    expect:
+    SnomedDeltaCalculateService.isRf2Archive(filename, contentType) == expected
+
+    where:
+    filename                                                       | contentType        || expected
+    "lt-lab-klt-nomenclature--1.0.6-PROD.json"                     | "application/json" || false   // the reported bug
+    "SnomedCT_InternationalRF2_PRODUCTION_20260501T120000Z.zip"    | "application/zip"  || true
+    "SnomedCT_Edition.ZIP"                                         | null               || true    // case-insensitive name
+    "no-extension-name"                                            | "application/zip"  || true    // content-type says zip
+    "archive.json"                                                 | null               || false
+    null                                                           | "application/json" || false
+    null                                                           | null               || false
+  }
+}


### PR DESCRIPTION
Follow-up to #182, addressing the **actual** root cause of the reported delta crash.

## Root cause
A **JSON nomenclature object** (`lt-lab-klt-nomenclature--1.0.6-PROD.json`, Bob UUID `5ef2d7bd`) was passed as the **current** RF2 archive. `requireSnomedArchive` validated only the *container*, not the content type, so the JSON reached the delta-generator — which processed the baseline RF2 fine (~12M components) but found **0** in the JSON, then crashed in `createArchive` (`ArrayIndexOutOfBoundsException`). Application-level bug: a JSON Bob UUID hit a code path expecting an RF2 zip, with no validation.

## Fix
- `requireSnomedArchive` now also requires the object to be an **RF2 zip** (filename ends `.zip`, or content-type is a zip), rejecting **both** current and baseline up front with a clear message naming the offending filename/content-type — before any subprocess runs.
- This complements the empty-delta detection in #182 (which stays as a backstop for a genuine same-edition/forward-empty delta).

## Test
`SnomedDeltaCalculateServiceSpec.isRf2Archive` — the exact reported `…nomenclature…json` → rejected, plus zip / case-insensitive / content-type-only / null cases.

## OOM (from the same report)
The OOM is expected behaviour (`-XX:+ExitOnOutOfMemoryError` → clean restart). The real gap is **no Docker memory cap** (`HostConfig.Memory=0`), so the JVM ceiling is host RAM and heap can exceed `-Xmx` under concurrent RF2-import + FHIR-cache load before the flag trips. Added a note to `deployment-configuration.md` recommending a container `mem_limit` ≥ `-Xmx` + headroom. No code change needed.