### PR TITLE
Make OWASP dependency-check advisory (decouple from NVD API flakiness)

### DIFF
--- a/.github/workflows/weekly-checks.yml
+++ b/.github/workflows/weekly-checks.yml
@@ -28,15 +28,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
-      # Persist the OWASP dependency-check NVD database across runs so each weekly run
-      # only fetches incremental CVE updates instead of re-downloading the full feed.
-      - name: Cache NVD database
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/dependency-check-data
-          key: nvd-data-${{ github.run_id }}
-          restore-keys: nvd-data-
-
       - name: Run checks
         working-directory: .
         run: ./gradlew check pmdCheck spotbugsCheck
@@ -44,21 +35,35 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # OWASP dependency-check is isolated and retried: the NVD API intermittently fails the
-      # bulk CVE download, and a transient hiccup shouldn't sink an otherwise-passing run.
+      # Restore a previously-good OWASP NVD database so a run only fetches incremental CVE
+      # updates. The "v2-" key prefix deliberately ignores older caches that may hold a
+      # partial DB from a failed download; we only save a fresh cache on success below.
+      - name: Restore NVD database
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: nvd-data-v2-${{ github.run_id }}
+          restore-keys: nvd-data-v2-
+
+      # OWASP dependency-check is advisory: the NVD API 2.0 intermittently returns bad
+      # responses that crash the bulk download (a known NvdCveClient bug), and a NIST
+      # outage must not turn an otherwise-green weekly run red. The scan still runs and
+      # reports whenever NVD cooperates.
       - name: OWASP dependency-check
+        id: owasp
+        continue-on-error: true
         working-directory: .
-        run: |
-          for attempt in 1 2 3; do
-            echo "::group::dependencyCheckAggregate attempt $attempt"
-            ./gradlew dependencyCheckAggregate && { echo "::endgroup::"; exit 0; }
-            echo "::endgroup::"
-            echo "attempt $attempt failed; retrying after backoff"
-            sleep 60
-          done
-          echo "dependencyCheckAggregate failed after 3 attempts"
-          exit 1
+        run: ./gradlew dependencyCheckAggregate
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+
+      # Only persist the NVD database when the scan actually succeeded, so a partial/corrupt
+      # DB from a failed download is never cached and cannot poison later runs.
+      - name: Save NVD database
+        if: steps.owasp.outcome == 'success'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: nvd-data-v2-${{ github.run_id }}


### PR DESCRIPTION
## Problem

After [#192](https://github.com/termx-health/termx-server/pull/192)/[#193](https://github.com/termx-health/termx-server/pull/193), the NVD API key works (no 403), but `dependencyCheckAggregate` still fails — now in ~15s per attempt — with a deterministic crash:

```
Caused by: java.lang.NullPointerException: Cannot read the array length because "bytes" is null
    at io.github.jeremylong.openvulnerability.client.nvd.NvdCveClient._next(NvdCveClient.java:418)
```

The NVD API 2.0 returns an empty/bad response body that the bundled client crashes on (known `open-vulnerability-client` bug). It's deterministic on a bad NVD response, so the `delay`/retry hardening from #193 can't help. Gating the weekly job on NIST API availability isn't right.

## Fix (chosen: advisory OWASP)

- `check pmdCheck spotbugsCheck` is the **blocking gate** (all green).
- `dependencyCheckAggregate` runs as a separate **`continue-on-error`** step — still scans and reports when NVD cooperates, but a NIST outage no longer reds the weekly job.
- NVD cache split into **restore + save-on-success** with a new **`nvd-data-v2-`** key, so partial/corrupt DBs from the earlier failed downloads are neither restored nor saved. The scan self-heals and caches a good DB on the next cooperative NVD run.

## Result
Weekly job goes green on tests/PMD/SpotBugs; OWASP shows as a soft-fail until NVD cooperates, then succeeds and seeds the cache.

## Follow-up options (not in this PR)
Track dependency CVEs via Dependabot/Renovate, or revisit a self-hosted NVD datafeed mirror if hard-blocking OWASP is wanted later.