### PR TITLE
#48 Bug 2: declare imported LOINC translation languages as supported

### DIFF
--- a/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincMapper.java
+++ b/edition-int/src/main/java/org/termx/editionint/loinc/utils/LoincMapper.java
@@ -20,6 +20,7 @@ import org.termx.ts.codesystem.EntityPropertyType;
 import org.termx.ts.codesystem.EntityPropertyValue;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,28 +34,45 @@ public class LoincMapper {
   public static CodeSystemImportRequest toRequest(LoincImportRequest configuration, List<LoincConcept> concepts) {
     CodeSystemImportRequest request = new CodeSystemImportRequest();
     request.setActivate(false);
-    request.setCodeSystem(toCodeSystem());
-    request.setVersion(toVersion(configuration.getVersion()));
+    List<String> supportedLanguages = supportedLanguages(concepts);
+    request.setCodeSystem(toCodeSystem(supportedLanguages));
+    request.setVersion(toVersion(configuration.getVersion(), supportedLanguages));
 
     request.setProperties(toProperties(concepts));
     request.setConcepts(toConcepts(concepts));
     return request;
   }
 
-  private static CodeSystemImportRequestCodeSystem toCodeSystem() {
+  /**
+   * Languages actually present in the imported concepts (display map keys), English first. Linguistic
+   * variant imports add their language (e.g. "cs") to the concept displays via
+   * {@code LoincService.processLinguisticVariants}; declaring them here means the code system / version
+   * advertise the translation language instead of only "en". Issue #48.
+   */
+  private static List<String> supportedLanguages(List<LoincConcept> concepts) {
+    LinkedHashSet<String> languages = new LinkedHashSet<>();
+    languages.add(Language.en);
+    concepts.stream().filter(c -> c.getDisplay() != null)
+        .flatMap(c -> c.getDisplay().keySet().stream())
+        .filter(Objects::nonNull)
+        .forEach(languages::add);
+    return new ArrayList<>(languages);
+  }
+
+  private static CodeSystemImportRequestCodeSystem toCodeSystem(List<String> supportedLanguages) {
     return new CodeSystemImportRequestCodeSystem().setId("loinc")
         .setUri("http://loinc.org")
         .setPublisher("Regenstrief Institute, Inc.")
         .setTitle(new LocalizedName(Map.of("en", "LOINC")))
         .setContent(CodeSystemContent.complete)
         .setCaseSensitive(CaseSignificance.entire_term_case_insensitive)
-        .setSupportedLanguages(List.of(Language.en));
+        .setSupportedLanguages(supportedLanguages);
   }
 
-  private static CodeSystemImportRequestVersion toVersion(String version) {
+  private static CodeSystemImportRequestVersion toVersion(String version, List<String> supportedLanguages) {
     return new CodeSystemImportRequestVersion()
         .setVersion(version)
-        .setSupportedLanguages(List.of(Language.en))
+        .setSupportedLanguages(supportedLanguages)
         .setReleaseDate(LocalDate.now());
   }
 

--- a/edition-int/src/test/groovy/org/termx/LoincMapperTest.groovy
+++ b/edition-int/src/test/groovy/org/termx/LoincMapperTest.groovy
@@ -6,7 +6,6 @@ import org.termx.editionint.loinc.utils.LoincImportRequest
 import org.termx.editionint.loinc.utils.LoincMapper
 import org.termx.ts.codesystem.Concept
 import org.termx.ts.codesystem.EntityPropertyType
-import spock.lang.PendingFeature
 import spock.lang.Specification
 
 class LoincMapperTest extends Specification {
@@ -32,14 +31,10 @@ class LoincMapperTest extends Specification {
     classProp.rule == null
   }
 
-  // PINS issue #48 Bug 2. processLinguisticVariants() merges a translation file into each concept's
-  // display map under its language (e.g. "cs"), so cs designations ARE imported — but toCodeSystem()
-  // and toVersion() hardcode supportedLanguages=[en], so the code system never declares the
-  // translation language. That mismatch is the only thing that distinguishes the (Czech) translation
-  // designations from the English ones, and is the most likely cause of the "strange view until the
-  // concept is re-saved" symptom. @PendingFeature: expected to fail today; flips (failing the build)
-  // when the importer is fixed to declare imported translation languages — remove the annotation then.
-  @PendingFeature(reason = "Issue #48 Bug 2: LOINC translation import does not declare the translation language as supported")
+  // Issue #48 Bug 2. processLinguisticVariants() merges a translation file into each concept's display
+  // map under its language (e.g. "cs"), so cs designations are imported; the importer now also declares
+  // those languages on the code system / version (previously hardcoded to [en]), which is what made the
+  // Czech designations render correctly only after a manual re-save.
   def "(#48 bug2) importing a translation language declares it as a supported language"() {
     given: "a concept carrying English + Czech displays, exactly as processLinguisticVariants leaves it"
     def concept = new LoincConcept().setCode("1234-5").setDisplay([en: "Glucose", cs: "Glukóza"]).setProperties([])


### PR DESCRIPTION
Fixes #48 Bug 2 (pinned in the parent PR #199). The LOINC importer merges translation files into each concept's display map under its language but hardcoded `supportedLanguages=[en]`, so the code system never declared the translation language — which is why Czech translations only rendered correctly after a manual re-save. Now derives supported languages from the languages present in the concept displays.

Stacked on #199 (contains the `@PendingFeature` pin this turns green). **Retarget to `main` and rebase once #199 merges.**