### PR TITLE
Make OWASP NVD update resilient to transient API failures

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -39,7 +39,25 @@ jobs:
 
       - name: Run checks
         working-directory: .
-        run: ./gradlew check pmdCheck spotbugsCheck dependencyCheckAggregate
+        run: ./gradlew check pmdCheck spotbugsCheck
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # OWASP dependency-check is isolated and retried: the NVD API intermittently fails the
+      # bulk CVE download, and a transient hiccup shouldn't sink an otherwise-passing run.
+      - name: OWASP dependency-check
+        working-directory: .
+        run: |
+          for attempt in 1 2 3; do
+            echo "::group::dependencyCheckAggregate attempt $attempt"
+            ./gradlew dependencyCheckAggregate && { echo "::endgroup::"; exit 0; }
+            echo "::endgroup::"
+            echo "attempt $attempt failed; retrying after backoff"
+            sleep 60
+          done
+          echo "dependencyCheckAggregate failed after 3 attempts"
+          exit 1
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,11 @@ version = file("VERSION").readText().trim()
 dependencyCheck {
     nvd {
         apiKey = System.getenv("NVD_API_KEY")
+        // The NVD API intermittently returns empty/error responses on the bulk download, which
+        // otherwise aborts the build (NvdCveClient NPE). Pace the calls and retry to ride it out;
+        // once the cached DB is seeded, later runs only fetch small incremental updates.
+        delay = 4000
+        maxRetryCount = 30
     }
 }
 


### PR DESCRIPTION
## Problem

After [#192](https://github.com/termx-health/termx-server/pull/192) (NVD API 2.0 + key), the first weekly run got deep into the CVE download but crashed mid-stream:

```
Caused by: java.lang.NullPointerException: Cannot read the array length because "bytes" is null
    at io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient._next(NvdCveClient.java:418)
> Task :dependencyCheckAggregate FAILED → Analysis failed.
```

The API key works (no 403). This is the NVD API's known intermittent flakiness — NIST returns an empty/error body on the bulk feed and the NVD client NPEs instead of recovering. It's transient, not a config error.

## Fix

- **Plugin-level:** pace NVD API calls (`delay = 4000`ms) and raise `maxRetryCount` to 30 so transient hiccups are retried.
- **Workflow-level:** split OWASP into its own step wrapped in a 3-attempt retry loop, so a flaky NVD download doesn't sink an otherwise-green run — and a retry doesn't re-run the whole test/PMD/SpotBugs suite. `check pmdCheck spotbugsCheck` stays a separate, deterministic step.
- Combined with the NVD DB cache from #192: once any run seeds the DB, later runs only do small incremental updates and rarely touch this failure mode.

## Verification
- `./gradlew dependencyCheckAggregate --dry-run` → `delay`/`maxRetryCount` DSL configures cleanly.
- Real end-to-end confirmation is the dispatched weekly run after merge.