### PR TITLE
Terminology: supplement/expand fixes, batch coverage, LOINC bindings, compressed expansion storage

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincMapper.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincMapper.java
@@ -15,12 +15,14 @@ import org.termx.ts.codesystem.CodeSystemImportRequest.CodeSystemImportRequestVe
 import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.Designation;
 import org.termx.ts.codesystem.EntityPropertyKind;
+import org.termx.ts.codesystem.EntityPropertyRule;
 import org.termx.ts.codesystem.EntityPropertyType;
 import org.termx.ts.codesystem.EntityPropertyValue;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class LoincMapper {
@@ -63,9 +65,27 @@ public class LoincMapper {
     // INSERT bug in CodeSystemEntityRepository.batchUpsert was fixed and the import reached
     // the LOINC concept code-system import for the first time.
     List<CodeSystemImportRequestProperty> properties = concepts.stream()
-        .flatMap(c -> c.getProperties().stream()).collect(Collectors.toSet()).stream()
-        .collect(Collectors.toMap(LoincConceptProperty::getName, p -> p, (p, q) -> p)).values().stream()
-        .map(property -> new CodeSystemImportRequestProperty().setName(property.getName()).setType(property.getType()).setKind(EntityPropertyKind.property))
+        .flatMap(c -> c.getProperties().stream())
+        .collect(Collectors.groupingBy(LoincConceptProperty::getName)).entrySet().stream()
+        .map(e -> {
+          LoincConceptProperty sample = e.getValue().get(0);
+          CodeSystemImportRequestProperty property = new CodeSystemImportRequestProperty()
+              .setName(e.getKey()).setType(sample.getType()).setKind(EntityPropertyKind.property);
+          // Coding-typed property values (e.g. answer-list) reference an external code system.
+          // Record those systems on the property definition so they survive import and the FHIR
+          // export can emit codesystem-property-codesystem. Issue #48.
+          if (EntityPropertyType.coding.equals(sample.getType())) {
+            List<String> codeSystems = e.getValue().stream()
+                .map(LoincConceptProperty::getValue)
+                .filter(Concept.class::isInstance).map(Concept.class::cast)
+                .map(Concept::getCodeSystem).filter(Objects::nonNull)
+                .distinct().toList();
+            if (!codeSystems.isEmpty()) {
+              property.setRule(new EntityPropertyRule().setCodeSystems(codeSystems));
+            }
+          }
+          return property;
+        })
         .collect(Collectors.toCollection(ArrayList::new));
     properties.add(new CodeSystemImportRequestProperty().setName(DISPLAY).setType(EntityPropertyType.string).setKind(EntityPropertyKind.designation));
     properties.add(new CodeSystemImportRequestProperty().setName(KEY_WORDS).setType(EntityPropertyType.string).setKind(EntityPropertyKind.property));

--- a/edition-int/src/test/groovy/org/termx/LoincMapperTest.groovy
+++ b/edition-int/src/test/groovy/org/termx/LoincMapperTest.groovy
@@ -1,0 +1,68 @@
+package org.termx
+
+import org.termx.editionint.loinc.utils.LoincConcept
+import org.termx.editionint.loinc.utils.LoincConcept.LoincConceptProperty
+import org.termx.editionint.loinc.utils.LoincImportRequest
+import org.termx.editionint.loinc.utils.LoincMapper
+import org.termx.ts.codesystem.Concept
+import org.termx.ts.codesystem.EntityPropertyType
+import spock.lang.PendingFeature
+import spock.lang.Specification
+
+class LoincMapperTest extends Specification {
+
+  def "(#48) Coding-typed property definitions carry the referenced external code system binding"() {
+    given: "two concepts whose 'answer-list' property values point into the answer-list code system"
+    def concepts = [
+        loincConcept("1234-5", "LL1", "answer-list"),
+        loincConcept("6789-0", "LL2", "answer-list"),
+    ]
+
+    when:
+    def request = LoincMapper.toRequest(new LoincImportRequest().setVersion("2.80"), concepts)
+    def answerList = request.properties.find { it.name == "answer-list" }
+    def classProp = request.properties.find { it.name == "CLASS" }
+
+    then: "the Coding property records the external code system on its rule (issue #48)"
+    answerList.rule != null
+    answerList.rule.codeSystems == ["answer-list"]
+
+    and: "a plain string property carries no binding"
+    classProp != null
+    classProp.rule == null
+  }
+
+  // PINS issue #48 Bug 2. processLinguisticVariants() merges a translation file into each concept's
+  // display map under its language (e.g. "cs"), so cs designations ARE imported — but toCodeSystem()
+  // and toVersion() hardcode supportedLanguages=[en], so the code system never declares the
+  // translation language. That mismatch is the only thing that distinguishes the (Czech) translation
+  // designations from the English ones, and is the most likely cause of the "strange view until the
+  // concept is re-saved" symptom. @PendingFeature: expected to fail today; flips (failing the build)
+  // when the importer is fixed to declare imported translation languages — remove the annotation then.
+  @PendingFeature(reason = "Issue #48 Bug 2: LOINC translation import does not declare the translation language as supported")
+  def "(#48 bug2) importing a translation language declares it as a supported language"() {
+    given: "a concept carrying English + Czech displays, exactly as processLinguisticVariants leaves it"
+    def concept = new LoincConcept().setCode("1234-5").setDisplay([en: "Glucose", cs: "Glukóza"]).setProperties([])
+
+    when:
+    def request = LoincMapper.toRequest(new LoincImportRequest().setVersion("2.80").setLanguage("cs"), [concept])
+
+    then: "the Czech designation is imported"
+    request.concepts.first().designations.any { it.language == "cs" && it.designationType == "display" }
+
+    and: "and cs must be declared supported on the code system and version (today it is NOT — the bug)"
+    request.codeSystem.supportedLanguages.contains("cs")
+    request.version.supportedLanguages.contains("cs")
+  }
+
+  private static LoincConcept loincConcept(String code, String answerCode, String answerSystem) {
+    return new LoincConcept()
+        .setCode(code)
+        .setDisplay([en: "display " + code])
+        .setProperties([
+            new LoincConceptProperty().setName("answer-list").setType(EntityPropertyType.coding)
+                .setValue(new Concept().setCode(answerCode).setCodeSystem(answerSystem)),
+            new LoincConceptProperty().setName("CLASS").setType(EntityPropertyType.string).setValue("CHEM"),
+        ])
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionService.java
@@ -108,7 +108,7 @@ public class CodeSystemEntityVersionService {
 
   public QueryResult<CodeSystemEntityVersion> query(CodeSystemEntityVersionQueryParams params) {
     QueryResult<CodeSystemEntityVersion> versions = repository.query(params);
-    versions.setData(decorate(versions.getData()));
+    versions.setData(decorate(versions.getData(), params.isDecorateBaseCodeSystem()));
     return versions;
   }
 
@@ -130,6 +130,10 @@ public class CodeSystemEntityVersionService {
   }
 
   public List<CodeSystemEntityVersion> decorate(List<CodeSystemEntityVersion> versions) {
+    return decorate(versions, true);
+  }
+
+  public List<CodeSystemEntityVersion> decorate(List<CodeSystemEntityVersion> versions, boolean decorateBaseCodeSystem) {
     if (CollectionUtils.isEmpty(versions)) {
       return versions;
     }
@@ -161,6 +165,10 @@ public class CodeSystemEntityVersionService {
             }
           });
         });
+
+    if (!decorateBaseCodeSystem) {
+      return versions;
+    }
 
     versions.stream().filter(v -> v.getCodeSystemBase() != null).collect(Collectors.groupingBy(CodeSystemEntityVersion::getCodeSystemBase)).entrySet().forEach(es -> {
       codeSystemProviders.forEach(provider -> {

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java
@@ -92,8 +92,13 @@ public class CodeSystemSupplementService {
 
   @Transactional
   public List<CodeSystemEntityVersion> supplementFromIds(String cs, String csv, List<Long> ids) {
-    Map<Long, List<CodeSystemEntityVersion>> versions = entityVersionService.query(new CodeSystemEntityVersionQueryParams()
-            .setIds(ids.stream().map(String::valueOf).collect(Collectors.joining(",")))).getData().stream()
+    // Fetch every requested entity version. Without all() the query keeps the default page size
+    // (101), so "add all codes" to a supplement silently dropped everything beyond the first 101
+    // ids regardless of how many were selected. Issue #55.
+    CodeSystemEntityVersionQueryParams params = new CodeSystemEntityVersionQueryParams()
+        .setIds(ids.stream().map(String::valueOf).collect(Collectors.joining(",")));
+    params.all();
+    Map<Long, List<CodeSystemEntityVersion>> versions = entityVersionService.query(params).getData().stream()
         .collect(Collectors.groupingBy(CodeSystemEntityVersion::getCodeSystemEntityId));
 
     CodeSystem codeSystem = codeSystemService.load(cs).orElseThrow();

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/providers/TerminologyCodeSystemImportProvider.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/providers/TerminologyCodeSystemImportProvider.java
@@ -142,6 +142,7 @@ public class TerminologyCodeSystemImportProvider extends CodeSystemImportProvide
       property.setName(p.getName());
       property.setType(p.getType());
       property.setKind(p.getKind());
+      property.setRule(p.getRule());
       property.setStatus(PublicationStatus.active);
       return property;
     }).toList();

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/compare/ValueSetCompareRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/compare/ValueSetCompareRepository.java
@@ -1,30 +1,47 @@
 package org.termx.terminology.terminology.valueset.compare;
 
 import com.kodality.commons.db.repo.BaseRepository;
+import com.kodality.commons.util.JsonUtil;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.termx.terminology.terminology.valueset.snapshot.SnapshotExpansionCodec;
 import org.termx.ts.valueset.ValueSetCompareResult;
+import org.termx.ts.valueset.ValueSetVersionConcept;
 import jakarta.inject.Singleton;
 
 @Singleton
 public class ValueSetCompareRepository extends BaseRepository {
+
   public ValueSetCompareResult compare(Long sourceVsVersionId, Long targetVsVersionId) {
-    String s = "select jsonb_array_elements(vss.expansion) from terminology.value_set_snapshot vss" +
-        " where vss.sys_status = 'A' and vss.value_set_version_id = ? ";
-    String sql = "with  c1 as ( " + s + " ), " +
-        "               c2 as ( " + s + " ) " +
-        "select 'deleted' t, jsonb_array_elements(c1) -> 'concept' ->> 'code' code from c1 " +
-        "  where not exists (select 1 from c2 where (jsonb_array_elements(c1) -> 'concept' ->> 'code') = (jsonb_array_elements(c2) -> 'concept' ->> 'code')) " +
-        "union all " +
-        "select 'added' t, jsonb_array_elements(c2) -> 'concept' ->> 'code' code from c2 " +
-        "  where not exists (select 1 from c1 where (jsonb_array_elements(c1) -> 'concept' ->> 'code') = (jsonb_array_elements(c2) -> 'concept' ->> 'code'))";
-    return jdbcTemplate.query(sql, rs -> {
-      ValueSetCompareResult r = new ValueSetCompareResult();
-      while (rs.next()) {
-        switch (rs.getString("t")) {
-          case "added" -> r.getAdded().add(rs.getString("code"));
-          case "deleted" -> r.getDeleted().add(rs.getString("code"));
-        }
+    // Expansions used to be diffed with jsonb_array_elements in SQL, but they are now stored as
+    // gzip-compressed bytea (issue #36) which SQL cannot unpack, so load and diff in-app. Reads
+    // across both columns to stay compatible with legacy uncompressed snapshots.
+    Set<String> source = codes(sourceVsVersionId);
+    Set<String> target = codes(targetVsVersionId);
+
+    ValueSetCompareResult result = new ValueSetCompareResult();
+    target.stream().filter(c -> !source.contains(c)).forEach(c -> result.getAdded().add(c));
+    source.stream().filter(c -> !target.contains(c)).forEach(c -> result.getDeleted().add(c));
+    return result;
+  }
+
+  private Set<String> codes(Long valueSetVersionId) {
+    String sql = "select vss.expansion::text as expansion_json, vss.expansion_bytea "
+        + "from terminology.value_set_snapshot vss where vss.sys_status = 'A' and vss.value_set_version_id = ? limit 1";
+    List<ValueSetVersionConcept> expansion = jdbcTemplate.query(sql, rs -> {
+      if (!rs.next()) {
+        return List.<ValueSetVersionConcept>of();
       }
-      return r;
-    }, sourceVsVersionId, targetVsVersionId);
+      byte[] gz = rs.getBytes("expansion_bytea");
+      String json = gz != null ? SnapshotExpansionCodec.decodeToJson(gz) : rs.getString("expansion_json");
+      return json == null ? List.<ValueSetVersionConcept>of()
+          : JsonUtil.fromJson(json, JsonUtil.getListType(ValueSetVersionConcept.class));
+    }, valueSetVersionId);
+    return expansion.stream()
+        .map(c -> c.getConcept() == null ? null : c.getConcept().getCode())
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -156,6 +156,7 @@ public class ValueSetVersionConceptService {
     CodeSystemEntityVersionQueryParams params = new CodeSystemEntityVersionQueryParams();
     params.setIds(String.join(",", versionIds));
     params.limit(versionIds.size());
+    params.setDecorateBaseCodeSystem(false); // language render path — don't fan out to base code systems. Issue #36.
     Map<Long, Designation> result = new HashMap<>();
     for (CodeSystemEntityVersion v : codeSystemEntityVersionService.query(params).getData()) {
       if (v.getId() == null || v.getDesignations() == null) {
@@ -253,6 +254,9 @@ public class ValueSetVersionConceptService {
     CodeSystemEntityVersionQueryParams params = new CodeSystemEntityVersionQueryParams();
     params.setIds(String.join(",", versionIds));
     params.limit(versionIds.size());
+    // Don't pull every dependent (base) code system's designations/properties per concept — that is
+    // what blows large expansions up to gigabytes. Issue #36.
+    params.setDecorateBaseCodeSystem(false);
     List<CodeSystemEntityVersion> entityVersions = codeSystemEntityVersionService.query(params).getData();
     Map<String, List<CodeSystemEntityVersion>> groupedVersions = entityVersions.stream().collect(Collectors.groupingBy(v -> v.getCodeSystem() + v.getCode()));
 
@@ -268,7 +272,14 @@ public class ValueSetVersionConceptService {
           List<String> csVersions = versions.stream().flatMap(v -> Optional.ofNullable(v.getVersions()).orElse(List.of()).stream().map(CodeSystemVersionReference::getVersion)).toList();
           c.getConcept().setCodeSystemVersions(csVersions);
 
-          List<Designation> designations = versions.stream()
+          // When a code exists as separate entity versions across several code system versions
+          // (e.g. LOINC 2.80 and 2.81), a value set rule bound to one version must only surface that
+          // version's designations. The expand never returns code system versions newer than the bound
+          // one, so the most recent entity version present here is the bound (or the newest still valid
+          // as of the bound) version. Collecting designations from every returned version leaked the
+          // other versions' designations. Issue #49.
+          List<CodeSystemEntityVersion> designationVersions = latestCodeSystemVersion(versions);
+          List<Designation> designations = designationVersions.stream()
               .filter(v -> CollectionUtils.isNotEmpty(v.getDesignations()))
               .flatMap(v -> v.getDesignations().stream())
               .filter(d -> !PublicationStatus.retired.equals(d.getStatus())).toList();
@@ -327,6 +338,31 @@ public class ValueSetVersionConceptService {
           }
         }).toList();
     return res;
+  }
+
+  /**
+   * Keep only the entity versions that belong to the most recent code system version among
+   * {@code versions} (by release date; an unreleased/null release date counts as newest, matching the
+   * expand SQL's {@code release_date desc nulls first} ordering). Used to scope designations to the
+   * version a value set rule is bound to. See issue #49.
+   */
+  static List<CodeSystemEntityVersion> latestCodeSystemVersion(List<CodeSystemEntityVersion> versions) {
+    if (versions == null || versions.size() <= 1) {
+      return versions == null ? List.of() : versions;
+    }
+    return versions.stream()
+        .max(Comparator.comparing(ValueSetVersionConceptService::maxReleaseDate))
+        .map(ValueSetVersionConceptService::maxReleaseDate)
+        .map(top -> versions.stream().filter(v -> top.equals(maxReleaseDate(v))).toList())
+        .orElse(versions);
+  }
+
+  private static java.time.LocalDate maxReleaseDate(CodeSystemEntityVersion version) {
+    return Optional.ofNullable(version.getVersions()).orElse(List.of()).stream()
+        .map(CodeSystemVersionReference::getReleaseDate)
+        .map(d -> d == null ? java.time.LocalDate.MAX : d)
+        .max(Comparator.naturalOrder())
+        .orElse(java.time.LocalDate.MIN);
   }
 
   private boolean calculatedActive(List<CodeSystemEntityVersion> versions) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/SnapshotExpansionCodec.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/SnapshotExpansionCodec.java
@@ -1,0 +1,47 @@
+package org.termx.terminology.terminology.valueset.snapshot;
+
+import com.kodality.commons.util.JsonUtil;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import org.termx.ts.valueset.ValueSetVersionConcept;
+
+/**
+ * Encodes/decodes a value set expansion as gzip-compressed JSON for storage in the
+ * {@code value_set_snapshot.expansion_bytea} column.
+ *
+ * <p>A raw {@code jsonb} value is capped near 1 GB by Postgres, which made large expansions
+ * unstorable (issue #36). Expansion JSON is extremely repetitive (the same keys per concept), so
+ * gzip shrinks it ~10-20x and lifts the practical ceiling well above the reported 1.7 GB case.
+ */
+public final class SnapshotExpansionCodec {
+  private SnapshotExpansionCodec() {}
+
+  public static byte[] encode(List<ValueSetVersionConcept> expansion) {
+    byte[] json = JsonUtil.toJson(expansion == null ? List.of() : expansion).getBytes(StandardCharsets.UTF_8);
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(64, json.length / 8));
+         GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+      gz.write(json);
+      gz.finish();
+      return baos.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("failed to compress value set expansion", e);
+    }
+  }
+
+  public static List<ValueSetVersionConcept> decode(byte[] gz) {
+    return JsonUtil.fromJson(decodeToJson(gz), JsonUtil.getListType(ValueSetVersionConcept.class));
+  }
+
+  public static String decodeToJson(byte[] gz) {
+    try (GZIPInputStream in = new GZIPInputStream(new ByteArrayInputStream(gz))) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException("failed to decompress value set expansion", e);
+    }
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotRepository.java
@@ -1,33 +1,40 @@
 package org.termx.terminology.terminology.valueset.snapshot;
 
-import com.kodality.commons.db.bean.PgBeanProcessor;
 import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
 import com.kodality.commons.db.sql.SqlBuilder;
 import com.kodality.commons.util.JsonUtil;
+import java.time.OffsetDateTime;
 import org.termx.ts.valueset.ValueSetSnapshot;
 import org.termx.ts.valueset.ValueSetSnapshotDependency;
 import org.termx.ts.valueset.ValueSetVersionConcept;
+import org.termx.ts.valueset.ValueSetVersionReference;
 import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Singleton
 public class ValueSetSnapshotRepository extends BaseRepository {
-  private final PgBeanProcessor bp = new PgBeanProcessor(ValueSetSnapshot.class, bp -> {
-    bp.addColumnProcessor("expansion", PgBeanProcessor.fromJson(JsonUtil.getListType(ValueSetVersionConcept.class)));
-    bp.addColumnProcessor("dependencies", PgBeanProcessor.fromJson(JsonUtil.getListType(ValueSetSnapshotDependency.class)));
-    bp.addColumnProcessor("value_set_version", PgBeanProcessor.fromJson());
-  });
 
-  private final static String select = "select vss.*, " +
-      "(select json_build_object('id', vsv.id, 'version', vsv.version) from terminology.value_set_version vsv where vsv.id = vss.value_set_version_id and vsv.sys_status = 'A') as value_set_version ";
+  // Safety valve below the ~1 GB Postgres field limit: if even the compressed expansion is larger,
+  // don't try to store it (the INSERT would fail and break $expand). Issue #36.
+  private static final long MAX_EXPANSION_BYTES = 900L * 1024 * 1024;
 
   public void save(ValueSetSnapshot snapshot) {
+    byte[] gz = SnapshotExpansionCodec.encode(snapshot.getExpansion());
+    if (gz.length > MAX_EXPANSION_BYTES) {
+      log.warn("Value set {} version {} expansion not cached: {} concepts compress to {} MB, over the {} MB snapshot limit (issue #36)",
+          snapshot.getValueSet(), snapshot.getValueSetVersion() == null ? null : snapshot.getValueSetVersion().getId(),
+          snapshot.getConceptsTotal(), gz.length / (1024 * 1024), MAX_EXPANSION_BYTES / (1024 * 1024));
+      return;
+    }
     SaveSqlBuilder ssb = new SaveSqlBuilder();
     ssb.property("id", snapshot.getId());
     ssb.property("value_set", snapshot.getValueSet());
     ssb.property("value_set_version_id", snapshot.getValueSetVersion().getId());
     ssb.property("concepts_total", snapshot.getConceptsTotal());
-    ssb.jsonProperty("expansion", snapshot.getExpansion(), false);
+    ssb.property("expansion_bytea", gz);
+    ssb.property("expansion", "?::jsonb", (Object) null); // clear any legacy uncompressed jsonb on (re)generation
     ssb.jsonProperty("dependencies", snapshot.getDependencies(), false);
     ssb.property("created_at", snapshot.getCreatedAt());
     ssb.property("created_by", snapshot.getCreatedBy());
@@ -37,16 +44,44 @@ public class ValueSetSnapshotRepository extends BaseRepository {
   }
 
   public ValueSetSnapshot load(String valueSet, Long valueSetVersionId) {
-    String sql = select + "from terminology.value_set_snapshot vss where vss.sys_status = 'A' and vss.value_set = ? and vss.value_set_version_id = ?";
-    return getBean(sql, bp, valueSet, valueSetVersionId);
+    String sql = "select vss.id, vss.value_set, vss.concepts_total, vss.expansion::text as expansion_json, " +
+        "vss.expansion_bytea, vss.dependencies::text as dependencies_json, vss.created_at, vss.created_by, " +
+        "(select json_build_object('id', vsv.id, 'version', vsv.version) from terminology.value_set_version vsv " +
+        " where vsv.id = vss.value_set_version_id and vsv.sys_status = 'A')::text as value_set_version_json " +
+        "from terminology.value_set_snapshot vss " +
+        "where vss.sys_status = 'A' and vss.value_set = ? and vss.value_set_version_id = ?";
+    return jdbcTemplate.query(sql, rs -> {
+      if (!rs.next()) {
+        return null;
+      }
+      ValueSetSnapshot s = new ValueSetSnapshot();
+      s.setId(rs.getLong("id"));
+      s.setValueSet(rs.getString("value_set"));
+      s.setConceptsTotal((Integer) rs.getObject("concepts_total"));
+      // Read across both columns: gzip bytea (new) wins, legacy uncompressed jsonb is the fallback.
+      byte[] gz = rs.getBytes("expansion_bytea");
+      String expansionJson = gz != null ? SnapshotExpansionCodec.decodeToJson(gz) : rs.getString("expansion_json");
+      s.setExpansion(expansionJson == null ? null : JsonUtil.fromJson(expansionJson, JsonUtil.getListType(ValueSetVersionConcept.class)));
+      String dependenciesJson = rs.getString("dependencies_json");
+      if (dependenciesJson != null) {
+        s.setDependencies(JsonUtil.fromJson(dependenciesJson, JsonUtil.getListType(ValueSetSnapshotDependency.class)));
+      }
+      String vsvJson = rs.getString("value_set_version_json");
+      if (vsvJson != null) {
+        s.setValueSetVersion(JsonUtil.fromJson(vsvJson, ValueSetVersionReference.class));
+      }
+      s.setCreatedAt(rs.getObject("created_at", OffsetDateTime.class));
+      s.setCreatedBy(rs.getString("created_by"));
+      return s;
+    }, valueSet, valueSetVersionId);
   }
 
   /**
    * Returns ONLY {@code concepts_total} for the saved snapshot, without loading the
-   * (potentially huge) {@code expansion} jsonb column. Lets the FHIR read flow emit
-   * {@code expansion.total} on {@code ?_summary=false} without paying for the full
-   * expansion list — used by {@link ValueSetResourceStorage} to populate the count
-   * on the open-in-FHIR list link. Returns {@code null} when no snapshot exists.
+   * (potentially huge) expansion. Lets the FHIR read flow emit {@code expansion.total} on
+   * {@code ?_summary=false} without paying for the full expansion list — used by
+   * {@link org.termx.terminology.fhir.valueset.ValueSetResourceStorage} to populate the count on the
+   * open-in-FHIR list link. Returns {@code null} when no snapshot exists.
    */
   public Integer loadConceptsTotal(String valueSet, Long valueSetVersionId) {
     String sql = "select concepts_total from terminology.value_set_snapshot " +

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionRepository.java
@@ -9,7 +9,12 @@ import com.kodality.commons.model.Identifier;
 import com.kodality.commons.model.QueryResult;
 import com.kodality.commons.util.JsonUtil;
 import com.kodality.commons.util.PipeUtil;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.termx.terminology.terminology.valueset.snapshot.SnapshotExpansionCodec;
 import org.termx.ts.valueset.ValueSetVersion;
+import org.termx.ts.valueset.ValueSetVersionConcept;
 import org.termx.ts.valueset.ValueSetVersionQueryParams;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Singleton;
@@ -78,18 +83,18 @@ public class ValueSetVersionRepository extends BaseRepository {
 
   public ValueSetVersion load(String valueSet, String version) {
     String sql = select + "from terminology.value_set_version vsv where vsv.sys_status = 'A' and vsv.value_set = ? and vsv.version = ?";
-    return getBean(sql, bp, valueSet, version);
+    return withCompressedExpansion(getBean(sql, bp, valueSet, version));
   }
 
   public ValueSetVersion load(Long id) {
     String sql = select + "from terminology.value_set_version vsv where vsv.sys_status = 'A' and vsv.id = ?";
-    return getBean(sql, bp, id);
+    return withCompressedExpansion(getBean(sql, bp, id));
   }
 
   public ValueSetVersion loadLastVersion(String valueSet) {
     String sql = select +
         "from terminology.value_set_version vsv where vsv.sys_status = 'A' and vsv.value_set = ? and (vsv.status = 'active' or vsv.status = 'draft') order by vsv.id, vsv.release_date desc";
-    return getBean(sql, bp, valueSet);
+    return withCompressedExpansion(getBean(sql, bp, valueSet));
   }
 
   public QueryResult<ValueSetVersion> query(ValueSetVersionQueryParams params) {
@@ -113,7 +118,45 @@ public class ValueSetVersionRepository extends BaseRepository {
           "where vsv.sys_status = 'A'");
       sb.append(filter(params));
       sb.append(limit(params));
-      return getBeans(sb.getSql(), bp, sb.getParams());
+      List<ValueSetVersion> beans = getBeans(sb.getSql(), bp, sb.getParams());
+      fillCompressedExpansions(beans);
+      return beans;
+    });
+  }
+
+  /**
+   * The version-load SQL inlines {@code vss.expansion} (the legacy uncompressed jsonb). Snapshots
+   * written after the gzip migration leave that column null and store the expansion in
+   * {@code expansion_bytea} instead, so for those the inlined expansion comes back null — fill it
+   * here by decompressing the bytea. Legacy rows keep their inlined expansion and skip this entirely.
+   * Issue #36.
+   */
+  private ValueSetVersion withCompressedExpansion(ValueSetVersion version) {
+    fillCompressedExpansions(version == null ? List.of() : List.of(version));
+    return version;
+  }
+
+  private void fillCompressedExpansions(List<ValueSetVersion> versions) {
+    List<Long> versionIds = versions.stream()
+        .filter(v -> v.getSnapshot() != null && v.getSnapshot().getExpansion() == null)
+        .map(ValueSetVersion::getId).toList();
+    if (versionIds.isEmpty()) {
+      return;
+    }
+    SqlBuilder sb = new SqlBuilder("select value_set_version_id, expansion_bytea from terminology.value_set_snapshot "
+        + "where sys_status = 'A' and expansion_bytea is not null");
+    sb.and().in("value_set_version_id", versionIds);
+    Map<Long, List<ValueSetVersionConcept>> byVersion = jdbcTemplate.query(sb.getSql(), rs -> {
+      Map<Long, List<ValueSetVersionConcept>> m = new HashMap<>();
+      while (rs.next()) {
+        m.put(rs.getLong("value_set_version_id"), SnapshotExpansionCodec.decode(rs.getBytes("expansion_bytea")));
+      }
+      return m;
+    }, sb.getParams());
+    versions.forEach(v -> {
+      if (v.getSnapshot() != null && byVersion.containsKey(v.getId())) {
+        v.getSnapshot().setExpansion(byVersion.get(v.getId()));
+      }
     });
   }
 

--- a/terminology/src/main/resources/terminology/changelog/terminology/05-value_set.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/05-value_set.sql
@@ -246,3 +246,12 @@ add column external_web_source text;
 --changeset termx:value_set_snapshot-dependencies
 alter table terminology.value_set_snapshot add column dependencies jsonb;
 --
+
+--changeset termx:value_set_snapshot-expansion-bytea
+-- Store the (potentially gigabyte-scale) expansion as gzip-compressed JSON. A single jsonb value is
+-- capped near 1 GB by Postgres and could not hold large expansions (issue #36). Existing rows keep
+-- their uncompressed jsonb in `expansion`; new/regenerated snapshots write `expansion_bytea` and
+-- leave `expansion` null, so readers must fall back across both columns.
+alter table terminology.value_set_snapshot add column expansion_bytea bytea;
+alter table terminology.value_set_snapshot alter column expansion drop not null;
+--

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementServiceTest.groovy
@@ -1,0 +1,41 @@
+package org.termx.terminology.terminology.codesystem.entity
+
+import com.kodality.commons.model.QueryResult
+import org.termx.core.ts.UcumSearchCacheInvalidator
+import org.termx.terminology.terminology.codesystem.CodeSystemRepository
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropertyService
+import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService
+import org.termx.ts.codesystem.CodeSystem
+import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams
+import spock.lang.Specification
+
+class CodeSystemSupplementServiceTest extends Specification {
+  def codeSystemService = Mock(CodeSystemService)
+  def conceptService = Mock(ConceptService)
+  def codeSystemRepository = Mock(CodeSystemRepository)
+  def entityVersionService = Mock(CodeSystemEntityVersionService)
+  def versionService = Mock(CodeSystemVersionService)
+  def entityPropertyService = Mock(EntityPropertyService)
+  def ucumSearchCacheInvalidator = Mock(UcumSearchCacheInvalidator)
+
+  def service = new CodeSystemSupplementService(codeSystemService, conceptService, codeSystemRepository,
+      entityVersionService, versionService, entityPropertyService, ucumSearchCacheInvalidator)
+
+  def "(#55) supplementFromIds fetches every selected id without the default page-size cap"() {
+    given: "more ids than the default page size (101)"
+    def ids = (1L..150L).collect()
+    codeSystemService.load("cs") >> Optional.of(new CodeSystem())
+    CodeSystemEntityVersionQueryParams captured = null
+
+    when:
+    service.supplementFromIds("cs", null, ids)
+
+    then: "the entity-version query is unbounded (all()) so none of the 150 codes are dropped"
+    1 * entityVersionService.query(_) >> { args -> captured = args[0] as CodeSystemEntityVersionQueryParams; QueryResult.empty() }
+    1 * entityVersionService.batchSave(_, "cs")
+    captured.limit == -1
+    captured.ids == ids.join(",")
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptServiceTest.groovy
@@ -9,8 +9,12 @@ import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropert
 import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotService
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionRepository
 import org.termx.ts.codesystem.CodeSystemEntityVersion
+import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams
+import org.termx.ts.codesystem.CodeSystemVersionReference
 import org.termx.ts.codesystem.Designation
 import org.termx.ts.valueset.ValueSetSnapshot
+
+import java.time.LocalDate
 import org.termx.ts.valueset.ValueSetVersion
 import org.termx.ts.valueset.ValueSetVersionConcept
 import org.termx.ts.valueset.ValueSetVersionRuleSet
@@ -165,6 +169,85 @@ class ValueSetVersionConceptServiceTest extends Specification {
     result != null
     result.expansion != null
     0 * valueSetSnapshotService.createSnapshot(_, _, _, _)
+  }
+
+  def "(#49) decorate scopes designations to the latest bound code system version"() {
+    given: "a code that exists as a separate entity version in LOINC 2.80 and 2.81, each with its own designations"
+    entityPropertyService.query(_) >> QueryResult.empty()
+    def v280 = new CodeSystemEntityVersion().setId(80L).setCodeSystem("loinc").setCode("1234-5").setStatus("active")
+        .setVersions([csVersionRef("2.80", LocalDate.of(2023, 1, 1))])
+        .setDesignations([designation("display", "en", "name 2.80"), designation("abbreviation", "en", "ab80")])
+    def v281 = new CodeSystemEntityVersion().setId(81L).setCodeSystem("loinc").setCode("1234-5").setStatus("active")
+        .setVersions([csVersionRef("2.81", LocalDate.of(2024, 1, 1))])
+        .setDesignations([designation("display", "en", "name 2.81"), designation("abbreviation", "en", "ab81")])
+    codeSystemEntityVersionService.query(_) >> new QueryResult([v280, v281])
+
+    and: "the expand returned both entity versions for the same code (cumulative version window)"
+    def concepts = [loincConcept("1234-5", 80L), loincConcept("1234-5", 81L)]
+
+    when:
+    def result = newService().decorate(concepts, loincVersion(), "en")
+
+    then: "only the newest (2.81) version's designations survive"
+    result.size() == 1
+    def c = result.first()
+    c.display.name == "name 2.81"
+    c.additionalDesignations*.name as Set == ["ab81"] as Set
+    !(c.additionalDesignations*.name.contains("ab80"))
+
+    and: "the concept still reports membership in every version it appears in"
+    c.concept.codeSystemVersions as Set == ["2.80", "2.81"] as Set
+  }
+
+  def "(#49) latestCodeSystemVersion keeps a single version and treats an unreleased version as newest"() {
+    expect:
+    ValueSetVersionConceptService.latestCodeSystemVersion([]) == []
+    ValueSetVersionConceptService.latestCodeSystemVersion(null) == []
+
+    when: "a released version competes with an unreleased (null release date) one"
+    def released = new CodeSystemEntityVersion().setId(1L).setVersions([csVersionRef("1.0", LocalDate.of(2024, 1, 1))])
+    def unreleased = new CodeSystemEntityVersion().setId(2L).setVersions([csVersionRef("2.0", null)])
+    def kept = ValueSetVersionConceptService.latestCodeSystemVersion([released, unreleased])
+
+    then: "the unreleased one wins (draft = newest), matching the expand SQL ordering"
+    kept*.id == [2L]
+  }
+
+  def "(#36) expansion queries entity versions with base-code-system fan-out disabled"() {
+    given:
+    entityPropertyService.query(_) >> QueryResult.empty()
+    CodeSystemEntityVersionQueryParams captured = null
+
+    when:
+    newService().decorate([loincConcept("1234-5", 80L)], loincVersion(), "en")
+
+    then: "the per-concept base/dependent code system designation+property fan-out is switched off (issue #36)"
+    1 * codeSystemEntityVersionService.query(_) >> { args -> captured = args[0] as CodeSystemEntityVersionQueryParams; QueryResult.empty() }
+    captured != null
+    !captured.decorateBaseCodeSystem
+  }
+
+  private static ValueSetVersionConcept loincConcept(String code, Long conceptVersionId) {
+    return new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConcept.ValueSetVersionConceptValue()
+            .setCode(code)
+            .setConceptVersionId(conceptVersionId)
+            .setCodeSystem("loinc")
+            .setCodeSystemUri("http://loinc.org"))
+        .setActive(true)
+  }
+
+  private static ValueSetVersion loincVersion() {
+    return new ValueSetVersion()
+        .setId(1L)
+        .setStatus("draft")
+        .setRuleSet(new ValueSetVersionRuleSet()
+            .setInactive(false)
+            .setRules([new ValueSetVersionRule().setType("include").setCodeSystem("loinc")]))
+  }
+
+  private static CodeSystemVersionReference csVersionRef(String version, LocalDate releaseDate) {
+    return new CodeSystemVersionReference().setVersion(version).setReleaseDate(releaseDate)
   }
 
   private ValueSetVersionConceptService newService() {

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/snapshot/SnapshotExpansionCodecTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/snapshot/SnapshotExpansionCodecTest.groovy
@@ -1,0 +1,34 @@
+package org.termx.terminology.terminology.valueset.snapshot
+
+import com.kodality.commons.util.JsonUtil
+import org.termx.ts.valueset.ValueSetVersionConcept
+import org.termx.ts.valueset.ValueSetVersionConcept.ValueSetVersionConceptValue
+import spock.lang.Specification
+
+class SnapshotExpansionCodecTest extends Specification {
+
+  def "gzip round-trips an expansion and actually compresses it"() {
+    given:
+    def expansion = (1..200).collect {
+      new ValueSetVersionConcept().setId(it as Long)
+          .setConcept(new ValueSetVersionConceptValue().setCode("code-" + it).setCodeSystem("cs"))
+    }
+
+    when:
+    def gz = SnapshotExpansionCodec.encode(expansion)
+    def back = SnapshotExpansionCodec.decode(gz)
+
+    then: "content survives the round trip"
+    back.size() == 200
+    back*.concept.code == expansion*.concept.code
+
+    and: "the gzip is materially smaller than the raw JSON"
+    gz.length < JsonUtil.toJson(expansion).getBytes("UTF-8").length
+  }
+
+  def "null and empty expansions encode to an empty list"() {
+    expect:
+    SnapshotExpansionCodec.decode(SnapshotExpansionCodec.encode(null)) == []
+    SnapshotExpansionCodec.decode(SnapshotExpansionCodec.encode([])) == []
+  }
+}

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemEntityVersionQueryParams.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemEntityVersionQueryParams.java
@@ -26,4 +26,9 @@ public class CodeSystemEntityVersionQueryParams extends QueryParams {
   private String codeSystemVersion;
   private String codeSystemUri;
   private Boolean unlinked;
+  // When false, skip appending designations/properties matched by code from a code system's
+  // base_code_system. Value set expansion sets this off to avoid materializing every dependent
+  // code system's designations for every concept (issue #36). Supplements are unaffected — they
+  // link via baseEntityVersionId, a separate path.
+  private boolean decorateBaseCodeSystem = true;
 }

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemImportRequest.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystemImportRequest.java
@@ -89,6 +89,9 @@ public class CodeSystemImportRequest {
     private String name;
     private String type;
     private String kind;
+    // Binding to the external code system(s)/value set a Coding-typed property's values point to.
+    // Carried through to EntityProperty.rule so the FHIR export can emit codesystem-property-codesystem.
+    private EntityPropertyRule rule;
   }
 }
 

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/BatchBundleIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/BatchBundleIT.groovy
@@ -1,0 +1,131 @@
+package org.termx.terminology.fhir
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.valueset.ValueSetService
+
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse.BodyHandlers
+
+/**
+ * Issue #34 — FHIR batch operations. A {@code POST /fhir} with a {@code Bundle} of
+ * {@code type=batch} must run each entry (here a ValueSet {@code $expand} via GET and a
+ * {@code $validate-code} via POST) and return a {@code batch-response} Bundle holding each
+ * operation's result. The batch plumbing lives in kefhir's {@code BundleService}; this test pins
+ * that it actually dispatches TermX terminology operations end-to-end over HTTP.
+ */
+// transactional = false: the batch runs on a separate HTTP request thread/connection, so the
+// fixtures must be committed (not held in the test's rolled-back transaction) to be visible.
+@MicronautTest(transactional = false)
+class BatchBundleIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject CodeSystemService csService
+  @Inject ValueSetService vsService
+
+  static final ObjectMapper MAPPER = new ObjectMapper()
+  static final String VS_URL = "http://hl7.org/fhir/test/ValueSet/simple-enumerated"
+  static final String CS_URL = "http://hl7.org/fhir/test/CodeSystem/simple"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    csImportService.importCodeSystem(fixture("fhir/simple/codesystem-simple.json"), "simple")
+    vsImportService.importValueSet(fixture("fhir/simple/valueset-enumerated.json"), "simple-enumerated")
+  }
+
+  void cleanup() {
+    vsService.cancel("simple-enumerated")
+    csService.cancel("simple")
+    SessionStore.clearLocal()
+  }
+
+  def "POST /fhir batch Bundle runs \$expand and \$validate-code and returns a batch-response"() {
+    given: "a batch bundle bundling a GET \$expand and a POST \$validate-code"
+    def bundle = """{
+      "resourceType": "Bundle",
+      "type": "batch",
+      "entry": [
+        {
+          "request": { "method": "GET", "url": "ValueSet/\$expand?url=${VS_URL}&excludeNested=true" }
+        },
+        {
+          "resource": {
+            "resourceType": "Parameters",
+            "parameter": [
+              { "name": "url", "valueUri": "${VS_URL}" },
+              { "name": "system", "valueUri": "${CS_URL}" },
+              { "name": "code", "valueCode": "code1" }
+            ]
+          },
+          "request": { "method": "POST", "url": "ValueSet/\$validate-code" }
+        }
+      ]
+    }"""
+
+    when:
+    def request = client.builder("/fhir")
+        .header("Content-Type", "application/fhir+json")
+        .header("Accept", "application/fhir+json")
+        .header("Authorization", 'Bearer yupi{"username":"test","privileges":["*.*.*"]}')
+        .POST(BodyPublishers.ofString(bundle))
+        .build()
+    def response = client.execute(request, BodyHandlers.ofString())
+    def body = MAPPER.readTree(response.body())
+
+    then: "the response is a batch-response with one entry per request"
+    response.statusCode() == 200
+    body.get("resourceType").asText() == "Bundle"
+    body.get("type").asText() == "batch-response"
+    body.get("entry").size() == 2
+
+    and: "the \$expand entry returns an expanded ValueSet containing code1"
+    def expandResource = resourceOfType(body, "ValueSet")
+    expandResource != null
+    expansionCodes(expandResource).contains("code1")
+
+    and: "the \$validate-code entry returns result=true for code1"
+    def validateResource = resourceOfType(body, "Parameters")
+    validateResource != null
+    parameterBoolean(validateResource, "result") == Boolean.TRUE
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+
+  private static JsonNode resourceOfType(JsonNode bundle, String resourceType) {
+    for (def entry : bundle.get("entry")) {
+      def resource = entry.get("resource")
+      if (resource != null && resource.get("resourceType")?.asText() == resourceType) {
+        return resource
+      }
+    }
+    return null
+  }
+
+  private static List<String> expansionCodes(JsonNode valueSet) {
+    def contains = valueSet.path("expansion").path("contains")
+    return contains.isArray() ? contains.collect { it.get("code").asText() } : []
+  }
+
+  private static Boolean parameterBoolean(JsonNode parameters, String name) {
+    for (def p : parameters.path("parameter")) {
+      if (p.get("name")?.asText() == name) {
+        return p.get("valueBoolean")?.asBoolean()
+      }
+    }
+    return null
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ResponseCompressionIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ResponseCompressionIT.groovy
@@ -1,0 +1,37 @@
+package org.termx.terminology.fhir
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import org.termx.TermxIntegTest
+
+import java.net.http.HttpResponse.BodyHandlers
+
+/**
+ * Pins that termx-server (Micronaut 4.6 / Netty) gzip-compresses HTTP responses out of the box when
+ * a (server-to-server) client sends {@code Accept-Encoding: gzip} — so FHIR clients like the IG
+ * Publisher / terminology-explorer that hit {@code :8200} directly (no nginx edge) already get
+ * compressed $expand/metadata responses without any server config. Browsers negotiate this
+ * automatically; the nginx edge gzip is the complementary lever for the browser hop.
+ *
+ * <p>java.net.http does NOT auto-negotiate or auto-decode gzip, so a compressed response comes back
+ * verbatim: {@code Content-Encoding: gzip} plus a gzip-magic (0x1f 0x8b) body.
+ */
+@MicronautTest(transactional = true)
+class ResponseCompressionIT extends TermxIntegTest {
+
+  def "termx-server gzip-compresses a large response when the client sends Accept-Encoding: gzip"() {
+    when: "a gzip-accepting client requests the (large) CapabilityStatement"
+    def request = client.builder("/fhir/metadata")
+        .header("Accept", "application/fhir+json")
+        .header("Accept-Encoding", "gzip")
+        .header("Authorization", 'Bearer yupi{"username":"test","privileges":["*.*.*"]}')
+        .GET().build()
+    def response = client.execute(request, BodyHandlers.ofByteArray())
+    def bytes = response.body()
+    boolean gzipMagic = bytes.length >= 2 && (bytes[0] & 0xff) == 0x1f && (bytes[1] & 0xff) == 0x8b
+
+    then: "the response is gzip-encoded on the wire"
+    response.statusCode() == 200
+    response.headers().firstValue("content-encoding").orElse("<none>") == "gzip"
+    gzipMagic
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetSnapshotStorageIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetSnapshotStorageIT.groovy
@@ -1,0 +1,130 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.util.JsonUtil
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import org.springframework.jdbc.core.JdbcTemplate
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.terminology.valueset.compare.ValueSetCompareService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotRepository
+import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionRepository
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionConcept
+import org.termx.ts.valueset.ValueSetVersionConcept.ValueSetVersionConceptValue
+
+import javax.sql.DataSource
+import java.time.LocalDate
+
+/**
+ * Issue #36 — the value set expansion is stored as gzip-compressed bytea ({@code expansion_bytea})
+ * rather than a single jsonb capped near 1 GB. This pins: new snapshots are written compressed and
+ * read back (directly and via the version-load hot path that inlines the snapshot), legacy
+ * uncompressed jsonb rows still read, and the in-app compare diffs compressed snapshots.
+ */
+@MicronautTest(transactional = true)
+class ValueSetSnapshotStorageIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject ValueSetVersionService vsVersionService
+  @Inject ValueSetVersionConceptService vsConceptService
+  @Inject ValueSetSnapshotService snapshotService
+  @Inject ValueSetSnapshotRepository snapshotRepository
+  @Inject ValueSetVersionRepository vsVersionRepository
+  @Inject ValueSetCompareService compareService
+  @Inject @Named("default") DataSource dataSource
+
+  static final String VS_ID = "simple-enumerated"
+  static final String VS_VERSION = "5.0.0"
+
+  JdbcTemplate jdbc
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    jdbc = new JdbcTemplate(dataSource)
+    csImportService.importCodeSystem(fixture("fhir/simple/codesystem-simple.json"), "simple")
+    vsImportService.importValueSet(fixture("fhir/simple/valueset-enumerated.json"), VS_ID)
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "a draft expand stores the snapshot gzip-compressed and reads it back across both paths"() {
+    given:
+    def versionId = vsVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+
+    when: "the draft version is expanded (which persists the snapshot)"
+    vsConceptService.expand(VS_ID, VS_VERSION)
+
+    then: "the snapshot row stores the expansion in bytea, with the legacy jsonb column left empty"
+    def cols = jdbc.queryForMap(
+        "select (expansion is null) as exp_null, (expansion_bytea is not null) as gz_present " +
+            "from terminology.value_set_snapshot where sys_status = 'A' and value_set_version_id = ?", versionId)
+    cols.exp_null == true
+    cols.gz_present == true
+
+    and: "loading the snapshot decompresses it"
+    def snapshot = snapshotRepository.load(VS_ID, versionId)
+    snapshot.expansion*.concept.code.containsAll(["code1", "code3"])
+
+    and: "the version-load path (which inlines the snapshot) also returns the decompressed expansion"
+    def reloaded = vsVersionRepository.load(VS_ID, VS_VERSION)
+    reloaded.snapshot != null
+    reloaded.snapshot.expansion*.concept.code.containsAll(["code1", "code3"])
+  }
+
+  def "a legacy uncompressed jsonb snapshot is still readable"() {
+    given: "an expanded snapshot rewritten to the pre-migration shape (jsonb set, bytea null)"
+    def versionId = vsVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+    vsConceptService.expand(VS_ID, VS_VERSION)
+    def json = JsonUtil.toJson(snapshotRepository.load(VS_ID, versionId).expansion)
+    jdbc.update("update terminology.value_set_snapshot set expansion = ?::jsonb, expansion_bytea = null " +
+        "where sys_status = 'A' and value_set_version_id = ?", json, versionId)
+
+    expect: "the reader falls back to the jsonb column"
+    snapshotRepository.load(VS_ID, versionId).expansion*.concept.code.containsAll(["code1", "code3"])
+    vsVersionRepository.load(VS_ID, VS_VERSION).snapshot.expansion*.concept.code.containsAll(["code1", "code3"])
+  }
+
+  def "compare diffs two compressed snapshots"() {
+    given: "two draft versions with hand-built expansions over different code sets"
+    def srcId = createVersion("cmp-src", ["code1", "code2"])
+    def tgtId = createVersion("cmp-tgt", ["code2", "code3"])
+
+    when:
+    def result = compareService.compare(srcId, tgtId)
+
+    then: "code1 dropped, code3 added"
+    result.deleted.contains("code1")
+    result.added.contains("code3")
+    !result.deleted.contains("code2")
+    !result.added.contains("code2")
+  }
+
+  private Long createVersion(String version, List<String> codes) {
+    vsVersionService.save(new ValueSetVersion().setValueSet(VS_ID).setVersion(version).setStatus(PublicationStatus.draft).setReleaseDate(LocalDate.now()))
+    def id = vsVersionService.load(VS_ID, version).orElseThrow().getId()
+    snapshotService.createSnapshot(VS_ID, id, codes.collect {
+      new ValueSetVersionConcept().setActive(true)
+          .setConcept(new ValueSetVersionConceptValue().setCode(it).setCodeSystem("simple"))
+    })
+    return id
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+}


### PR DESCRIPTION
Addresses several open terminology issues, with tests for each.

## #55 — supplement "add all codes" capped at 101
`CodeSystemSupplementService.supplementFromIds` queried with the default 101-row page cap, so adding all codes silently dropped everything past the first 101. Now queries `all()`.

## #49 — expand leaked designations from all CS versions
For a code bound to one code system version, `$expand` returned designations from *every* version the code appears in. Designations are now scoped to the most recent (bound) version present.

## #34 — FHIR batch operations
Already supported via kefhir's `BundleService`; added an HTTP-level integration test (`BatchBundleIT`) posting a `batch` Bundle with `$expand` (GET) + `$validate-code` (POST) and asserting a `batch-response`.

## #48 — LOINC importer
- **Bug 1 (fixed):** Coding-typed property values (e.g. `answer-list`) referenced an external code system that was dropped from the property *definition*. Carried via `EntityPropertyRule.codeSystems` so the FHIR export emits `codesystem-property-codesystem`.
- **Bug 2 (pinned):** `@PendingFeature` test capturing that the importer never declares the translation language (e.g. `cs`) in `supportedLanguages` — the most likely cause of the "strange view until re-save" symptom. Fix to follow.

## #36 — large expansions could not be stored (~1.7 GB)
- **Fan-out:** skip the per-concept `base_code_system` designation/property fan-out during expansion (the primary size multiplier). Supplements are unaffected — they link via `baseEntityVersionId`, a separate path.
- **Storage:** store the expansion as gzip-compressed `bytea` (`expansion_bytea`) with a size guard. Additive, data-safe migration: existing uncompressed `jsonb` rows are untouched and still read; new/regenerated snapshots write compressed and null the legacy column. The version-load hot path and `compare` read across both columns (compare moved in-app since `jsonb_array_elements` can't run on bytea).

## Transport
Pinned (`ResponseCompressionIT`) that termx-server already gzip-compresses responses for `Accept-Encoding: gzip` clients (Micronaut/Netty default).

## Tests
Unit + integration (Testcontainers) for each item; full `termx-integtest` suite green.