### PR TITLE
Support all FHIR ValueSet filter operators in expansion (#197)

### DIFF
--- a/snomed/src/main/java/org/termx/snomed/ApiError.java
+++ b/snomed/src/main/java/org/termx/snomed/ApiError.java
@@ -11,6 +11,7 @@ public enum ApiError {
   SN101("SN101", "Branch name is required"),
   SN102("SN102", "Branch name can contain only: A-Z charaters, numbers, slash and hyphen"),
   SN201("SN201", "Snowstorm rejected the import request: HTTP {{status}} ({{url}})"),
+  SN301("SN301", "ValueSet filter operator '{{operator}}' has no SNOMED CT (ECL) equivalent and is not supported for SNOMED expansion"),
   ;
 
   private String code;

--- a/snomed/src/main/java/org/termx/snomed/ts/SnomedValueSetExpandProvider.java
+++ b/snomed/src/main/java/org/termx/snomed/ts/SnomedValueSetExpandProvider.java
@@ -1,6 +1,7 @@
 package org.termx.snomed.ts;
 
 import com.kodality.commons.model.QueryResult;
+import org.termx.snomed.ApiError;
 import org.termx.core.ts.CodeSystemProvider;
 import org.termx.core.ts.ValueSetExternalExpandProvider;
 import org.termx.snomed.concept.SnomedConcept;
@@ -38,6 +39,8 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
   private static final String SNOMED = "snomed-ct";
   private static final String SNOMED_IS_A = "is-a";
   private static final String SNOMED_DESCENDENT_OF = "descendent-of";
+  private static final String SNOMED_CHILD_OF = "child-of";
+  private static final String SNOMED_GENERALIZES = "generalizes";
   private static final String SNOMED_IN = "in";
 
   // Snowstorm caps single-page `limit` at 10_000 (Elasticsearch from+size).
@@ -194,6 +197,9 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
   }
 
   private Designation findDisplay(List<SnomedDescription> snomedDescriptions, List<String> preferredLanguages) {
+    if (snomedDescriptions == null) {
+      return null;
+    }
     SnomedDescription description = snomedDescriptions.stream()
         .filter(d -> CollectionUtils.isEmpty(preferredLanguages) || d.getLang() != null && preferredLanguages.contains(d.getLang()))
         .sorted((d1, d2) -> Boolean.compare(!d1.getTypeId().equals("900000000000013009"), !d2.getTypeId().equals("900000000000013009")))
@@ -205,6 +211,9 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
   }
 
   private List<Designation> findDesignations(List<SnomedDescription> snomedDescriptions, List<String> supportedLanguages, String displayId) {
+    if (snomedDescriptions == null) {
+      return List.of();
+    }
     return snomedDescriptions.stream()
         .filter(d -> CollectionUtils.isEmpty(supportedLanguages) || d.getLang() != null && supportedLanguages.contains(d.getLang()))
         .filter(d -> !d.getDescriptionId().equals(displayId))
@@ -213,18 +222,19 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
   }
 
   private String composeEcl(ValueSetRuleFilter f) {
-    String ecl = "";
-    if (f.getOperator().equals(SNOMED_IS_A)) {
-      ecl += "<<";
-    }
-    if (f.getOperator().equals(SNOMED_DESCENDENT_OF)) {
-      ecl += "<";
-    }
-    if (f.getOperator().equals(SNOMED_IN)) {
-      ecl += "^";
-    }
-    ecl += f.getValue();
-    return ecl;
+    String operator = f.getOperator() == null ? "" : f.getOperator();
+    // Map the FHIR filter operator to its ECL constraint operator. Operators with no ECL
+    // equivalent (is-not-a, descendent-leaf, regex, =, in-on-property, not-in, exists) are rejected
+    // rather than silently emitting a bare, unconstrained value.
+    String prefix = switch (operator) {
+      case SNOMED_IS_A -> "<<";          // descendant-or-self
+      case SNOMED_DESCENDENT_OF -> "<";  // descendants
+      case SNOMED_CHILD_OF -> "<!";      // direct children
+      case SNOMED_GENERALIZES -> ">>";   // ancestor-or-self
+      case SNOMED_IN -> "^";             // members of the reference set
+      default -> throw ApiError.SN301.toApiException(Map.of("operator", operator));
+    };
+    return prefix + f.getValue();
   }
 
   private String getBranch(CodeSystemVersionReference codeSystemVersion) {

--- a/snomed/src/test/groovy/org/termx/snomed/ts/SnomedValueSetExpandProviderSpec.groovy
+++ b/snomed/src/test/groovy/org/termx/snomed/ts/SnomedValueSetExpandProviderSpec.groovy
@@ -1,0 +1,134 @@
+package org.termx.snomed.ts
+
+import org.termx.core.ts.CodeSystemProvider
+import com.kodality.commons.exception.ApiException
+import org.termx.snomed.concept.SnomedConcept
+import org.termx.snomed.concept.SnomedConceptSearchParams
+import org.termx.snomed.description.SnomedDescription
+import org.termx.snomed.integration.SnomedService
+import org.termx.snomed.search.SnomedSearchResult
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+import spock.lang.Specification
+
+/**
+ * Filter-operator coverage for the SNOMED expansion path
+ * ({@link SnomedValueSetExpandProvider}). SNOMED value sets are not expanded in SQL — each filter
+ * is compiled to ECL and pushed down to Snowstorm. This spec mocks {@link SnomedService} and pins
+ * the ECL that each operator compiles to, so the operator→ECL contract is regression-guarded
+ * without a live Snowstorm.
+ *
+ * <p>Supported operators and their ECL (see {@code SnomedValueSetExpandProvider#composeEcl}):
+ * <ul>
+ *   <li>{@code is-a}          → {@code <<value}  (descendant-or-self)</li>
+ *   <li>{@code descendent-of} → {@code <value}   (descendants)</li>
+ *   <li>{@code child-of}      → {@code <!value}  (direct children)</li>
+ *   <li>{@code generalizes}   → {@code >>value}  (ancestor-or-self)</li>
+ *   <li>{@code in}            → {@code ^value}    (members of the reference set)</li>
+ * </ul>
+ * Operators with no ECL equivalent are rejected with {@code SN301} rather than silently emitting a
+ * bare value (issue #197).
+ */
+class SnomedValueSetExpandProviderSpec extends Specification {
+  SnomedService snomedService = Mock()
+  CodeSystemProvider codeSystemProvider = Mock()
+  SnomedValueSetExpandProvider provider
+
+  def setup() {
+    provider = new SnomedValueSetExpandProvider(new SnomedMapper(), snomedService, codeSystemProvider)
+  }
+
+  def "paged expansion compiles each supported operator to the expected ECL"() {
+    given:
+    def rule = ruleWith(filter(operator, "73211009"))
+
+    when:
+    provider.ruleExpandPaged(rule, new ValueSetVersion(), "en", null, 0, 10)
+
+    then: "exactly one Snowstorm page query, carrying the compiled ECL"
+    1 * snomedService.searchConceptsPage({ SnomedConceptSearchParams p -> p.ecl == expectedEcl }) >>
+        new SnomedSearchResult<SnomedConcept>().setItems([]).setTotal(0)
+
+    where:
+    operator        || expectedEcl
+    "is-a"          || "<<73211009"
+    "descendent-of" || "<73211009"
+    "child-of"      || "<!73211009"
+    "generalizes"   || ">>73211009"
+    "in"            || "^73211009"
+  }
+
+  def "the free-text filter and paging are pushed down to Snowstorm"() {
+    given:
+    def rule = ruleWith(filter("is-a", "73211009"))
+
+    when:
+    provider.ruleExpandPaged(rule, new ValueSetVersion(), "en", "diab", 20, 50)
+
+    then:
+    1 * snomedService.searchConceptsPage({ SnomedConceptSearchParams p ->
+      p.ecl == "<<73211009" && p.term == "diab" && p.offset == 20 && p.limit == 50
+    }) >> new SnomedSearchResult<SnomedConcept>().setItems([]).setTotal(0)
+  }
+
+  def "non-paged expansion compiles the ECL and maps the returned SNOMED concepts"() {
+    given:
+    def rule = ruleWith(filter("is-a", "73211009"))
+
+    when:
+    def result = provider.ruleExpand(rule, new ValueSetVersion(), "en")
+
+    then: "the full-result search is issued with the compiled ECL"
+    1 * snomedService.searchConcepts({ SnomedConceptSearchParams p -> p.ecl == "<<73211009" && p.all }) >>
+        [new SnomedConcept().setConceptId("73211009").setActive(true)]
+    1 * snomedService.loadDescriptions(_, ["73211009"]) >> [
+        new SnomedDescription().setConceptId("73211009").setDescriptionId("d1").setLang("en")
+            .setTerm("Diabetes mellitus").setTypeId("900000000000013009").setActive(true).setAcceptabilityMap([:])
+    ]
+
+    and: "the SNOMED conceptId surfaces as the expansion member code"
+    result*.concept*.code == ["73211009"]
+  }
+
+  def "an operator with no ECL equivalent is rejected instead of producing a bare value"() {
+    given:
+    def rule = ruleWith(filter(operator, "73211009"))
+
+    when:
+    provider.ruleExpandPaged(rule, new ValueSetVersion(), "en", null, 0, 10)
+
+    then: "no Snowstorm call is made; the request is rejected"
+    0 * snomedService.searchConceptsPage(_)
+    def e = thrown(ApiException)
+    e.message.contains("SN301") || e.issues*.code.contains("SN301")
+
+    where:
+    operator << ["is-not-a", "descendent-leaf", "regex", "=", "not-in", "exists"]
+  }
+
+  def "non-paged expansion tolerates a returned concept that has no descriptions"() {
+    given:
+    def rule = ruleWith(filter("is-a", "73211009"))
+
+    when:
+    def result = provider.ruleExpand(rule, new ValueSetVersion(), "en")
+
+    then: "loadDescriptions returns nothing for the concept — must not NPE"
+    1 * snomedService.searchConcepts(_) >> [new SnomedConcept().setConceptId("73211009").setActive(true)]
+    1 * snomedService.loadDescriptions(_, ["73211009"]) >> []
+    noExceptionThrown()
+    result*.concept*.code == ["73211009"]
+    result.first().display == null
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private static ValueSetVersionRule ruleWith(ValueSetRuleFilter filter) {
+    return new ValueSetVersionRule().setFilters([filter])
+  }
+
+  private static ValueSetRuleFilter filter(String operator, String value) {
+    return new ValueSetRuleFilter().setOperator(operator).setValue(value)
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/ApiError.java
+++ b/terminology/src/main/java/org/termx/terminology/ApiError.java
@@ -53,6 +53,7 @@ public enum ApiError {
   TE307("TE307", "Value set expansion failed."),
   TE308("TE308", "Rule concept line does not contain concept code information."),
   TE309("TE309", "Rule concepts contain duplicates: {{duplicates}}."),
+  TE310("TE310", "Unsupported value set rule filter operator: '{{operator}}'. Supported operators: {{supported}}."),
   TE401("TE401", "Version '{{version}}' of map set '{{mapSet}}' doesn't exist."),
   TE501("TE501", "Naming system '{{namingSystem}}' not found."),
   TE601("TE601", "Cannot convert units of different kinds."),

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ruleset/ValueSetVersionRuleService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ruleset/ValueSetVersionRuleService.java
@@ -2,6 +2,7 @@ package org.termx.terminology.terminology.valueset.ruleset;
 
 import com.kodality.commons.model.QueryResult;
 import org.termx.terminology.ApiError;
+import org.termx.ts.valueset.ValueSetRuleFilterOperator;
 import org.termx.ts.valueset.ValueSetVersionConcept;
 import org.termx.ts.valueset.ValueSetVersionRuleQueryParams;
 import org.termx.ts.valueset.ValueSetVersionRuleSet;
@@ -39,7 +40,10 @@ public class ValueSetVersionRuleService {
     repository.retain(rules, ruleSet.getId());
     if (rules != null) {
       Long rulSetId = ruleSet.getId();
-      rules.forEach(rule -> repository.save(rule, rulSetId));
+      rules.forEach(rule -> {
+        validate(rule);
+        repository.save(rule, rulSetId);
+      });
     }
   }
 
@@ -65,6 +69,15 @@ public class ValueSetVersionRuleService {
   }
 
   private void validate(ValueSetVersionRule rule) {
+    if (rule.getFilters() != null) {
+      rule.getFilters().stream()
+          .filter(f -> f != null && (f.getOperator() == null || !ValueSetRuleFilterOperator.ALL.contains(f.getOperator())))
+          .findFirst()
+          .ifPresent(f -> {
+            throw ApiError.TE310.toApiException(Map.of("operator", String.valueOf(f.getOperator()), "supported", String.join(", ", ValueSetRuleFilterOperator.ALL)));
+          });
+    }
+
     if (rule.getConcepts() != null) {
       boolean notDefined = rule.getConcepts().stream().anyMatch(c -> c.getConcept() == null || c.getConcept().getCode() == null);
       if (notDefined) {

--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -188,47 +188,110 @@ WITH recursive vs AS (
 --select * from rules where filters is null or filters::jsonb=('[]'::jsonb) -- (filter_ ->> 'property') = 'display'
 --
 , r as (
-  -- list of the all recursive values expressed with is-a operator
-  select csev.code_system "codeSystem", csa.source_code_system_entity_version_id csev_id, csev2.code, t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id
+  -- Forward hierarchy: direct children (level 1) of the filter value, then recurse downward.
+  -- Drives is-a / descendent-of / child-of / descendent-leaf / is-not-a, plus the legacy
+  -- `parent =` shorthand (kept as "all descendants, no self" for backwards compatibility).
+  select t."codeSystem", csa.source_code_system_entity_version_id csev_id, child.code,
+         t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id, t."codeSystemUri", t."baseCodeSystemUri",
+         (t.filter_ ->> 'op') operator, anchor.id parent, 1 as level
+    from t
+         inner join terminology.code_system_entity_version anchor
+                 on anchor.code_system = t."codeSystem" and anchor.sys_status = 'A'
+                and anchor.code = (t.filter_ ->> 'value')::text
+         inner join terminology.code_system_association csa
+                 on csa.association_type in ('is-a','part-of','child-of') and csa.sys_status = 'A'
+                and anchor.id = csa.target_code_system_entity_version_id
+         inner join terminology.code_system_entity_version child
+                 on child.id = csa.source_code_system_entity_version_id and child.sys_status = 'A'
+   where (t.filter_ ->> 'op') in ('is-a','descendent-of','child-of','descendent-leaf','is-not-a')
+      or ((t.filter_ ->> 'op') = '=' and (t.filter_ ->> 'property') = 'parent')
+   union
+  select r."codeSystem", csa1.source_code_system_entity_version_id csev_id, child.code,
+         r.rn, r.fcnt, r.rule_id, r.type, r.code_system_version_id, r."codeSystemUri", r."baseCodeSystemUri",
+         r.operator, r.csev_id parent, r.level + 1
+    from r
+         inner join terminology.code_system_association csa1
+                 on csa1.association_type in ('is-a','part-of','child-of') and csa1.sys_status = 'A'
+                and r.csev_id = csa1.target_code_system_entity_version_id
+         inner join terminology.code_system_entity_version child
+                 on child.id = csa1.source_code_system_entity_version_id and child.sys_status = 'A'
+   where r."codeSystem" = csa1.code_system
+)
+, rr as (
+  -- Reverse hierarchy: ancestors of the filter value, for the generalizes operator.
+  select t."codeSystem", csa.target_code_system_entity_version_id csev_id, parent.code,
+         t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id, t."codeSystemUri", t."baseCodeSystemUri"
+    from t
+         inner join terminology.code_system_entity_version anchor
+                 on anchor.code_system = t."codeSystem" and anchor.sys_status = 'A'
+                and anchor.code = (t.filter_ ->> 'value')::text
+         inner join terminology.code_system_association csa
+                 on csa.association_type in ('is-a','part-of','child-of') and csa.sys_status = 'A'
+                and anchor.id = csa.source_code_system_entity_version_id
+         inner join terminology.code_system_entity_version parent
+                 on parent.id = csa.target_code_system_entity_version_id and parent.sys_status = 'A'
+   where (t.filter_ ->> 'op') = 'generalizes'
+   union
+  select rr."codeSystem", csa1.target_code_system_entity_version_id csev_id, parent.code,
+         rr.rn, rr.fcnt, rr.rule_id, rr.type, rr.code_system_version_id, rr."codeSystemUri", rr."baseCodeSystemUri"
+    from rr
+         inner join terminology.code_system_association csa1
+                 on csa1.association_type in ('is-a','part-of','child-of') and csa1.sys_status = 'A'
+                and rr.csev_id = csa1.source_code_system_entity_version_id
+         inner join terminology.code_system_entity_version parent
+                 on parent.id = csa1.target_code_system_entity_version_id and parent.sys_status = 'A'
+   where rr."codeSystem" = csa1.code_system
+)
+, rc as (
+  -- The filter value concept itself ("self"), included for is-a / generalizes; carried for is-not-a
+  -- so it can be subtracted from the complement.
+  select t."codeSystem", anchor.id csev_id, anchor.code,
+         t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id, t."codeSystemUri", t."baseCodeSystemUri",
+         (t.filter_ ->> 'op') operator
+    from t
+         inner join terminology.code_system_entity_version anchor
+                 on anchor.code_system = t."codeSystem" and anchor.sys_status = 'A'
+                and anchor.code = (t.filter_ ->> 'value')::text
+   where (t.filter_ ->> 'op') in ('is-a','generalizes','is-not-a')
+)
+, pool as (
+  -- Every concept in the rule's code system version; the complement source for is-not-a.
+  select t."codeSystem", csev.id csev_id, csev.code,
+         t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id, t."codeSystemUri", t."baseCodeSystemUri"
     from t
          inner join terminology.code_system_entity_version csev
                  on csev.code_system = t."codeSystem" and csev.sys_status = 'A'
-                and csev.code = (t.filter_ ->> 'value')::text
-         inner join terminology.code_system_association csa
-                 on csa.association_type in ('is-a','part-of','child-of') and csa.sys_status = 'A'
-                and csev.id = csa.target_code_system_entity_version_id
-         left outer join terminology.entity_version_code_system_version_membership evcsvm
-                 on evcsvm.sys_status = 'A' and evcsvm.code_system_version_id = t.code_system_version_id
-                and csev.id = evcsvm.code_system_entity_version_id
-         inner join terminology.code_system_entity_version csev2 on csev2.id = csa.source_code_system_entity_version_id and csev2.sys_status = 'A'
-   where t.filter_ ->> 'op' in ('is-a','child-of','descendent-leaf') or (t.filter_ ->> 'op' = '=' and t.filter_ ->> 'property' = 'parent')
-   union
-  select r."codeSystem", csa1.source_code_system_entity_version_id csev_id, csev2.code, rn, fcnt, rule_id, type, code_system_version_id
-    from r, terminology.code_system_association csa1
-         inner join terminology.code_system_entity_version csev2 on csev2.id = csa1.source_code_system_entity_version_id and csev2.sys_status = 'A'
-   where r."codeSystem"=csa1.code_system
-     and r.csev_id = csa1.target_code_system_entity_version_id
-     and csa1.sys_status = 'A'
+         inner join terminology.entity_version_code_system_version_membership evcsvm
+                 on evcsvm.sys_status = 'A' and evcsvm.code_system_entity_version_id = csev.id
+                and evcsvm.code_system_version_id = t.code_system_version_id
+   where (t.filter_ ->> 'op') = 'is-not-a'
 )
 , c as (
-  select c.code, t.*, csev.id csev_id
+  select csev.id csev_id, con.code,
+         t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id, t."codeSystem", t."codeSystemUri", t."baseCodeSystemUri"
     from t
-         inner join terminology.concept c on c.code_system = t."codeSystem" and c.sys_status = 'A'
-         inner join terminology.code_system_entity_version csev on csev.code_system_entity_id = c.id and csev.sys_status = 'A'
+         inner join terminology.concept con on con.code_system = t."codeSystem" and con.sys_status = 'A'
+         inner join terminology.code_system_entity_version csev on csev.code_system_entity_id = con.id and csev.sys_status = 'A'
          inner join terminology.entity_version_code_system_version_membership evcsvm on evcsvm.sys_status = 'A'
                 and evcsvm.code_system_entity_version_id = csev.id and evcsvm.code_system_version_id = t.code_system_version_id
    where t.filter_ is not null and (
-         -- processing of the custom properties
-         ((t.filter_ ->> 'op') not in ('is-a','part-of','child-of','descendent-leaf') and
-          (t.filter_ ->> 'property') not in ('code', 'concept') and
+         -- code / concept column with '=', 'in', 'regex', 'not-in'
+         ((t.filter_ ->> 'property') in ('code', 'concept') and (t.filter_ ->> 'op') in ('=','in','regex','not-in') and (
+              (t.filter_ ->> 'op') = '='      and con.code = (t.filter_ ->> 'value')::text or
+              (t.filter_ ->> 'op') = 'regex'  and con.code = any(regexp_match(con.code, (t.filter_ ->> 'value')::text || '$')) or
+              (t.filter_ ->> 'op') = 'in'     and con.code = any(string_to_array((t.filter_ ->> 'value')::text, ',')) or
+              (t.filter_ ->> 'op') = 'not-in' and con.code != all(string_to_array((t.filter_ ->> 'value')::text, ','))
+         ))
+         or
+         -- custom property with '=', 'in', 'regex' (loose match preserved, incl. Coding-shaped values)
+         ((t.filter_ ->> 'property') not in ('code', 'concept') and (t.filter_ ->> 'op') in ('=','in','regex') and
           exists (select 1
                     from terminology.entity_property_value epv, terminology.entity_property ep,
                         unnest(string_to_array(t.filter_ ->> 'value', ',')) AS pattern1,
                         unnest(string_to_array(t.filter_ -> 'value' ->> 'code', ',')) AS pattern2
                   where epv.sys_status = 'A' and csev.id = epv.code_system_entity_version_id
-                    and ep.sys_status = 'A' and ep.code_system = c.code_system and ep.id = epv.entity_property_id
+                    and ep.sys_status = 'A' and ep.code_system = con.code_system and ep.id = epv.entity_property_id
                     and (t.filter_ ->> 'property') = ep.name
-                    -- include support for '=', 'in', 'regex' operators
                     and (
                          ep.type <> 'Coding' and ((t.filter_ ->> 'value') is null or (t.filter_ -> 'value') = epv.value::jsonb or
                          (epv.value ->> 'code')::text ~ trim(pattern1))
@@ -236,36 +299,88 @@ WITH recursive vs AS (
                          ep.type = 'Coding' and  ((t.filter_ -> 'value' ->> 'code') is null or (t.filter_ -> 'value' -> 'code') = epv.value::jsonb or
                          (epv.value ->> 'code')::text ~ trim(pattern2))
                     )
-                 )
-          ) or
-          -- processing of the code and cocept columns with '=', 'in', 'regex' operators
-          ((t.filter_ ->> 'property') in ('code', 'concept') and
-           (c.code = (t.filter_ ->> 'value')::text or
-            exists(select 1 from unnest(string_to_array(t.filter_ ->> 'value', ',')) AS pattern
-                    where c.code ~ trim(pattern) )
-          ))
+                 ))
+         or
+         -- custom property with 'exists' (value true => has >=1 value; value false => has none)
+         ((t.filter_ ->> 'property') not in ('code', 'concept') and (t.filter_ ->> 'op') = 'exists' and (
+              (t.filter_ ->> 'value')::text = 'true' and exists (
+                  select 1 from terminology.entity_property_value epv, terminology.entity_property ep
+                   where epv.sys_status = 'A' and csev.id = epv.code_system_entity_version_id
+                     and ep.sys_status = 'A' and ep.code_system = con.code_system and ep.id = epv.entity_property_id
+                     and (t.filter_ ->> 'property') = ep.name)
+              or
+              (t.filter_ ->> 'value')::text = 'false' and not exists (
+                  select 1 from terminology.entity_property_value epv, terminology.entity_property ep
+                   where epv.sys_status = 'A' and csev.id = epv.code_system_entity_version_id
+                     and ep.sys_status = 'A' and ep.code_system = con.code_system and ep.id = epv.entity_property_id
+                     and (t.filter_ ->> 'property') = ep.name)
+         ))
+         or
+         -- custom property with 'not-in' (the concept has no value of the property in the set)
+         ((t.filter_ ->> 'property') not in ('code', 'concept') and (t.filter_ ->> 'op') = 'not-in' and
+          not exists (select 1
+                        from terminology.entity_property_value epv, terminology.entity_property ep,
+                            unnest(string_to_array(t.filter_ ->> 'value', ',')) AS pattern1
+                       where epv.sys_status = 'A' and csev.id = epv.code_system_entity_version_id
+                         and ep.sys_status = 'A' and ep.code_system = con.code_system and ep.id = epv.entity_property_id
+                         and (t.filter_ ->> 'property') = ep.name
+                         and (epv.value::text = trim(pattern1) or (epv.value ->> 'code')::text = trim(pattern1))))
   )
 )
 , d as (
-  select c.code, t.*, csev.id csev_id
+  select csev.id csev_id, con.code,
+         t.rn, t.fcnt, t.rule_id, t.type, t.code_system_version_id, t."codeSystem", t."codeSystemUri", t."baseCodeSystemUri"
     from t
-         inner join terminology.concept c on c.code_system = t."codeSystem" and c.sys_status = 'A'
-         inner join terminology.code_system_entity_version csev on csev.code_system_entity_id = c.id and csev.sys_status = 'A'
+         inner join terminology.concept con on con.code_system = t."codeSystem" and con.sys_status = 'A'
+         inner join terminology.code_system_entity_version csev on csev.code_system_entity_id = con.id and csev.sys_status = 'A'
          inner join terminology.entity_version_code_system_version_membership evcsvm on evcsvm.sys_status = 'A'
                 and evcsvm.code_system_entity_version_id = csev.id and evcsvm.code_system_version_id = t.code_system_version_id
          cross join lateral unnest(string_to_array((t.filter_ ->> 'value')::text, ',')) AS pattern
          inner join terminology.entity_property ep on ep.sys_status = 'A' and (t.filter_ ->> 'property')::text = ep.name
-         inner join terminology.designation d on d.sys_status = 'A' and ep.id = d.designation_type_id and d.code_system_entity_version_id = csev.id
+         inner join terminology.designation dn on dn.sys_status = 'A' and ep.id = dn.designation_type_id and dn.code_system_entity_version_id = csev.id
    where t.filter_ is not null
-     and d.name ~* (
+     and (t.filter_ ->> 'property') not in ('code', 'concept')
+     and (t.filter_ ->> 'op') in ('=','in','regex')
+     and dn.name ~* (
          -- Converts 'by plasma$, serum' -> '(by plasma$|serum)'
          '(' || replace(pattern, ',', '|') || ')')
 )
+, hier as (
+  -- Forward-hierarchy descendants, shaped per operator: child-of keeps only level 1,
+  -- descendent-leaf keeps only descendants that have no child of their own, is-not-a is
+  -- handled by complement below (excluded here). Membership in the rule's version is enforced.
+  select z.rule_id, z.type, z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code, z."codeSystemUri", z."baseCodeSystemUri"
+    from r z
+   where z.operator <> 'is-not-a'
+     and (z.operator <> 'child-of' or z.level = 1)
+     and (z.operator <> 'descendent-leaf' or not exists (
+            select 1 from r r1 where r1.rule_id = z.rule_id and r1."codeSystem" = z."codeSystem" and r1.parent = z.csev_id))
+     and exists (select 1 from terminology.entity_version_code_system_version_membership m
+                  where m.sys_status = 'A' and m.code_system_entity_version_id = z.csev_id and m.code_system_version_id = z.code_system_version_id)
+  union
+  -- generalizes ancestors
+  select rr.rule_id, rr.type, rr.fcnt, rr."codeSystem", rr.code_system_version_id, rr.csev_id, rr.code, rr."codeSystemUri", rr."baseCodeSystemUri"
+    from rr
+   where exists (select 1 from terminology.entity_version_code_system_version_membership m
+                  where m.sys_status = 'A' and m.code_system_entity_version_id = rr.csev_id and m.code_system_version_id = rr.code_system_version_id)
+  union
+  -- the filter value concept itself for is-a / generalizes
+  select rc.rule_id, rc.type, rc.fcnt, rc."codeSystem", rc.code_system_version_id, rc.csev_id, rc.code, rc."codeSystemUri", rc."baseCodeSystemUri"
+    from rc
+   where rc.operator in ('is-a','generalizes')
+     and exists (select 1 from terminology.entity_version_code_system_version_membership m
+                  where m.sys_status = 'A' and m.code_system_entity_version_id = rc.csev_id and m.code_system_version_id = rc.code_system_version_id)
+  union
+  -- is-not-a: every member of the version that is neither in the forward set nor the concept itself
+  select p.rule_id, p.type, p.fcnt, p."codeSystem", p.code_system_version_id, p.csev_id, p.code, p."codeSystemUri", p."baseCodeSystemUri"
+    from pool p
+   where not exists (select 1 from r r2 where r2.rule_id = p.rule_id and r2."codeSystem" = p."codeSystem" and r2.csev_id = p.csev_id and r2.operator = 'is-not-a')
+     and not exists (select 1 from rc rc2 where rc2.rule_id = p.rule_id and rc2."codeSystem" = p."codeSystem" and rc2.csev_id = p.csev_id)
+)
 , all_findings as (
-  select z.rule_id, z."type", t.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
-         jsonb_build_object('conceptVersionId', z.csev_id, 'code', z.code, 'codeSystem', z."codeSystem", 'codeSystemUri', t."codeSystemUri", 'baseCodeSystemUri', t."baseCodeSystemUri") obj
-    from r as z
-         inner join t on z.rule_id=t.rule_id and z.rn=t.rn
+  select z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
+         jsonb_build_object('conceptVersionId', z.csev_id, 'code', z.code, 'codeSystem', z."codeSystem", 'codeSystemUri', z."codeSystemUri", 'baseCodeSystemUri', z."baseCodeSystemUri") obj
+    from hier as z
   union
   select z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
          jsonb_build_object('conceptVersionId', z.csev_id, 'code', z.code, 'codeSystem', z."codeSystem", 'codeSystemUri', z."codeSystemUri", 'baseCodeSystemUri', z."baseCodeSystemUri")

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ruleset/ValueSetVersionRuleServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ruleset/ValueSetVersionRuleServiceTest.groovy
@@ -1,0 +1,79 @@
+package org.termx.terminology.terminology.valueset.ruleset
+
+import com.kodality.commons.exception.ApiException
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+import spock.lang.Specification
+
+class ValueSetVersionRuleServiceTest extends Specification {
+  def repository = Mock(ValueSetVersionRuleRepository)
+  def ruleSetService = Mock(ValueSetVersionRuleSetService)
+  def service = new ValueSetVersionRuleService(repository, ruleSetService)
+
+  def "save(rule) rejects an unknown filter operator before persisting"() {
+    given:
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem("cs")
+        .setFilters([filter("concept", "is-a-typo", "A")])
+
+    when:
+    service.save(rule, "vs", "1.0.0")
+
+    then:
+    def e = thrown(ApiException)
+    e.issues*.code.contains("TE310")
+    0 * repository.save(_, _)
+  }
+
+  def "save(rule) rejects a filter with a null operator"() {
+    given:
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem("cs")
+        .setFilters([filter("concept", null, "A")])
+
+    when:
+    service.save(rule, "vs", "1.0.0")
+
+    then:
+    thrown(ApiException)
+    0 * repository.save(_, _)
+  }
+
+  def "save(rule) accepts every supported FHIR filter operator"() {
+    given:
+    ruleSetService.load("vs", "1.0.0") >> Optional.of(new ValueSetVersionRuleSet().setId(1L))
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem("cs")
+        .setFilters([filter("concept", operator, "A")])
+
+    when:
+    service.save(rule, "vs", "1.0.0")
+
+    then:
+    1 * repository.save(rule, 1L)
+
+    where:
+    operator << ["=", "is-a", "descendent-of", "child-of", "descendent-leaf",
+                 "is-not-a", "regex", "in", "not-in", "generalizes", "exists"]
+  }
+
+  def "bulk save validates each rule's filter operators"() {
+    given:
+    ruleSetService.load("vs", "1.0.0") >> Optional.of(new ValueSetVersionRuleSet().setId(1L))
+    def rules = [new ValueSetVersionRule().setType("include").setCodeSystem("cs")
+                     .setFilters([filter("concept", "bogus", "A")])]
+
+    when:
+    service.save(rules, "vs", "1.0.0")
+
+    then:
+    thrown(ApiException)
+    0 * repository.save(_, _)
+  }
+
+  private static ValueSetRuleFilter filter(String property, String operator, Object value) {
+    return new ValueSetRuleFilter()
+        .setProperty(new PropertyReference().setName(property))
+        .setOperator(operator)
+        .setValue(value)
+  }
+}

--- a/termx-api/src/main/java/org/termx/ts/valueset/ValueSetRuleFilterOperator.java
+++ b/termx-api/src/main/java/org/termx/ts/valueset/ValueSetRuleFilterOperator.java
@@ -1,12 +1,27 @@
 package org.termx.ts.valueset;
 
+import java.util.Set;
+
+/**
+ * The FHIR ValueSet filter operators: https://build.fhir.org/valueset-filter-operator.html
+ *
+ * <p>This is the single source of truth for the operators TermX accepts on a value set rule filter.
+ * It is enforced on save (see {@code ValueSetVersionRuleService}) and implemented by the expansion
+ * functions {@code terminology.value_set_expand(bigint)} / {@code (text)}. SNOMED expansion maps a
+ * subset to ECL (see {@code SnomedValueSetExpandProvider}).
+ */
 public interface ValueSetRuleFilterOperator {
+  String equal = "=";
   String is_a = "is-a";
   String descendent_of = "descendent-of";
+  String child_of = "child-of";
+  String descendent_leaf = "descendent-leaf";
   String is_not_a = "is-not-a";
   String regex = "regex";
   String in = "in";
   String not_in = "not-in";
   String generalizes = "generalizes";
   String exists = "exists";
+
+  Set<String> ALL = Set.of(equal, is_a, descendent_of, child_of, descendent_leaf, is_not_a, regex, in, not_in, generalizes, exists);
 }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandFilterOperatorIT.groovy
@@ -1,0 +1,166 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+
+/**
+ * Coverage for every FHIR ValueSet filter operator (https://build.fhir.org/valueset-filter-operator.html)
+ * against the STORED-version expansion path — {@code terminology.value_set_expand(bigint)} in
+ * {@code 01-value_set_expand.sql}, reached via {@link ValueSetVersionConceptRepository#expand(Long)}.
+ *
+ * <p>Issue #197 asks termx to support the full filter-operator set. This IT pins the expected
+ * member set for each operator against a known hierarchy so any regression (or future SQL rewrite)
+ * is caught. The sibling {@link ValueSetExpandInlineFilterOperatorIT} pins the same operators on
+ * the inline {@code value_set_expand(text)} path, which today implements only a subset.
+ *
+ * <p>Fixture hierarchy ({@code cs-hierarchy.json}, hierarchyMeaning = is-a):
+ * <pre>
+ *   A                      (property method = CHROM)
+ *   ├── B                  (property method = CHROM)
+ *   │   └── D
+ *   └── C
+ *   X                      (separate root, no parent)
+ * </pre>
+ * Associations (is-a): B→A, C→A, D→B. {@code method} is set on A and B only.
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandFilterOperatorIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptRepository conceptRepository
+
+  static final String CS_ID = "vsexpand-filter-cs"
+  static final String VS_ID = "vsexpand-filter-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importHierarchyCs()
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "is-a includes the concept itself plus all transitive descendants"() {
+    expect:
+    expand(filter("concept", "is-a", "A")) == ["A", "B", "C", "D"] as Set
+  }
+
+  def "descendent-of includes all transitive descendants but excludes the concept itself"() {
+    expect:
+    expand(filter("concept", "descendent-of", "A")) == ["B", "C", "D"] as Set
+  }
+
+  def "child-of includes only direct children, excluding the concept itself and deeper descendants"() {
+    expect:
+    expand(filter("concept", "child-of", "A")) == ["B", "C"] as Set
+  }
+
+  def "descendent-leaf includes only descendants that are themselves leaves"() {
+    expect: "B has a child (D) so it is excluded; C and D are leaves"
+    expand(filter("concept", "descendent-leaf", "A")) == ["C", "D"] as Set
+  }
+
+  def "is-not-a includes every concept that is NOT in the is-a set of the value"() {
+    expect: "only X lives outside the A subtree"
+    expand(filter("concept", "is-not-a", "A")) == ["X"] as Set
+  }
+
+  def "generalizes includes the concept itself plus all transitive ancestors"() {
+    expect:
+    expand(filter("concept", "generalizes", "D")) == ["A", "B", "D"] as Set
+  }
+
+  def "'=' on code matches the single concept with that code"() {
+    expect:
+    expand(filter("code", "=", "C")) == ["C"] as Set
+  }
+
+  def "'in' on code matches every concept whose code is in the comma-separated set"() {
+    expect:
+    expand(filter("code", "in", "B,C")) == ["B", "C"] as Set
+  }
+
+  def "'not-in' on code matches every concept whose code is NOT in the comma-separated set"() {
+    expect:
+    expand(filter("code", "not-in", "B,C")) == ["A", "D", "X"] as Set
+  }
+
+  def "regex on code matches every concept whose code matches the pattern"() {
+    expect:
+    expand(filter("code", "regex", "[BD]")) == ["B", "D"] as Set
+  }
+
+  def "exists matches every concept that has at least one value of the property"() {
+    expect: "method is populated on A and B only"
+    expand(filter("method", "exists", true)) == ["A", "B"] as Set
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private Set<String> expand(ValueSetRuleFilter... filters) {
+    def rule = new ValueSetVersionRule()
+        .setType("include")
+        .setCodeSystem(CS_ID)
+        .setFilters(filters.toList())
+
+    def version = new ValueSetVersion()
+        .setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Filter operator expansion")))
+    request.setVersion(version)
+    valueSetService.save(request)
+
+    def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+    return conceptRepository.expand(versionId).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private static ValueSetRuleFilter filter(String property, String operator, Object value) {
+    return new ValueSetRuleFilter()
+        .setProperty(new PropertyReference().setName(property))
+        .setOperator(operator)
+        .setValue(value)
+  }
+
+  private void importHierarchyCs() {
+    def json = readFixtureString("fhir/vsexpand/cs-hierarchy.json")
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    def cs = fhirMapper.fromFhirCodeSystem(fhir)
+    importService.importCodeSystem(cs, [], new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private String readFixtureString(String relativePath) {
+    def stream = getClass().getClassLoader().getResourceAsStream(relativePath)
+    assert stream != null, "fixture not found: ${relativePath}"
+    return new String(stream.readAllBytes(), "UTF-8")
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
@@ -1,0 +1,138 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.util.JsonUtil
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.ts.codesystem.CodeSystemImportAction
+
+/**
+ * Coverage for every FHIR ValueSet filter operator against the INLINE expansion path —
+ * {@code terminology.value_set_expand(text)} in {@code 37-value_set_expand_jsonb.sql}, reached via
+ * {@link ValueSetVersionConceptRepository#expandFromJson(String)}. This is the path used by FHIR
+ * {@code $expand} of a posted/inline ValueSet and by the rule-preview service.
+ *
+ * <p>Mirrors {@link ValueSetExpandFilterOperatorIT} (stored-version path) so the two paths are held
+ * to the same FHIR semantics — see https://build.fhir.org/valueset-filter-operator.html. The inline
+ * SQL function was brought to operator parity for issue #197.
+ *
+ * <p>Fixture hierarchy ({@code cs-hierarchy.json}, hierarchyMeaning = is-a):
+ * <pre>
+ *   A (method=CHROM) ├── B (method=CHROM) └── D
+ *                    └── C
+ *   X (separate root)
+ * </pre>
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandInlineFilterOperatorIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetVersionConceptRepository conceptRepository
+
+  static final String CS_ID = "vsexpand-filter-cs"
+  static final String CS_URI = "http://termx-test.local/CodeSystem/vsexpand-filter-cs"
+  static final String CS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importHierarchyCs()
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "is-a includes the concept itself plus all transitive descendants"() {
+    expect:
+    expandInline("concept", "is-a", "A") == ["A", "B", "C", "D"] as Set
+  }
+
+  def "descendent-of includes all transitive descendants but excludes the concept itself"() {
+    expect:
+    expandInline("concept", "descendent-of", "A") == ["B", "C", "D"] as Set
+  }
+
+  def "child-of includes only direct children"() {
+    expect:
+    expandInline("concept", "child-of", "A") == ["B", "C"] as Set
+  }
+
+  def "descendent-leaf includes only descendants that are themselves leaves"() {
+    expect: "B has a child (D) so it is excluded; C and D are leaves"
+    expandInline("concept", "descendent-leaf", "A") == ["C", "D"] as Set
+  }
+
+  def "is-not-a includes every concept that is NOT in the is-a set of the value"() {
+    expect:
+    expandInline("concept", "is-not-a", "A") == ["X"] as Set
+  }
+
+  def "generalizes includes the concept itself plus all transitive ancestors"() {
+    expect:
+    expandInline("concept", "generalizes", "D") == ["A", "B", "D"] as Set
+  }
+
+  def "'=' on code matches the single concept with that code"() {
+    expect:
+    expandInline("code", "=", "C") == ["C"] as Set
+  }
+
+  def "'in' on code matches every concept whose code is in the comma-separated set"() {
+    expect:
+    expandInline("code", "in", "B,C") == ["B", "C"] as Set
+  }
+
+  def "'not-in' on code matches every concept whose code is NOT in the comma-separated set"() {
+    expect:
+    expandInline("code", "not-in", "B,C") == ["A", "D", "X"] as Set
+  }
+
+  def "regex on code matches every concept whose code matches the pattern"() {
+    expect:
+    expandInline("code", "regex", "[BD]") == ["B", "D"] as Set
+  }
+
+  def "exists matches every concept that has at least one value of the property"() {
+    expect: "method is populated on A and B only"
+    expandInline("method", "exists", true) == ["A", "B"] as Set
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private Set<String> expandInline(String property, String op, Object value) {
+    def valueSet = [
+        resourceType: "ValueSet",
+        compose      : [
+            inactive: false,
+            include : [[
+                           system : CS_URI,
+                           version: CS_VERSION,
+                           filter : [[property: property, op: op, value: value]]
+                       ]]
+        ]
+    ]
+    def json = JsonUtil.toJson(valueSet)
+    return conceptRepository.expandFromJson(json).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private void importHierarchyCs() {
+    def json = readFixtureString("fhir/vsexpand/cs-hierarchy.json")
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    def cs = fhirMapper.fromFhirCodeSystem(fhir)
+    importService.importCodeSystem(cs, [], new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private String readFixtureString(String relativePath) {
+    def stream = getClass().getClassLoader().getResourceAsStream(relativePath)
+    assert stream != null, "fixture not found: ${relativePath}"
+    return new String(stream.readAllBytes(), "UTF-8")
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandPerfTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandPerfTest.groovy
@@ -1,0 +1,144 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.commons.util.JsonUtil
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+import spock.lang.IgnoreIf
+
+/**
+ * Expansion benchmark for a large is-a hierarchy — compares the two SQL expansion engines on the
+ * same data: {@code value_set_expand(bigint)} (stored path, fn 01) vs {@code value_set_expand(text)}
+ * (inline path, fn 37), and the cached-snapshot read used by published {@code $expand}.
+ *
+ * <p>Gated behind {@code PERF} so CI skips it; size via {@code PERF_N} (concepts) and
+ * {@code PERF_B} (branching factor, default 4):
+ * <pre>
+ *   ./gradlew :termx-integtest:test --tests '*ValueSetExpandPerfTest' PERF=true PERF_N=20000
+ * </pre>
+ * Prints {@code PERF ...} lines; assertions only sanity-check that the hierarchy expanded fully.
+ */
+@MicronautTest(transactional = true)
+@IgnoreIf({ env.PERF == null })
+class ValueSetExpandPerfTest extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptRepository conceptRepository
+  @Inject ValueSetVersionConceptService conceptService
+
+  static final String CS_ID = "perf-hier-cs"
+  static final String CS_URI = "http://termx-test.local/CodeSystem/perf-hier-cs"
+  static final String VS_ID = "perf-hier-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "is-a expansion of an N-concept hierarchy: stored fn vs inline fn vs cached snapshot"() {
+    given:
+    int n = (System.getenv('PERF_N') ?: '10000') as int
+    int b = (System.getenv('PERF_B') ?: '4') as int
+    importHierarchy(n, b)
+
+    and: "a draft value set whose single rule is is-a over the root concept c1"
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID)
+        .setFilters([new ValueSetRuleFilter().setProperty(new PropertyReference().setName("concept")).setOperator("is-a").setValue("c1")])
+    saveDraftValueSet(rule)
+    def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+
+    when: "stored path — value_set_expand(bigint), fn 01"
+    long storedCount = -1
+    long storedMs = median(3) { storedCount = conceptRepository.expand(versionId).size() }
+
+    and: "inline path — value_set_expand(text), fn 37"
+    def inlineJson = JsonUtil.toJson([resourceType: "ValueSet", compose: [inactive: false,
+        include: [[system: CS_URI, version: VS_VERSION, filter: [[property: "concept", op: "is-a", value: "c1"]]]]]])
+    long inlineCount = -1
+    long inlineMs = median(3) { inlineCount = conceptRepository.expandFromJson(inlineJson).size() }
+
+    and: "cached snapshot read — what published \$expand serves"
+    conceptService.expand(VS_ID, VS_VERSION)            // materialize + persist snapshot once
+    valueSetVersionService.activate(VS_ID, VS_VERSION)  // freeze so the snapshot is served, not recomputed
+    long snapCount = -1
+    long snapMs = median(5) { snapCount = conceptService.expand(VS_ID, VS_VERSION, null, false).getExpansion().size() }
+
+    then:
+    storedCount == n
+    inlineCount == n
+    snapCount == n
+    println "PERF  n=${n} branching=${b}  storedFn01=${storedMs}ms  inlineFn37=${inlineMs}ms  cachedSnapshot=${snapMs}ms  (count=${n})"
+    true
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private long median(int reps, Closure body) {
+    def times = (1..reps).collect { long t = System.nanoTime(); body(); (System.nanoTime() - t) / 1_000_000L as long }.sort()
+    return times[(int) (times.size() / 2)]
+  }
+
+  private void importHierarchy(int n, int b) {
+    Map<Integer, List<Integer>> children = [:].withDefault { [] }
+    for (int i = 2; i <= n; i++) {
+      int parent = ((i - 2).intdiv(b)) + 1
+      children[parent] << i
+    }
+    Closure<Map> buildConcept
+    buildConcept = { int i ->
+      def c = [code: "c${i}".toString(), display: "Concept ${i}".toString()]
+      def kids = children[i]
+      if (kids) {
+        c.concept = kids.collect { buildConcept(it) }
+      }
+      return c
+    }
+    def cs = [resourceType: "CodeSystem", id: CS_ID, url: CS_URI, version: "1.0.0", name: "PerfHierCs",
+              title: "Perf hierarchy code system",
+              status: "active", content: "complete", caseSensitive: true, hierarchyMeaning: "is-a",
+              concept: [buildConcept(1)]]
+    def fhir = FhirMapper.fromJson(JsonUtil.toJson(cs), com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    importService.importCodeSystem(fhirMapper.fromFhirCodeSystem(fhir), [],
+        new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private void saveDraftValueSet(ValueSetVersionRule rule) {
+    def version = new ValueSetVersion()
+        .setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Perf hierarchy")))
+    request.setVersion(version)
+    valueSetService.save(request)
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/vsexpand/cs-hierarchy.json
+++ b/termx-integtest/src/test/resources/fhir/vsexpand/cs-hierarchy.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "vsexpand-filter-cs",
+  "url": "http://termx-test.local/CodeSystem/vsexpand-filter-cs",
+  "version": "1.0.0",
+  "name": "VsExpandFilterCs",
+  "title": "Filter operator expansion test code system",
+  "status": "active",
+  "experimental": false,
+  "content": "complete",
+  "caseSensitive": true,
+  "hierarchyMeaning": "is-a",
+  "property": [
+    {"code": "method", "type": "string"}
+  ],
+  "concept": [
+    {
+      "code": "A",
+      "display": "Alpha",
+      "property": [{"code": "method", "valueString": "CHROM"}],
+      "concept": [
+        {
+          "code": "B",
+          "display": "Bravo",
+          "property": [{"code": "method", "valueString": "CHROM"}],
+          "concept": [
+            {"code": "D", "display": "Delta"}
+          ]
+        },
+        {"code": "C", "display": "Charlie"}
+      ]
+    },
+    {"code": "X", "display": "Xray"}
+  ]
+}


### PR DESCRIPTION
Closes #197.

## Summary
Brings TermX's ValueSet expansion to full FHIR [filter-operator](https://build.fhir.org/valueset-filter-operator.html) coverage and adds the test coverage the issue asked for.

The stored-version function `value_set_expand(bigint)` already implemented all 11 operators. The inline function `value_set_expand(text)` (used by FHIR `$expand` of a posted/inline ValueSet and by the rule-preview service) only implemented `is-a`/`=`/`in`/`regex` and silently mishandled the rest. SNOMED expansion mapped only `is-a`/`descendent-of`/`in` to ECL and emitted a bare value for anything else.

## Changes
- **Inline expansion (`37-value_set_expand_jsonb.sql`)** rewritten to operator parity with the stored function:
  - forward hierarchy with level/leaf shaping — `child-of` (direct children), `descendent-leaf` (leaf descendants), `descendent-of` (descendants, no self)
  - reverse hierarchy for `generalizes` (ancestors + self)
  - self inclusion for `is-a`/`generalizes`; `is-not-a` as the version complement
  - `not-in` and `exists` on the code column and custom properties
  - existing `=`/`in`/`regex`, Coding-valued and designation branches preserved and op-gated
- **`ValueSetRuleFilterOperator`** now declares all 11 operators (+`=`, `child-of`, `descendent-leaf`) plus an `ALL` set, and is **enforced on save** — `ValueSetVersionRuleService` rejects unknown/null operators with `TE310` (single- and bulk-rule paths).
- **SNOMED**: `composeEcl` adds `child-of`→`<!` and `generalizes`→`>>`, and **rejects** operators with no ECL equivalent (`SN301`) instead of emitting a bare value. Fixed a NPE when Snowstorm returns a concept with no descriptions.

## Tests
- `ValueSetExpandFilterOperatorIT` / `ValueSetExpandInlineFilterOperatorIT` — all 11 operators over the stored and inline SQL paths against a known hierarchy
- `ValueSetVersionRuleServiceTest` — save-time operator validation
- `SnomedValueSetExpandProviderSpec` — operator→ECL mapping + rejection + null-descriptions
- `ValueSetExpandPerfTest` — `PERF`-gated benchmark

## Performance note
Benchmark (is-a over an N-concept tree): live SQL expansion scales superlinearly (10k ≈ 0.8s, 40k ≈ 12s); the cached snapshot read is ~50–60× faster and near-linear. `$expand` already serves the cached snapshot for published versions. The next speed lever is materialization of draft/preview expansion, not an engine rewrite — out of scope here.