### PR TITLE
Resolve SpotBugs findings in vendored kodality-commons / zmei modules

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -117,4 +117,66 @@
         <Bug pattern="SBSC_USE_STRINGBUFFER_CONCATENATION"/>
     </Match>
 
+    <!-- ============================================================================ -->
+    <!-- Vendored modules: kodality-commons (com.kodality.commons.*) and zmei         -->
+    <!-- (com.kodality.zmei.*), plus the Apache Commons DbUtils code vendored into    -->
+    <!-- commons-db. These are borrowed library/model code; the genuine bugs (charset,-->
+    <!-- thread-safety, final fields, map iteration) are fixed in place, while the    -->
+    <!-- remaining findings below are either intentional patterns or false positives. -->
+    <!-- First-party code is org.termx.*, so these package-scoped matches never        -->
+    <!-- touch our own code.                                                          -->
+    <!-- ============================================================================ -->
+
+    <!-- Exposing internal representation on vendored Lombok data/model classes        -->
+    <!-- (QueryResult, Reference, Bundle, ApiException, CsvRecord, …) and the shared    -->
+    <!-- singleton ObjectMapper/Writer accessors (JsonUtil, FhirMapper). These rely on -->
+    <!-- direct field access / shared instances; defensive copies would change         -->
+    <!-- mutate-through semantics across the whole codebase or defeat the singletons.  -->
+    <Match>
+        <Or>
+            <Bug pattern="EI_EXPOSE_REP"/>
+            <Bug pattern="EI_EXPOSE_REP2"/>
+            <Bug pattern="MS_EXPOSE_REP"/>
+        </Or>
+        <Or>
+            <Class name="~com\.kodality\..*"/>
+            <Class name="~org\.apache\.commons\.dbutils\..*"/>
+        </Or>
+    </Match>
+
+    <!-- FHIR model class names are domain terms, not Java exceptions -->
+    <!-- e.g. Coverage.CoverageCostToBeneficiaryException is a FHIR backbone element -->
+    <Match>
+        <Bug pattern="NM_CLASS_NOT_EXCEPTION"/>
+        <Class name="~com\.kodality\.zmei\.fhir\..*"/>
+    </Match>
+
+    <!-- BaseBeanRepository intentionally mirrors the framework-injected jdbcTemplate -->
+    <!-- member of its superclass (see the NP_NULL_ON_SOME_PATH suppression above) -->
+    <Match>
+        <Or>
+            <Bug pattern="HSM_HIDING_METHOD"/>
+            <Bug pattern="MF_CLASS_MASKS_FIELD"/>
+        </Or>
+        <Class name="~.*BaseBeanRepository"/>
+    </Match>
+
+    <!-- Intentional static holders populated at bean construction (e.g. BeanContext -->
+    <!-- captures the Micronaut ApplicationContext; test deserializers seed statics) -->
+    <Match>
+        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>
+        <Class name="~com\.kodality\..*"/>
+    </Match>
+
+    <!-- Vendored test-only findings: instanceof assertions verifying polymorphic FHIR -->
+    <!-- deserialization, public test fixtures, and \n in test assertion messages -->
+    <Match>
+        <Or>
+            <Bug pattern="JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS"/>
+            <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+            <Bug pattern="VA_FORMAT_STRING_USES_NEWLINE"/>
+        </Or>
+        <Class name="~com\.kodality\..*"/>
+    </Match>
+
 </FindBugsFilter>

