### PR TITLE
Clear first-party SpotBugs findings for weekly checks

### DIFF
--- a/bob/src/main/java/org/termx/bob/BobObjectController.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectController.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -44,6 +45,7 @@ import reactor.core.publisher.Mono;
  * left empty so the {@link org.termx.core.auth.AuthorizationFilter} allows authenticated
  * users past the static check, and the dynamic per-container authz runs inside each handler.</p>
  */
+@Slf4j
 @Singleton
 @Controller("/bob/objects")
 public class BobObjectController {
@@ -127,7 +129,9 @@ public class BobObjectController {
       if (!Boolean.TRUE.equals(ok)) {
         try {
           Files.deleteIfExists(temp);
-        } catch (IOException ignored) {}
+        } catch (IOException e) {
+          log.debug("Failed to delete temp upload file {}", temp, e);
+        }
         throw new RuntimeException("Failed to spool upload to disk");
       }
       try {
@@ -138,7 +142,9 @@ public class BobObjectController {
         SessionStore.clearLocal();
         try {
           Files.deleteIfExists(temp);
-        } catch (IOException ignored) {}
+        } catch (IOException e) {
+          log.debug("Failed to delete temp upload file {}", temp, e);
+        }
       }
     });
   }

--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -29,6 +29,7 @@
             <Class name="~.*SpaceGithubController\$.*"/>
             <Class name="~.*SpaceGithubDataWikiHandler\$.*"/>
             <Class name="~.*SpaceGithubDataWikiSsgHandler\$.*"/>
+            <Class name="~.*ClosureService\$ClosureDelta"/>
         </Or>
     </Match>
 
@@ -87,19 +88,44 @@
         <Bug pattern="BX_UNBOXING_IMMEDIATELY_REBOXED"/>
     </Match>
 
+    <!-- Suppress expose rep warnings for constructor-injected framework beans -->
+    <!-- These controllers/storages store Micronaut-injected @Singleton services; defensive copying a DI bean is meaningless -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Or>
+            <Class name="~.*BobObjectController"/>
+            <Class name="~.*CodeSystemResourceStorage"/>
+        </Or>
+    </Match>
+
+    <!-- Suppress boolean-return-null warning for the nullable tri-state JSON config reader -->
+    <!-- booleanValue() returns null to mean "field absent", mirroring its textValue()/stringList() siblings -->
+    <Match>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
+        <Class name="~.*TerminologyServerService"/>
+    </Match>
+
     <!-- Suppress expose rep warnings in test code (tests often need to manipulate data structures) -->
+    <!-- Covers JUnit (*Test), Spock specs (*Spec and their generated $_closure inner classes) and test-support fixtures -->
     <Match>
         <Or>
             <Bug pattern="EI_EXPOSE_REP"/>
             <Bug pattern="EI_EXPOSE_REP2"/>
         </Or>
-        <Class name="~.*Test.*"/>
+        <Or>
+            <Class name="~.*Test.*"/>
+            <Class name="~.*Spec(\$.*)?"/>
+            <Class name="~.*SchemaAssertingTerminologyCapabilityInitializer.*"/>
+        </Or>
     </Match>
 
     <!-- Suppress uncalled private method warnings in test classes (helper methods used by test frameworks) -->
     <Match>
         <Bug pattern="UPM_UNCALLED_PRIVATE_METHOD"/>
-        <Class name="~.*Test.*"/>
+        <Or>
+            <Class name="~.*Test.*"/>
+            <Class name="~.*Spec(\$.*)?"/>
+        </Or>
     </Match>
 
     <!-- Suppress nonnull field not initialized warnings for Lombok data classes (fields initialized via setters) -->

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedDeltaCalculateService.java
@@ -4,6 +4,7 @@ import com.kodality.commons.exception.NotFoundException;
 import com.kodality.commons.model.QueryResult;
 import com.kodality.commons.util.JsonUtil;
 import jakarta.inject.Singleton;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -302,7 +303,8 @@ public class SnomedDeltaCalculateService {
     }
     try (Stream<Path> s = Files.walk(dir)) {
       s.sorted(Comparator.reverseOrder()).forEach(SnomedDeltaCalculateService::deleteQuietly);
-    } catch (Exception ignored) {
+    } catch (IOException | RuntimeException ignored) {
+      // best-effort cleanup of a scratch tree; nothing actionable if it fails
     }
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -191,8 +191,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       cp.setCode(code);
       cp.setCodeSystem(csId);
       cp.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
-      QueryResult<Concept> queryResult = conceptService.query(cp);
-      Concept concept = queryResult == null ? null : queryResult.findFirst().orElse(null);
+      Concept concept = conceptService.query(cp).findFirst().orElse(null);
       if (concept != null && CollectionUtils.isNotEmpty(concept.getVersions())) {
         List<Designation> designations = concept.getVersions().getFirst().getDesignations();
         if (designations != null) {


### PR DESCRIPTION
## Context

Once the weekly-checks 401 was fixed ([#186](https://github.com/termx-health/termx-server/pull/186)), `spotbugsCheck` finally ran to completion and exposed a backlog that had been masked the whole time — **88 findings across ~21 module-tasks** on `main`. SpotBugs runs only in the weekly job (not in `check`/CI), so none of this gated normal PRs.

This PR clears all **17 first-party findings**. Vendored modules (`kodality-commons/*`, `zmei/*`, 71 findings) are intentionally left for a **separate follow-up** that will exclude vendored code from SpotBugs.

## Real code fixes
- **bob** `BobObjectController` — log the two best-effort temp-file cleanup failures (`log.debug`) instead of silently swallowing `IOException` (`DE_MIGHT_IGNORE`).
- **snomed** `SnomedDeltaCalculateService.deleteTreeQuietly` — narrow `catch (Exception)` → `catch (IOException | RuntimeException)` (`REC_CATCH_EXCEPTION`).
- **terminology** `ValueSetValidateCodeOperation.collectDesignations` — drop a redundant null-check on the non-null `ConceptService.query()` result (`RCN_REDUNDANT_NULLCHECK`).

## Documented suppressions (intentional patterns / framework false-positives)
Added to `config/spotbugs/exclude.xml`, consistent with the existing convention there:
- `EI_EXPOSE_REP2` on `BobObjectController` + `CodeSystemResourceStorage` — constructor-injected `@Singleton` beans; defensive-copying a DI dependency is meaningless.
- `EI_EXPOSE_REP`/`REP2` on the `ClosureDelta` **record** — internal output data holder.
- `NP_BOOLEAN_RETURN_NULL` on `TerminologyServerService.booleanValue` — intentional nullable tri-state JSON reader (mirrors its `textValue`/`stringList` siblings).
- Broadened the existing test-code EI/UPM suppressions to also match Spock `*Spec` classes (and their generated `$_closure` inner classes) plus the `SchemaAssertingTerminologyCapabilityInitializer` fixture.

## Verification
`./gradlew :bob:spotbugsMain :snomed:spotbugsMain :terminology:spotbugsMain :terminology:spotbugsTest :termx-core:spotbugsMain :termx-core:spotbugsTest :termx-integtest:spotbugsTest` → **BUILD SUCCESSFUL** locally.

## Remaining for the weekly job to go fully green
Follow-up PR: exclude vendored `kodality-commons`/`zmei` modules from SpotBugs (71 findings).