### PR TITLE
Sort resource versions by version-algorithm; backfill algorithm

### DIFF
--- a/modeler/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionService.java
+++ b/modeler/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionService.java
@@ -7,6 +7,7 @@ import org.termx.modeler.structuredefinition.StructureDefinitionVersion;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kodality.commons.model.QueryResult;
 import org.termx.core.utils.ObjectUtil;
+import org.termx.core.utils.VersionSortUtil;
 import jakarta.inject.Singleton;
 import java.util.List;
 import java.util.Optional;
@@ -47,7 +48,11 @@ public class StructureDefinitionService {
   }
 
   public List<StructureDefinitionVersion> listVersions(Long structureDefinitionId) {
-    return versionRepository.listByStructureDefinition(structureDefinitionId);
+    return VersionSortUtil.sortDescending(
+        versionRepository.listByStructureDefinition(structureDefinitionId),
+        StructureDefinitionVersion::getVersion,
+        StructureDefinitionVersion::getAlgorithm,
+        v -> v.getReleaseDate() == null ? null : v.getReleaseDate().toLocalDate());
   }
 
   public QueryResult<StructureDefinition> query(StructureDefinitionQueryParams params) {

--- a/modeler/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionVersionRepository.java
+++ b/modeler/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionVersionRepository.java
@@ -25,6 +25,7 @@ public class StructureDefinitionVersionRepository extends BaseRepository {
     ssb.property("content_format", v.getContentFormat());
     ssb.property("status", v.getStatus());
     ssb.property("release_date", v.getReleaseDate());
+    ssb.property("algorithm", v.getAlgorithm());
     ssb.jsonProperty("description", v.getDescription());
     SqlBuilder sb = ssb.buildSave("modeler.structure_definition_version", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());

--- a/modeler/src/main/resources/modeler/changelog/modeler/13-structure_definition_version_algorithm.sql
+++ b/modeler/src/main/resources/modeler/changelog/modeler/13-structure_definition_version_algorithm.sql
@@ -1,0 +1,19 @@
+--liquibase formatted sql
+
+--changeset termx:structure_definition_version-algorithm
+alter table modeler.structure_definition_version add column algorithm text;
+--rollback alter table modeler.structure_definition_version drop column algorithm;
+
+-- Infer the FHIR versionAlgorithm (http://hl7.org/fhir/ValueSet/version-algorithm) from the
+-- shape of each existing version string. Only fills rows where algorithm is still null, so it is
+-- safe to re-run and never overwrites an explicitly chosen algorithm.
+--changeset termx:structure_definition_version-algorithm-backfill
+update modeler.structure_definition_version
+   set algorithm = case
+     when version ~ '^[0-9]+$' then 'integer'
+     when version ~ '^[0-9]+\.[0-9]+(\.[0-9]+)?$' then 'semver'
+     when version ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}' then 'date'
+     else 'natural'
+   end
+ where algorithm is null and version is not null and sys_status = 'A';
+--rollback update modeler.structure_definition_version set algorithm = null;

--- a/modeler/src/main/resources/modeler/changelog/modeler/changelog.xml
+++ b/modeler/src/main/resources/modeler/changelog/modeler/changelog.xml
@@ -9,5 +9,6 @@
     <include file="10-structure_definition.sql" relativeToChangelogFile="true"/>
     <include file="11-structure_definition_versioning.sql" relativeToChangelogFile="true"/>
     <include file="12-structure_definition_content_reference.sql" relativeToChangelogFile="true"/>
+    <include file="13-structure_definition_version_algorithm.sql" relativeToChangelogFile="true"/>
     <include file="20-transformation_definition.sql" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemService.java
@@ -2,6 +2,7 @@ package org.termx.terminology.terminology.codesystem;
 
 import com.kodality.commons.model.QueryResult;
 import org.termx.core.fhir.BaseFhirMapper;
+import org.termx.core.utils.VersionSortUtil;
 import org.termx.terminology.ApiError;
 import org.termx.terminology.terminology.codesystem.concept.ConceptService;
 import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropertyService;
@@ -123,7 +124,9 @@ public class CodeSystemService {
     versionParams.setReleaseDateGe(params.getVersionReleaseDateGe());
     versionParams.setExpirationDateLe(params.getVersionExpirationDateLe());
     versionParams.all();
-    codeSystem.setVersions(codeSystemVersionService.query(versionParams).getData());
+    codeSystem.setVersions(VersionSortUtil.sortDescending(
+        codeSystemVersionService.query(versionParams).getData(),
+        CodeSystemVersion::getVersion, CodeSystemVersion::getAlgorithm, CodeSystemVersion::getReleaseDate));
   }
 
   @Transactional

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetService.java
@@ -3,6 +3,7 @@ package org.termx.terminology.terminology.mapset;
 import com.kodality.commons.model.QueryResult;
 import org.termx.terminology.ApiError;
 import org.termx.core.fhir.BaseFhirMapper;
+import org.termx.core.utils.VersionSortUtil;
 import org.termx.terminology.terminology.mapset.association.MapSetAssociationService;
 import org.termx.terminology.terminology.mapset.property.MapSetPropertyService;
 import org.termx.terminology.terminology.mapset.version.MapSetVersionService;
@@ -80,7 +81,9 @@ public class MapSetService {
       versionParams.setMapSet(mapSet.getId());
       versionParams.setVersion(params.getVersionVersion());
       versionParams.all();
-      mapSet.setVersions(mapSetVersionService.query(versionParams).getData());
+      mapSet.setVersions(VersionSortUtil.sortDescending(
+          mapSetVersionService.query(versionParams).getData(),
+          MapSetVersion::getVersion, MapSetVersion::getAlgorithm, MapSetVersion::getReleaseDate));
     }
     return mapSet;
   }

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetService.java
@@ -3,6 +3,7 @@ package org.termx.terminology.terminology.valueset;
 import com.kodality.commons.model.QueryResult;
 import org.termx.terminology.ApiError;
 import org.termx.core.fhir.BaseFhirMapper;
+import org.termx.core.utils.VersionSortUtil;
 import org.termx.terminology.terminology.valueset.ruleset.ValueSetVersionRuleService;
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.ts.valueset.ValueSet;
@@ -71,7 +72,9 @@ public class ValueSetService {
     ValueSetVersionQueryParams params = new ValueSetVersionQueryParams();
     params.setValueSet(valueSet.getId());
     params.all();
-    valueSet.setVersions(valueSetVersionService.query(params).getData());
+    valueSet.setVersions(VersionSortUtil.sortDescending(
+        valueSetVersionService.query(params).getData(),
+        ValueSetVersion::getVersion, ValueSetVersion::getAlgorithm, ValueSetVersion::getReleaseDate));
     return valueSet;
   }
 

--- a/terminology/src/main/resources/terminology/changelog/data/12-version-algorithm-backfill.sql
+++ b/terminology/src/main/resources/terminology/changelog/data/12-version-algorithm-backfill.sql
@@ -1,0 +1,43 @@
+--liquibase formatted sql
+
+-- Backfill the FHIR versionAlgorithm (http://hl7.org/fhir/ValueSet/version-algorithm) on existing
+-- CodeSystem / ValueSet / ConceptMap(MapSet) versions, inferred from the shape of the version
+-- string. Each statement only fills rows where algorithm is still null, so the changesets are
+-- safe to re-run and never overwrite an explicitly chosen algorithm.
+--   number(.number(.number))  -> semver
+--   digits only               -> integer
+--   yyyy-mm-dd…               -> date
+--   anything else             -> natural
+
+--changeset termx:code_system_version-algorithm-backfill
+update terminology.code_system_version
+   set algorithm = case
+     when version ~ '^[0-9]+$' then 'integer'
+     when version ~ '^[0-9]+\.[0-9]+(\.[0-9]+)?$' then 'semver'
+     when version ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}' then 'date'
+     else 'natural'
+   end
+ where algorithm is null and version is not null and sys_status = 'A';
+--rollback update terminology.code_system_version set algorithm = null;
+
+--changeset termx:value_set_version-algorithm-backfill
+update terminology.value_set_version
+   set algorithm = case
+     when version ~ '^[0-9]+$' then 'integer'
+     when version ~ '^[0-9]+\.[0-9]+(\.[0-9]+)?$' then 'semver'
+     when version ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}' then 'date'
+     else 'natural'
+   end
+ where algorithm is null and version is not null and sys_status = 'A';
+--rollback update terminology.value_set_version set algorithm = null;
+
+--changeset termx:map_set_version-algorithm-backfill
+update terminology.map_set_version
+   set algorithm = case
+     when version ~ '^[0-9]+$' then 'integer'
+     when version ~ '^[0-9]+\.[0-9]+(\.[0-9]+)?$' then 'semver'
+     when version ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}' then 'date'
+     else 'natural'
+   end
+ where algorithm is null and version is not null and sys_status = 'A';
+--rollback update terminology.map_set_version set algorithm = null;

