### PR TITLE
Fix terminology:test regression from SpotBugs RCN cleanup

### DIFF
--- a/config/spotbugs/exclude.xml
+++ b/config/spotbugs/exclude.xml
@@ -105,6 +105,14 @@
         <Class name="~.*TerminologyServerService"/>
     </Match>
 
+    <!-- Retain the defensive null-guard on conceptService.query() in collectDesignations. -->
+    <!-- query() is non-null in production, but the guard keeps the operation robust and lets -->
+    <!-- unit tests exercise display validation without stubbing the secondary concept lookup. -->
+    <Match>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+        <Class name="~.*ValueSetValidateCodeOperation"/>
+    </Match>
+
     <!-- Suppress expose rep warnings in test code (tests often need to manipulate data structures) -->
     <!-- Covers JUnit (*Test), Spock specs (*Spec and their generated $_closure inner classes) and test-support fixtures -->
     <Match>

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -191,7 +191,8 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       cp.setCode(code);
       cp.setCodeSystem(csId);
       cp.setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
-      Concept concept = conceptService.query(cp).findFirst().orElse(null);
+      QueryResult<Concept> queryResult = conceptService.query(cp);
+      Concept concept = queryResult == null ? null : queryResult.findFirst().orElse(null);
       if (concept != null && CollectionUtils.isNotEmpty(concept.getVersions())) {
         List<Designation> designations = concept.getVersions().getFirst().getDesignations();
         if (designations != null) {


### PR DESCRIPTION
## Problem

The weekly checks run on `main` after [#189](https://github.com/termx-health/termx-server/pull/189)+[#190](https://github.com/termx-health/termx-server/pull/190) merged ([run 27554834106](https://github.com/termx-health/termx-server/actions/runs/27554834106)) failed at `:terminology:test` — 5 NPEs in `ValueSetValidateCodeOperationTest`.

Cause: #189 removed the null-check on `conceptService.query()` in `ValueSetValidateCodeOperation.collectDesignations` as an `RCN_REDUNDANT_NULLCHECK` cleanup. `query()` *is* non-null in production, but the test uses `Mock(ConceptService)` and the 5 affected cases don't stub `query()` — an unstubbed Spock mock returns `null`, which the old guard absorbed and the simplified code dereferenced.

This was my own regression from #189, and my #189 verification ran the SpotBugs tasks but not `:terminology:test`, so it slipped through.

## Fix

Restore the defensive null-guard and suppress `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` for this class with a documented reason. A global `setup()` stub was rejected because one test (`accepts a display that matches a code system designation…`) deliberately stubs `query()` and Spock's "earliest interaction wins" rule let the `setup()` stub override it. Reverting the cleanup is the zero-behavioral-risk fix — it returns the operation to its pre-#189 behavior that all 7 tests expect.

## Verification (this time including the tests)
- `:terminology:test` → **BUILD SUCCESSFUL** (was 5 failures)
- `:terminology:spotbugsMain` → **BUILD SUCCESSFUL** (RCN suppressed)
- `:snomed:test`, `:termx-core:test` → pass (other #189-touched modules)

After merge, the weekly job should finally go green end-to-end.