### PR TITLE
Upgrade OWASP dependency-check to NVD API 2.0

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -28,9 +28,19 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      # Persist the OWASP dependency-check NVD database across runs so each weekly run
+      # only fetches incremental CVE updates instead of re-downloading the full feed.
+      - name: Cache NVD database
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: nvd-data-${{ github.run_id }}
+          restore-keys: nvd-data-
+
       - name: Run checks
         working-directory: .
         run: ./gradlew check pmdCheck spotbugsCheck dependencyCheckAggregate
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `maven-publish`
-    id("org.owasp.dependencycheck") version "8.4.2"
+    id("org.owasp.dependencycheck") version "12.1.0"
     id("io.micronaut.minimal.library") version "4.6.2"
     id("io.micronaut.minimal.application") version "4.6.2"
     id("com.gradleup.shadow") version "9.3.2" apply false
@@ -10,6 +10,15 @@ plugins {
 
 group = "org.termx"
 version = file("VERSION").readText().trim()
+
+// OWASP dependency-check: NIST retired the legacy NVD v1.1 JSON data feeds (they now return 403),
+// so this runs against the NVD API 2.0. An NVD API key (the NVD_API_KEY secret, optional locally)
+// lifts the strict anonymous rate limit; CI also caches the downloaded CVE database between runs.
+dependencyCheck {
+    nvd {
+        apiKey = System.getenv("NVD_API_KEY")
+    }
+}
 
 allprojects {
     apply(plugin = "java-library")


### PR DESCRIPTION
## Problem

With the 401 ([#186](https://github.com/termx-health/termx-server/pull/186)), SpotBugs ([#189](https://github.com/termx-health/termx-server/pull/189)/[#190](https://github.com/termx-health/termx-server/pull/190)) and the test regression ([#191](https://github.com/termx-health/termx-server/pull/191)) all fixed, the weekly job now runs the full suite and reaches its final task — `:dependencyCheckAggregate` — which fails:

```
Error retrieving https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.meta; received response code 403; Forbidden
> Task :dependencyCheckAggregate FAILED  →  Analysis failed.
```

This is **not a code issue**: NIST retired the legacy NVD v1.1 JSON data feeds, and OWASP dependency-check **8.4.2** still pulls from them. The scan can't fetch CVE data, so it can't run. (It was never reached before because earlier failures killed the build upstream.)

## Fix

- Upgrade `org.owasp.dependencycheck` **8.4.2 → 12.1.0**, which uses the **NVD API 2.0**.
- Configure an **NVD API key** via the `NVD_API_KEY` env var (lifts the strict anonymous rate limit that otherwise makes the full CVE download time out in CI).
- Cache `~/.gradle/dependency-check-data` in the workflow so each run only fetches incremental CVE updates.

`failBuildOnCVSS` is left at the plugin default (11), so the scan reports vulnerabilities without failing the build — i.e. once data loads, the task passes.

## ⚠️ Required before this goes green — repo secret

This needs a free NVD API key added as a repository secret named **`NVD_API_KEY`**:
1. Request one at https://nvd.nist.gov/developers/request-an-api-key (instant email).
2. Add it: repo **Settings → Secrets and variables → Actions → New repository secret**, name `NVD_API_KEY`.

(The build also runs without the key — just slower and rate-limited — but CI reliability needs it.)

## Verification
- `./gradlew dependencyCheckAggregate --dry-run` → plugin 12.1.0 + the `nvd { apiKey }` DSL configure cleanly across all modules.
- Full run requires the `NVD_API_KEY` secret; can't be exercised locally without a key.

## After merge
Add the secret, then dispatch the weekly workflow — with #186/#189/#190/#191 + this, `check pmdCheck spotbugsCheck dependencyCheckAggregate` should finally pass end-to-end.