### PR TITLE
CS import: clean-version reconciles in place (no concept-version churn)

### DIFF
--- a/docs/features/codesystem-import.md
+++ b/docs/features/codesystem-import.md
@@ -27,7 +27,7 @@ FHIR resource) to persisted concepts and **entity versions**, the merge vs. repl
 |------|----|--------|
 | `activate` | version status = `active` | publish the version after import (requires `CS_MAINTAIN`) |
 | `retire` | — | retire the version after import |
-| `cleanRun` | "clean version" | wipe and recreate the whole version |
+| `cleanRun` | "clean version" | reconcile the version in place (reuse the row, hold unchanged concepts, retire concepts absent from the file) |
 | `cleanConceptRun` | "replace concepts" | **REPLACE** concept set (vs **MERGE**) |
 | `generateValueSet` | — | also generate a value set from the code system |
 | `spaceToAdd` | — | attach to a space/package |
@@ -70,13 +70,14 @@ FHIR resource) to persisted concepts and **entity versions**, the merge vs. repl
 6. `activate` the active versions, `retire` the retired ones, then `linkEntityVersions` to bind the
    versions to the code-system version; finally upsert associations.
 
-> **Clean-version vs merge.** The per-concept hold above only applies to a normal import. A
-> *clean-version* import (`cleanRun` / the "clean version" option — which the **FHIR import path
-> always uses**) first cancels and recreates the whole CS version (`saveCodeSystemVersion`), so the
-> per-concept lookup finds nothing and every concept necessarily gets a fresh version. Rebuilding the
-> version is the point of that mode; it is separate from the merge described here. (A non-clean
-> re-import into an already-*active* version is rejected with `TE104` — re-import targets a draft
-> version, or uses clean-version.)
+> **Clean-version reconciles in place.** A *clean-version* import (`cleanRun` / the "clean version"
+> option — which the **FHIR import path always uses**) **reuses the existing CS version row** instead
+> of cancelling and recreating it (`saveCodeSystemVersion`). So the per-concept hold above applies
+> here too: unchanged concepts keep their entity versions (no churn), changed concepts get a new
+> version, and concepts **absent from the import are retired** (`cancelOrRetireRedundantConcepts`) so
+> the version still ends up matching the file exactly. The only difference from a plain merge is that
+> retire-of-absent. (A non-clean re-import into an already-*active* version is still rejected with
+> `TE104`; clean-version is how you re-import a published edition.)
 
 ## 5. Content signature & version churn
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
@@ -100,7 +100,14 @@ public class CodeSystemImportService {
     saveCodeSystemVersion(codeSystemVersion, action.isCleanRun());
 
     List<EntityProperty> entityProperties = saveProperties(codeSystem.getProperties(), codeSystem.getId());
-    saveConcepts(prepareConcepts(codeSystem.getConcepts(), codeSystem.getBaseCodeSystem()), codeSystemVersion, entityProperties, action.isCleanConceptRun());
+    // Retire concepts absent from the import when reconciling the version to the file (clean-version)
+    // or explicitly replacing concepts. Use replace-mode version handling only for replace-concepts on
+    // a draft — clean-version reconciles the (reused) version in place with merge-mode handling, so a
+    // changed active concept gets one new version (and the old is unlinked), not a duplicate.
+    boolean retireRedundant = action.isCleanRun() || action.isCleanConceptRun();
+    boolean replaceConceptVersions = action.isCleanConceptRun() && !action.isCleanRun();
+    saveConcepts(prepareConcepts(codeSystem.getConcepts(), codeSystem.getBaseCodeSystem()), codeSystemVersion, entityProperties,
+        replaceConceptVersions, retireRedundant);
 
     if (action.isActivate()) {
       SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_MAINTAIN);
@@ -171,8 +178,11 @@ public class CodeSystemImportService {
     Optional<CodeSystemVersion> existingVersion = codeSystemVersionService.load(codeSystemVersion.getCodeSystem(), codeSystemVersion.getVersion());
 
     if (cleanRun && existingVersion.isPresent()) {
-      log.info("Cancelling existing code system version {}", codeSystemVersion.getVersion());
-      codeSystemVersionService.cancel(existingVersion.get().getId(), existingVersion.get().getCodeSystem());
+      // Reconcile in place: reuse the existing version row instead of cancelling and recreating it.
+      // Recreating gave every concept a brand-new entity version (churn); reusing lets saveConcepts
+      // hold the unchanged ones. Concepts absent from the import are retired by saveConcepts.
+      log.info("Reconciling existing code system version {} in place", codeSystemVersion.getVersion());
+      codeSystemVersion.setId(existingVersion.get().getId());
     } else if (existingVersion.isPresent() && !existingVersion.get().getStatus().equals(PublicationStatus.draft)) {
       throw ApiError.TE104.toApiException(Map.of("version", codeSystemVersion.getVersion()));
     }
@@ -202,7 +212,8 @@ public class CodeSystemImportService {
     return entityPropertyService.save(codeSystem, entityProperties);
   }
 
-  public void saveConcepts(List<Concept> concepts, CodeSystemVersion version, List<EntityProperty> entityProperties, boolean cleanRun) {
+  public void saveConcepts(List<Concept> concepts, CodeSystemVersion version, List<EntityProperty> entityProperties,
+                           boolean replaceConceptVersions, boolean retireRedundant) {
     SessionStore.require().checkPermitted(version.getCodeSystem(), Privilege.CS_WRITE);
 
     log.info("Creating '{}' concepts", concepts.size());
@@ -210,9 +221,11 @@ public class CodeSystemImportService {
     conceptService.batchSave(concepts, version.getCodeSystem());
     log.info("Concepts created (" + (System.currentTimeMillis() - start) / 1000 + " sec)");
 
-    // if we import in replace mode
-    if (cleanRun) {
-      log.info("Cleaning concepts");
+    // Reconcile the version to exactly the imported set: retire concepts that are no longer present
+    // (clean-version or replace-concepts). Held concepts keep their version; this only touches the
+    // ones absent from the import.
+    if (retireRedundant) {
+      log.info("Retiring concepts absent from the import");
       conceptService.cancelOrRetireRedundantConcepts(concepts, version);
     }
 
@@ -232,7 +245,7 @@ public class CodeSystemImportService {
     }
     Map<Long, EntityProperty> propertiesById = entityProperties.stream()
         .filter(p -> p.getId() != null).collect(Collectors.toMap(EntityProperty::getId, p -> p, (a, b) -> a));
-    holdUnchangedAndMerge(version, concepts, entityVersionMap, propertiesById, retiredConceptIds, cleanRun);
+    holdUnchangedAndMerge(version, concepts, entityVersionMap, propertiesById, retiredConceptIds, replaceConceptVersions);
     codeSystemEntityVersionService.batchSave(entityVersionMap, version.getCodeSystem());
     log.info("Concept versions created (" + (System.currentTimeMillis() - start) / 1000 + " sec)");
 

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/CodeSystemImportServiceMergeTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/CodeSystemImportServiceMergeTest.groovy
@@ -61,7 +61,7 @@ class CodeSystemImportServiceMergeTest extends Specification {
     def concept = concept(version(null, PublicationStatus.active, [designation("Apple")]))
 
     when:
-    service.saveConcepts([concept], csVersion(), [], false)
+    service.saveConcepts([concept], csVersion(), [], false, false)
 
     then:
     concept.versions.first().id == 999L
@@ -74,7 +74,7 @@ class CodeSystemImportServiceMergeTest extends Specification {
     def concept = concept(version(null, PublicationStatus.active, [designation("Apricot")]))
 
     when:
-    service.saveConcepts([concept], csVersion(), [], false)
+    service.saveConcepts([concept], csVersion(), [], false, false)
 
     then:
     concept.versions.first().id == null
@@ -87,7 +87,7 @@ class CodeSystemImportServiceMergeTest extends Specification {
     def concept = concept(version(null, PublicationStatus.active, [designation("Apple")]))
 
     when:
-    service.saveConcepts([concept], csVersion(), [], true)
+    service.saveConcepts([concept], csVersion(), [], true, true)
 
     then:
     concept.versions.first().id == 999L
@@ -100,7 +100,7 @@ class CodeSystemImportServiceMergeTest extends Specification {
     def concept = concept(version(null, PublicationStatus.active, [designation("Apricot")]))
 
     when:
-    service.saveConcepts([concept], csVersion(), [], true)
+    service.saveConcepts([concept], csVersion(), [], true, true)
 
     then:
     concept.versions.first().id == null
@@ -113,7 +113,7 @@ class CodeSystemImportServiceMergeTest extends Specification {
     def concept = concept(version(null, PublicationStatus.retired, [designation("Apple")]))
 
     when:
-    service.saveConcepts([concept], csVersion(), [], false)
+    service.saveConcepts([concept], csVersion(), [], false, false)
 
     then:
     concept.versions.first().id == null
@@ -126,7 +126,7 @@ class CodeSystemImportServiceMergeTest extends Specification {
     def concept = concept(version(null, PublicationStatus.retired, [designation("Apple")]))
 
     when:
-    service.saveConcepts([concept], csVersion(), [], false)
+    service.saveConcepts([concept], csVersion(), [], false, false)
 
     then:
     concept.versions.first().id == 999L

--- a/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/CodeSystemImportChurnTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/CodeSystemImportChurnTest.groovy
@@ -71,6 +71,38 @@ class CodeSystemImportChurnTest extends TermxIntegTest {
     versionIds(csId, "a").size() == 2
   }
 
+  def "CLEAN-VERSION re-import reconciles in place: unchanged held, removed concept retired"() {
+    given:
+    def json = readFixtureString("fhir/churn/cs.json")   // concepts a and b
+    def csId = "churn-cs-clean"
+    def jsonCs = json.replace('"id": "churn-cs"', '"id": "' + csId + '"').replace('/churn-cs"', '/' + csId + '"')
+
+    when: "first clean-version import (active)"
+    importService.importCodeSystem(domainCs(jsonCs), [], cleanAction())
+    def a0 = versionIds(csId, "a")
+    def b0 = versionIds(csId, "b")
+
+    then: "one active version per concept"
+    a0.size() == 1
+    b0.size() == 1
+
+    when: "the identical content is re-imported with clean-version"
+    importService.importCodeSystem(domainCs(jsonCs), [], cleanAction())
+
+    then: "the version is reconciled in place — the same concept versions are kept, no churn"
+    versionIds(csId, "a") == a0
+    versionIds(csId, "b") == b0
+
+    when: "concept 'b' is removed from the file and re-imported with clean-version"
+    def withoutB = domainCs(jsonCs)
+    withoutB.setConcepts(withoutB.getConcepts().findAll { it.code != "b" })
+    importService.importCodeSystem(withoutB, [], cleanAction())
+
+    then: "'a' is still held; 'b' is retired (no active version remains)"
+    versionIds(csId, "a") == a0
+    activeVersionIds(csId, "b").isEmpty()
+  }
+
   private org.termx.ts.codesystem.CodeSystem domainCs(String json) {
     def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
     return fhirMapper.fromFhirCodeSystem(fhir)
@@ -78,6 +110,10 @@ class CodeSystemImportChurnTest extends TermxIntegTest {
 
   private static CodeSystemImportAction mergeAction() {
     return new CodeSystemImportAction().setActivate(false).setCleanRun(false).setCleanConceptRun(false)
+  }
+
+  private static CodeSystemImportAction cleanAction() {
+    return new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false)
   }
 
   private Set<Long> versionIds(String csId, String code) {


### PR DESCRIPTION
Completes the concept-version churn fix for the **clean-version** path (the one the customer actually hits — FHIR import always runs clean, and so does file import with "clean version").

## Problem
Clean-version import **cancelled and recreated** the whole CS version (`saveCodeSystemVersion`). `saveConcepts` then ran against a fresh, empty version, so the per-concept hold (#176/#178) found nothing and **every concept got a new entity version — even unchanged ones**. The merge-path fix never reached this path.

## Fix — reconcile in place
- **`saveCodeSystemVersion`**: for `cleanRun`, **reuse the existing version row** (set its id) instead of cancel + recreate.
- **`saveConcepts`**: split the single flag into `replaceConceptVersions` (replace-mode concept handling) and `retireRedundant` (retire concepts absent from the file). Clean-version uses **merge-mode** handling — a changed *active* concept gets one new version with the old unlinked, not a duplicate — **plus** retire-of-absent, so the version still matches the file exactly.
- **`importCodeSystem`**: `retireRedundant = cleanRun || cleanConceptRun`; `replaceConceptVersions = cleanConceptRun && !cleanRun`.

Net: re-importing an unchanged edition with clean-version (or via FHIR) **no longer churns** concept versions; only changed concepts get a new version, removed ones are retired. The CS version row id/created date persist (in-place reconcile, not rebuild).

## Tests
- `CodeSystemImportChurnTest` — new clean-version case: identical re-import **holds all concept versions** (no churn), and a **removed concept is retired**. (Plus the existing merge case.)
- Merge unit tests updated to the two-flag signature.
- **Regression:** import unit suite (fileimporter / codesystem / fhir mapper) + the **FHIR round-trip** integration test (which now reconciles in place) all pass.

## Note
This changes clean-version semantics from "throw away the version and rebuild" to "reconcile the version in place." End state is identical (version = the file's concepts), but the version row and unchanged concept versions are now preserved. Verified harmless for references — ValueSets store concepts as JSONB, ConceptMaps store codes; nothing FKs the churning entity-version id.