--- a/terminology/src/main/resources/terminology/changelog/data/changelog.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/changelog.xml
@@ -12,6 +12,7 @@
   <include file="valueset/changelog-data-valueset.xml" relativeToChangelogFile="true"/>
 
   <include file="11-migration.sql" relativeToChangelogFile="true"/>
+  <include file="12-version-algorithm-backfill.sql" relativeToChangelogFile="true"/>
   <!--include file="12-migration.sql" relativeToChangelogFile="true"/-->
 
 

--- a/termx-api/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionVersion.java
+++ b/termx-api/src/main/java/org/termx/modeler/structuredefinition/StructureDefinitionVersion.java
@@ -21,4 +21,5 @@ public class StructureDefinitionVersion {
   private String status;
   private OffsetDateTime releaseDate;
   private LocalizedName description;
+  private String algorithm;
 }

--- a/termx-core/src/main/java/org/termx/core/utils/VersionSortUtil.java
+++ b/termx-core/src/main/java/org/termx/core/utils/VersionSortUtil.java
@@ -1,0 +1,171 @@
+package org.termx.core.utils;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Sorts a resource's versions newest-first, honouring the FHIR R5
+ * {@code versionAlgorithm} of each version (TermX stores it in the {@code algorithm} field).
+ *
+ * <p>Plain string ordering puts {@code "1.0.10"} <em>before</em> {@code "1.0.9"} (lexicographic),
+ * which is the bug this fixes. The algorithm codes come from
+ * {@code http://hl7.org/fhir/ValueSet/version-algorithm}:
+ * <ul>
+ *   <li>{@code semver} / {@code integer} / {@code natural} — natural-order comparison (numeric
+ *       runs compared as numbers), which orders dotted-numeric and integer versions correctly;</li>
+ *   <li>{@code date} — parsed as an ISO date when possible, otherwise natural order;</li>
+ *   <li>{@code alpha} — case-insensitive lexicographic;</li>
+ *   <li>blank/unknown — natural order (the safe general default).</li>
+ * </ul>
+ *
+ * <p>Primary key is the version string (descending); {@code releaseDate} (descending, nulls last)
+ * is the tie-breaker. Mixed-algorithm version lists fall back to natural order across the set so
+ * the comparison stays consistent and total.
+ */
+public final class VersionSortUtil {
+  private VersionSortUtil() {}
+
+  public static final String SEMVER = "semver";
+  public static final String INTEGER = "integer";
+  public static final String DATE = "date";
+  public static final String ALPHA = "alpha";
+  public static final String NATURAL = "natural";
+
+  /**
+   * Returns a new mutable list sorted newest-first. The input is not mutated; {@code null} yields
+   * an empty list. Pass accessors for the version string, the algorithm code, and the release date.
+   */
+  public static <T> List<T> sortDescending(List<T> versions,
+                                           Function<T, String> versionFn,
+                                           Function<T, String> algorithmFn,
+                                           Function<T, LocalDate> releaseDateFn) {
+    List<T> result = new ArrayList<>(versions == null ? List.of() : versions);
+    if (result.size() < 2) {
+      return result;
+    }
+    String algorithm = resolveCommonAlgorithm(result, algorithmFn);
+    Comparator<String> versionComparator = comparator(algorithm);
+    Comparator<T> byVersion = Comparator.comparing(versionFn, Comparator.nullsLast(versionComparator));
+    Comparator<T> byReleaseDate = Comparator.comparing(releaseDateFn, Comparator.nullsLast(Comparator.naturalOrder()));
+    // newest first: reverse both keys.
+    result.sort(byVersion.thenComparing(byReleaseDate).reversed());
+    return result;
+  }
+
+  /** A version-string comparator (ascending) for the given algorithm code. */
+  public static Comparator<String> comparator(String algorithm) {
+    String algo = algorithm == null ? "" : algorithm.trim().toLowerCase();
+    return switch (algo) {
+      case ALPHA -> String.CASE_INSENSITIVE_ORDER;
+      case DATE -> VersionSortUtil::compareDate;
+      // semver / integer / natural / unknown all sort correctly under natural order.
+      default -> VersionSortUtil::compareNatural;
+    };
+  }
+
+  /**
+   * When every version declares the same algorithm, use it. Otherwise (mixed or partial) fall back
+   * to natural order so the comparator stays consistent across the whole list.
+   */
+  private static <T> String resolveCommonAlgorithm(List<T> versions, Function<T, String> algorithmFn) {
+    String common = null;
+    for (T v : versions) {
+      String a = algorithmFn.apply(v);
+      a = a == null ? "" : a.trim().toLowerCase();
+      if (a.isEmpty()) {
+        return NATURAL;
+      }
+      if (common == null) {
+        common = a;
+      } else if (!common.equals(a)) {
+        return NATURAL;
+      }
+    }
+    return common == null ? NATURAL : common;
+  }
+
+  private static int compareDate(String a, String b) {
+    LocalDate da = tryParseDate(a);
+    LocalDate db = tryParseDate(b);
+    if (da != null && db != null) {
+      return da.compareTo(db);
+    }
+    if (da != null) {
+      return 1; // a parses, b doesn't — treat parseable as greater (newer-looking)
+    }
+    if (db != null) {
+      return -1;
+    }
+    return compareNatural(a, b);
+  }
+
+  private static LocalDate tryParseDate(String s) {
+    if (s == null || s.length() < 10) {
+      return null;
+    }
+    try {
+      return LocalDate.parse(s.substring(0, 10));
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /**
+   * Natural-order comparison: split each string into maximal digit and non-digit runs and compare
+   * run-by-run, numerically where both runs are digits. Numeric runs are compared by value (so
+   * {@code "9" < "10"}) with leading zeros broken by length as a last resort.
+   */
+  static int compareNatural(String a, String b) {
+    if (a == null || b == null) {
+      return a == null ? (b == null ? 0 : -1) : 1;
+    }
+    int i = 0;
+    int j = 0;
+    int lenA = a.length();
+    int lenB = b.length();
+    while (i < lenA && j < lenB) {
+      char ca = a.charAt(i);
+      char cb = b.charAt(j);
+      boolean da = Character.isDigit(ca);
+      boolean db = Character.isDigit(cb);
+      if (da && db) {
+        int startA = i;
+        int startB = j;
+        while (i < lenA && Character.isDigit(a.charAt(i))) {
+          i++;
+        }
+        while (j < lenB && Character.isDigit(b.charAt(j))) {
+          j++;
+        }
+        String numA = stripLeadingZeros(a.substring(startA, i));
+        String numB = stripLeadingZeros(b.substring(startB, j));
+        if (numA.length() != numB.length()) {
+          return numA.length() - numB.length();
+        }
+        int cmp = numA.compareTo(numB);
+        if (cmp != 0) {
+          return cmp;
+        }
+      } else {
+        int cmp = Character.compare(Character.toLowerCase(ca), Character.toLowerCase(cb));
+        if (cmp != 0) {
+          return cmp;
+        }
+        i++;
+        j++;
+      }
+    }
+    return (lenA - i) - (lenB - j);
+  }
+
+  private static String stripLeadingZeros(String num) {
+    int k = 0;
+    while (k < num.length() - 1 && num.charAt(k) == '0') {
+      k++;
+    }
+    return num.substring(k);
+  }
+}

--- a/termx-core/src/test/groovy/org/termx/core/utils/VersionSortUtilSpec.groovy
+++ b/termx-core/src/test/groovy/org/termx/core/utils/VersionSortUtilSpec.groovy
@@ -1,0 +1,99 @@
+package org.termx.core.utils
+
+import spock.lang.Specification
+import java.time.LocalDate
+import java.util.function.Function
+
+/**
+ * Covers {@link VersionSortUtil}, the algorithm-aware, newest-first version sorter applied when a
+ * resource returns its versions list. The headline case is the reported bug: "1.0.10" must sort
+ * ABOVE "1.0.9"/"1.0.8" (numeric), not below them (lexicographic).
+ */
+class VersionSortUtilSpec extends Specification {
+
+  static Function<Map, String> VERSION = { it.version } as Function
+  static Function<Map, String> ALGO = { it.algorithm } as Function
+  static Function<Map, LocalDate> RELEASE = { it.releaseDate } as Function
+
+  private static List<String> sortedVersions(List<Map> versions) {
+    return VersionSortUtil.sortDescending(versions, VERSION, ALGO, RELEASE).collect { it.version }
+  }
+
+  def "semver versions sort newest-first numerically (1.0.10 above 1.0.9)"() {
+    given:
+    def versions = [[version: '1.0.9', algorithm: 'semver'],
+                    [version: '1.0.10', algorithm: 'semver'],
+                    [version: '1.0.8', algorithm: 'semver']]
+
+    expect:
+    sortedVersions(versions) == ['1.0.10', '1.0.9', '1.0.8']
+  }
+
+  def "blank/unknown algorithm falls back to natural order (still numeric-aware)"() {
+    given:
+    def versions = [[version: '1.0.9', algorithm: null],
+                    [version: '1.0.10', algorithm: null],
+                    [version: '1.0.8', algorithm: '']]
+
+    expect:
+    sortedVersions(versions) == ['1.0.10', '1.0.9', '1.0.8']
+  }
+
+  def "integer algorithm orders numerically, not lexically"() {
+    given:
+    def versions = [[version: '2', algorithm: 'integer'],
+                    [version: '10', algorithm: 'integer'],
+                    [version: '9', algorithm: 'integer']]
+
+    expect:
+    sortedVersions(versions) == ['10', '9', '2']
+  }
+
+  def "date algorithm orders chronologically newest-first"() {
+    given:
+    def versions = [[version: '2026-01-05', algorithm: 'date'],
+                    [version: '2026-02-01', algorithm: 'date'],
+                    [version: '2025-12-31', algorithm: 'date']]
+
+    expect:
+    sortedVersions(versions) == ['2026-02-01', '2026-01-05', '2025-12-31']
+  }
+
+  def "alpha algorithm is case-insensitive lexicographic, newest-first"() {
+    given:
+    def versions = [[version: 'alpha', algorithm: 'alpha'],
+                    [version: 'Charlie', algorithm: 'alpha'],
+                    [version: 'bravo', algorithm: 'alpha']]
+
+    expect:
+    sortedVersions(versions) == ['Charlie', 'bravo', 'alpha']
+  }
+
+  def "mixed algorithms across the list fall back to a consistent natural order"() {
+    given:
+    def versions = [[version: '1.0.9', algorithm: 'semver'],
+                    [version: '1.0.10', algorithm: 'integer'],
+                    [version: '1.0.2', algorithm: 'date']]
+
+    expect:
+    sortedVersions(versions) == ['1.0.10', '1.0.9', '1.0.2']
+  }
+
+  def "release date breaks ties when version strings are equal, newest-first"() {
+    given:
+    def versions = [[version: '1.0.0', algorithm: 'semver', releaseDate: LocalDate.of(2025, 1, 1)],
+                    [version: '1.0.0', algorithm: 'semver', releaseDate: LocalDate.of(2026, 1, 1)]]
+
+    when:
+    def sorted = VersionSortUtil.sortDescending(versions, VERSION, ALGO, RELEASE)
+
+    then:
+    sorted*.releaseDate == [LocalDate.of(2026, 1, 1), LocalDate.of(2025, 1, 1)]
+  }
+
+  def "null and singleton lists are handled"() {
+    expect:
+    VersionSortUtil.sortDescending(null, VERSION, ALGO, RELEASE) == []
+    sortedVersions([[version: '1.0.0', algorithm: 'semver']]) == ['1.0.0']
+  }
+}


### PR DESCRIPTION
## Problem 2
Version lists rendered in the wrong order — e.g. `1.0.10` appeared *below* `1.0.9`/`1.0.8` because versions were ordered by a plain string comparison (lexicographic).

## What this does
- **`VersionSortUtil`** (new, `termx-core`): algorithm-aware, newest-first version sorter honouring the FHIR R5 `versionAlgorithm` (`semver` / `integer` / `date` / `alpha` / `natural`; blank or mixed falls back to natural order). Version string is the primary key, `releaseDate` the tie-breaker. Unit-tested (`VersionSortUtilSpec`).
- Applied where each resource attaches its versions list: `CodeSystemService`, `ValueSetService`, `MapSetService` decorate paths, and StructureDefinition `listVersions`.
- **StructureDefinition** versions gain an `algorithm` field end-to-end (domain, repository save, `modeler.structure_definition_version.algorithm` column) to match CodeSystem/ValueSet/MapSet, which already had it.
- **Liquibase data migration** backfills `algorithm` on existing CS/VS/MapSet/SD versions, inferred from the version-string shape (`number.number(.number)`→semver, digits→integer, `yyyy-mm-dd`→date, else natural). Guarded on `algorithm is null`, so it is safe to re-run.

The `version-algorithm` CodeSystem and `http://hl7.org/fhir/ValueSet/version-algorithm` ValueSet were already seeded — no new seed needed.

## Verification
- `VersionSortUtilSpec` passes (semver/integer/date/alpha/mixed/tie-break cases).
- `terminology` + `modeler` compile; an integration test boots cleanly, exercising both new Liquibase changesets.

## Notes / follow-ups
- FHIR `versionAlgorithm` round-trip for StructureDefinition (export) is not included; persistence + sorting are. CS/VS/ConceptMap already round-trip it.
- The companion termx-web change adds the algorithm select to the SD version form and stops the widgets from re-sorting client-side.