### PR TITLE
Fix weekly checks 401 on GitHub Packages auth

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -10,6 +10,11 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     name: Tests, PMD, SpotBugs, OWASP
+
+    permissions:
+      packages: read
+      contents: read
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -26,3 +31,6 @@ jobs:
       - name: Run checks
         working-directory: .
         run: ./gradlew check pmdCheck spotbugsCheck dependencyCheckAggregate
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The [weekly checks job](https://github.com/termx-health/termx-server/actions/runs/27542628723) fails during dependency resolution:

```
Could not resolve com.kodality.kefhir:kefhir-core:R5.7
  > Received status code 401 from server: Unauthorized
```

`kefhir-core` is hosted on the `termx-health/kefhir` GitHub Packages Maven registry. The `maven.pkg.github.com` endpoint **always requires authentication, even for public packages** — anonymous requests return 401 before visibility is ever checked. The weekly job sent no token, so resolution failed before any check ran.

## Fix

Mirror what `build.yml` already does:
- Pass `GITHUB_ACTOR` / `GITHUB_TOKEN` into the Gradle step so it can authenticate (`build.gradle.kts` reads these for the kefhir repository credentials).
- Grant the job `packages: read` (read is sufficient here; `build.yml` needs `write` only because it pushes images).

No new secrets required — the default `GITHUB_TOKEN` is enough, since the package is public and only needs *a* valid token to pass the mandatory-auth gate.

## Validation

The workflow has `workflow_dispatch`, so it can be triggered manually to confirm the green run after merge.