--- a/kodality-commons/commons-db/src/main/java/com/kodality/commons/db/bean/BeanProcessor.java
+++ b/kodality-commons/commons-db/src/main/java/com/kodality/commons/db/bean/BeanProcessor.java
@@ -95,8 +95,9 @@ public class BeanProcessor extends GenerousBeanProcessor {
   }
 
   private <T> void invokeRowProcessors(ResultSet rs, T bean) throws SQLException {
-    for (String property : rowProcessors.keySet()) {
-      RowProcessor processor = rowProcessors.get(property);
+    for (Map.Entry<String, RowProcessor> entry : rowProcessors.entrySet()) {
+      String property = entry.getKey();
+      RowProcessor processor = entry.getValue();
       Object data = processor.process(rs);
       if (data == null) {
         continue;

--- a/kodality-commons/commons-micronaut-drools/src/main/java/com/kodality/commons/drools/DroolsController.java
+++ b/kodality-commons/commons-micronaut-drools/src/main/java/com/kodality/commons/drools/DroolsController.java
@@ -5,6 +5,7 @@ import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.kie.api.builder.Message;
@@ -26,7 +27,7 @@ public class DroolsController {
   public DroolsExecuteResponse execute(@Body DroolsExecuteRequest request) {
     Class<?> objectClass = droolsConfiguration.getClassMappings().get(request.getRuleContext());
     Object fact = JsonUtil.fromJson(request.getInput(), objectClass);
-    droolsRunner.run(request.getRule().getBytes(), fact);
+    droolsRunner.run(request.getRule().getBytes(StandardCharsets.UTF_8), fact);
 
     DroolsExecuteResponse response = new DroolsExecuteResponse();
     response.setOutput(JsonUtil.toJson(fact));
@@ -35,6 +36,6 @@ public class DroolsController {
 
   @Post("/validate")
   public List<Message> validate(@Body DroolsValidateRequest request) {
-    return droolsRunner.validate(request.getRule().getBytes());
+    return droolsRunner.validate(request.getRule().getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/kodality-commons/commons-micronaut/src/main/java/com/kodality/commons/micronaut/rest/MultipartBodyReader.java
+++ b/kodality-commons/commons-micronaut/src/main/java/com/kodality/commons/micronaut/rest/MultipartBodyReader.java
@@ -3,6 +3,7 @@ package com.kodality.commons.micronaut.rest;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.server.netty.multipart.NettyCompletedAttribute;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Getter;
@@ -25,7 +26,7 @@ public class MultipartBodyReader {
           result.getAttachments().put(x.getName(), a);
         }
         if (part instanceof NettyCompletedAttribute) {
-          result.getTextParts().put(part.getName(), new String(part.getBytes()));
+          result.getTextParts().put(part.getName(), new String(part.getBytes(), StandardCharsets.UTF_8));
         }
       } catch (Exception e) {
         return Flux.error(e);

--- a/kodality-commons/commons-util/src/main/java/com/kodality/commons/util/JsonUtil.java
+++ b/kodality-commons/commons-util/src/main/java/com/kodality/commons/util/JsonUtil.java
@@ -57,7 +57,7 @@ public class JsonUtil {
     return mapper;
   }
 
-  public static ObjectWriter getPrettyWriter() {
+  public static synchronized ObjectWriter getPrettyWriter() {
     if (prettyWriter == null) {
       prettyWriter = getObjectMapper().writer().withDefaultPrettyPrinter();
     }

--- a/kodality-commons/commons-util/src/main/java/com/kodality/commons/util/RecurrenceUtil.java
+++ b/kodality-commons/commons-util/src/main/java/com/kodality/commons/util/RecurrenceUtil.java
@@ -14,8 +14,8 @@ import org.dmfs.rfc5545.recur.RecurrenceRule.Part;
 import org.dmfs.rfc5545.recur.RecurrenceRuleIterator;
 
 public class RecurrenceUtil {
-  public static String FREQ = "DAILY";
-  public static int INTERVAL = 1;
+  private static final String FREQ = "DAILY";
+  private static final int INTERVAL = 1;
 
   public static List<LocalDateTime> findRecurrenceDates(List<Integer> hours, LocalDateTime start, LocalDateTime end) {
     try {

--- a/zmei/zmei-fhir-jackson/src/main/java/com/kodality/zmei/fhir/FhirMapper.java
+++ b/zmei/zmei-fhir-jackson/src/main/java/com/kodality/zmei/fhir/FhirMapper.java
@@ -47,7 +47,7 @@ public final class FhirMapper {
     return mapper;
   }
 
-  public static ObjectWriter getPrettyWriter() {
+  public static synchronized ObjectWriter getPrettyWriter() {
     if (prettyWriter == null) {
       prettyWriter = getObjectMapper().writer().withDefaultPrettyPrinter();
     }

--- a/zmei/zmei-fhir/src/main/java/com/kodality/zmei/fhir/resource/other/Binary.java
+++ b/zmei/zmei-fhir/src/main/java/com/kodality/zmei/fhir/resource/other/Binary.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.kodality.zmei.fhir.datatypes.Reference;
 import com.kodality.zmei.fhir.resource.Resource;
 import com.kodality.zmei.fhir.resource.ResourceType;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,7 +38,7 @@ public class Binary extends Resource {
 
   @JsonIgnore
   public void setDataBytes(byte[] bytes) {
-    setData(new String(Base64.getEncoder().encode(bytes)));
+    setData(new String(Base64.getEncoder().encode(bytes), StandardCharsets.UTF_8));
   }
 
   @JsonIgnore
@@ -47,12 +48,12 @@ public class Binary extends Resource {
 
   @JsonIgnore
   public void setDataString(String data) {
-    setDataBytes(data.getBytes());
+    setDataBytes(data.getBytes(StandardCharsets.UTF_8));
   }
 
   @JsonIgnore
   public String getDataString() {
-    return new String(getDataBytes());
+    return new String(getDataBytes(), StandardCharsets.UTF_8);
   }
 
 


### PR DESCRIPTION
## Context

Second and final part of clearing the weekly `spotbugsCheck` backlog that surfaced once the 401 ([#186](https://github.com/termx-health/termx-server/pull/186)) was fixed. First-party findings are handled in [#189](https://github.com/termx-health/termx-server/pull/189); this PR covers the **vendored `kodality-commons` and `zmei` modules** (~57 findings).

These are vendored *source* subprojects (not binary deps), so the approach is **fix the genuine bugs in place, suppress only intentional patterns / false positives** — not switch SpotBugs off for them.

## Real code fixes
| Bug | Where | Fix |
|---|---|---|
| `DM_DEFAULT_ENCODING` ×4 | `Binary` (FHIR), `MultipartBodyReader`, `DroolsController` | pin `StandardCharsets.UTF_8` on String↔bytes |
| `LI_LAZY_INIT_STATIC` ×2 | `JsonUtil`, `FhirMapper` | `synchronized` the lazy `prettyWriter` accessor |
| `MS_SHOULD_BE_FINAL` ×2 | `RecurrenceUtil.FREQ/INTERVAL` | `private static final` |
| `WMI_WRONG_MAP_ITERATOR` | commons-db `BeanProcessor` | iterate `entrySet()` |

## Documented suppressions
Scoped to the vendored `com.kodality.*` / `org.apache.commons.dbutils.*` packages — verified there is **no first-party `com.kodality` code** (ours is `org.termx.*`), so these never touch our own code:
- `EI_EXPOSE_REP`/`REP2` + `MS_EXPOSE_REP` on Lombok data/model classes (`QueryResult`, `Reference`, `Bundle`, `ApiException`, `CsvRecord`, …) and the shared `ObjectMapper`/`Writer` singletons. Defensive copies here would change **mutate-through semantics across the whole server** (e.g. `queryResult.getData().add(x)`) or defeat the singletons — net-negative for a benign warning.
- `NM_CLASS_NOT_EXCEPTION` — FHIR model names like `Coverage.CoverageCostToBeneficiaryException` are domain terms, not Java exceptions.
- `HSM_HIDING_METHOD`/`MF_CLASS_MASKS_FIELD` on `BaseBeanRepository` (intentional framework `jdbcTemplate` mirroring); `ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD` on static context holders.
- Test-only patterns (`JUA_DONT_ASSERT_INSTANCEOF_IN_TESTS` — instanceof assertions that legitimately verify polymorphic FHIR deserialization, public test fixtures, `\n` in assertion messages).

## Verification
- All vendored `spotbugsMain`/`spotbugsTest` tasks → **BUILD SUCCESSFUL**.
- Tests for every module with a code change (`commons-util`, `commons-db`, `zmei-fhir`, `zmei-fhir-jackson`) → **pass**.

## Weekly job status
With **#189 + this PR** merged, `./gradlew check pmdCheck spotbugsCheck dependencyCheckAggregate` finally runs end-to-end with no failures. Merge order doesn't matter (both branch off `main`; both edit `exclude.xml` in different regions).