### PR TITLE
Fix ConceptMap FHIR search/read timeout on empty associations

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
@@ -191,7 +191,12 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
   }
 
   private List<ConceptMapGroup> toFhirGroup(List<MapSetAssociation> associations, MapSetVersionScope scope, String preferredLanguage) {
-    if (associations == null) {
+    // No associations => no groups to emit. Bail out before buildDisplayMap(), which would otherwise
+    // load every concept in the scope's code systems / expand its value sets just to populate display
+    // lookups that are only ever read inside the per-association loop below. This is the lightweight
+    // (?_summary=true) path and the read path with associations skipped; both previously paid that cost
+    // for nothing and timed out on large-scope ConceptMaps.
+    if (associations == null || associations.isEmpty()) {
       return new ArrayList<>();
     }
     List<MapSetResourceReference> allCS = new ArrayList<>();


### PR DESCRIPTION
## Problem

`GET /api/fhir/ConceptMap?_summary=true` returns **504 after 120s** (nginx gateway timeout), while `?_summary=count` returns in ~0.15s. The summary query is supposed to be the *cheap* path, so this effectively makes the endpoint unusable for any non-count summary request — even `_count=1` times out.

## Root cause

`ConceptMapFhirMapper.toFhirGroup()` only short-circuited when the association list was `null`. But the lightweight summary path (`ConceptMapResourceStorage.search()`) and the association-skipped read path (`load()`) set associations to an **empty-but-non-null** `List.of()`. So execution fell through to:

```java
Map<String, String> sourceDisplays = buildDisplayMap(scope, true, preferredLanguage);
Map<String, String> targetDisplays = buildDisplayMap(scope, false, preferredLanguage);
```

`buildDisplayMap()` loads **every concept in the scope's source and target code systems** (`conceptService.query(...).all()`), or **fully expands the scope value sets**. Those display lookups are only ever read inside the per-association loop — which is empty here — so the work is entirely wasted. For a ConceptMap whose scope is a large code system, this unbounded per-entry load blows past the gateway timeout.

`?_summary=count` is fast because the framework never builds bundle entries, so `toFhir`/`toFhirGroup` is never invoked.

## Fix

Bail out of `toFhirGroup()` when associations are null **or** empty:

```java
if (associations == null || associations.isEmpty()) {
  return new ArrayList<>();
}
```

The emitted `group[]` was already empty in this case, so the change is behavior-preserving for the summary/lightweight responses and removes the wasted full-code-system load. Fixes both the search and read paths.

## Verification

- `./gradlew :terminology:compileJava` passes.

### Follow-up (not in this PR)
For **full-detail** (non-summary) reads, `buildDisplayMap` still does `.all()` over the entire code system to display only the mapped codes. Scoping that to the codes actually present in the associations (a `code IN (...)` lookup) would make detailed reads of large-scope maps fast too.