### PR TITLE
Combine value set rule filters with logical AND (#196)

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
@@ -289,8 +289,10 @@ expressions as (
                          (t.filter_ ->> 'operator')::text = 'not-in' and d.name != all(string_to_array((t.filter_ ->> 'value')::text, ','))
                     ))
   union
-  -- all recursive (hierarchical) concepts calculated before
-  select c.*, r.rn, r.fcnt, r.level from c
+  -- all recursive (hierarchical) concepts calculated before.
+  -- is-not-a concepts come from the left-joined `r` being NULL, so fall back to the filter row `t`
+  -- for rn/fcnt — otherwise their rn is NULL and the AND check (#196) would drop them.
+  select c.*, coalesce(r.rn, t.rn), coalesce(r.fcnt, t.fcnt), r.level from c
   left join r  on c.code_system = r.code_system  and c.rule_id = r.rule_id  and c.csev_id = r.csev_id
   left join rc on c.code_system = rc.code_system and c.rule_id = rc.rule_id and c.csev_id = rc.csev_id
   left join t  on t.code_system = c.code_system  and t.rule_id = c.rule_id
@@ -312,9 +314,13 @@ expressions as (
      and rc.operator <> 'is-not-a'
 ),
 expression_concepts as (
-  select rule_id, type, csev_code, obj, fcnt, count(*)
+  -- A rule's filters combine with logical AND (FHIR compose.include[].filter[]): a concept is kept
+  -- only when it matched every filter of the rule. Each row in `expressions` carries the rn of the
+  -- filter that produced it, so a concept that satisfied all `fcnt` filters has `fcnt` distinct rn. (#196)
+  select rule_id, type, csev_code, obj, fcnt
     from expressions
    group by rule_id, type, csev_code, obj, fcnt
+  having count(distinct rn) = fcnt
 ),
 cs_all as (
   select t.rule_id, t."type", t.code_system, t.original_code_system_version_id, t.code_system_version_id, csev.id csev_id, csev.code csev_code,

--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -349,7 +349,7 @@ WITH recursive vs AS (
   -- Forward-hierarchy descendants, shaped per operator: child-of keeps only level 1,
   -- descendent-leaf keeps only descendants that have no child of their own, is-not-a is
   -- handled by complement below (excluded here). Membership in the rule's version is enforced.
-  select z.rule_id, z.type, z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code, z."codeSystemUri", z."baseCodeSystemUri"
+  select z.rn, z.rule_id, z.type, z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code, z."codeSystemUri", z."baseCodeSystemUri"
     from r z
    where z.operator <> 'is-not-a'
      and (z.operator <> 'child-of' or z.level = 1)
@@ -359,42 +359,45 @@ WITH recursive vs AS (
                   where m.sys_status = 'A' and m.code_system_entity_version_id = z.csev_id and m.code_system_version_id = z.code_system_version_id)
   union
   -- generalizes ancestors
-  select rr.rule_id, rr.type, rr.fcnt, rr."codeSystem", rr.code_system_version_id, rr.csev_id, rr.code, rr."codeSystemUri", rr."baseCodeSystemUri"
+  select rr.rn, rr.rule_id, rr.type, rr.fcnt, rr."codeSystem", rr.code_system_version_id, rr.csev_id, rr.code, rr."codeSystemUri", rr."baseCodeSystemUri"
     from rr
    where exists (select 1 from terminology.entity_version_code_system_version_membership m
                   where m.sys_status = 'A' and m.code_system_entity_version_id = rr.csev_id and m.code_system_version_id = rr.code_system_version_id)
   union
   -- the filter value concept itself for is-a / generalizes
-  select rc.rule_id, rc.type, rc.fcnt, rc."codeSystem", rc.code_system_version_id, rc.csev_id, rc.code, rc."codeSystemUri", rc."baseCodeSystemUri"
+  select rc.rn, rc.rule_id, rc.type, rc.fcnt, rc."codeSystem", rc.code_system_version_id, rc.csev_id, rc.code, rc."codeSystemUri", rc."baseCodeSystemUri"
     from rc
    where rc.operator in ('is-a','generalizes')
      and exists (select 1 from terminology.entity_version_code_system_version_membership m
                   where m.sys_status = 'A' and m.code_system_entity_version_id = rc.csev_id and m.code_system_version_id = rc.code_system_version_id)
   union
   -- is-not-a: every member of the version that is neither in the forward set nor the concept itself
-  select p.rule_id, p.type, p.fcnt, p."codeSystem", p.code_system_version_id, p.csev_id, p.code, p."codeSystemUri", p."baseCodeSystemUri"
+  select p.rn, p.rule_id, p.type, p.fcnt, p."codeSystem", p.code_system_version_id, p.csev_id, p.code, p."codeSystemUri", p."baseCodeSystemUri"
     from pool p
    where not exists (select 1 from r r2 where r2.rule_id = p.rule_id and r2."codeSystem" = p."codeSystem" and r2.csev_id = p.csev_id and r2.operator = 'is-not-a')
      and not exists (select 1 from rc rc2 where rc2.rule_id = p.rule_id and rc2."codeSystem" = p."codeSystem" and rc2.csev_id = p.csev_id)
 )
 , all_findings as (
-  select z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
+  select z.rn, z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
          jsonb_build_object('conceptVersionId', z.csev_id, 'code', z.code, 'codeSystem', z."codeSystem", 'codeSystemUri', z."codeSystemUri", 'baseCodeSystemUri', z."baseCodeSystemUri") obj
     from hier as z
   union
-  select z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
+  select z.rn, z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
          jsonb_build_object('conceptVersionId', z.csev_id, 'code', z.code, 'codeSystem', z."codeSystem", 'codeSystemUri', z."codeSystemUri", 'baseCodeSystemUri', z."baseCodeSystemUri")
     from c as z
   union
-  select z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
+  select z.rn, z.rule_id, z."type", z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code,
          jsonb_build_object('conceptVersionId', z.csev_id, 'code', z.code, 'codeSystem', z."codeSystem", 'codeSystemUri', z."codeSystemUri", 'baseCodeSystemUri', z."baseCodeSystemUri")
     from d as z
 )
 , expression_concepts as (
-  select rule_id, type, code, obj, fcnt, count(*)
+  -- A rule's filters combine with logical AND (FHIR compose.include[].filter[]): a concept is kept
+  -- only when it matched every filter of the rule. Each finding carries the rn of the filter that
+  -- produced it, so a concept that satisfied all `fcnt` filters has `fcnt` distinct rn. (#196)
+  select rule_id, type, code, obj, fcnt
     from all_findings
    group by rule_id, type, code, obj, fcnt
-  having fcnt = count(*)
+  having count(distinct rn) = fcnt
 )
 , cs as (
   select r.type, csev.code,

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandFilterOperatorIT.groovy
@@ -120,6 +120,16 @@ class ValueSetExpandFilterOperatorIT extends TermxIntegTest {
     expand(filter("method", "exists", true)) == ["A", "B"] as Set
   }
 
+  def "exists=false matches every concept that has NO value of the property"() {
+    expect: "the complement of the exists=true set"
+    expand(filter("method", "exists", false)) == ["C", "D", "X"] as Set
+  }
+
+  def "'=' on a custom property matches concepts whose property equals the value"() {
+    expect: "method = CHROM on A and B"
+    expand(filter("method", "=", "CHROM")) == ["A", "B"] as Set
+  }
+
   // --- helpers ---------------------------------------------------------------
 
   private Set<String> expand(ValueSetRuleFilter... filters) {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
@@ -105,6 +105,21 @@ class ValueSetExpandInlineFilterOperatorIT extends TermxIntegTest {
     expandInline("method", "exists", true) == ["A", "B"] as Set
   }
 
+  def "exists=false matches every concept that has NO value of the property"() {
+    expect:
+    expandInline("method", "exists", false) == ["C", "D", "X"] as Set
+  }
+
+  // NB: a string-valued custom-property '=' (e.g. method = "CHROM") returns empty on the inline path —
+  // value_set_expand(text) expects Coding-OBJECT values for custom-property filters (the only form the
+  // UI/FHIR import produces). The stored path matches it via jsonb equality. Tracked as a follow-up
+  // inconsistency; not asserted here so as not to pin buggy behaviour.
+
+  def "legacy 'parent =' shorthand returns the descendants of the value (no self)"() {
+    expect: "preserved backwards-compatible behaviour: descendants of A"
+    expandInline("parent", "=", "A") == ["B", "C", "D"] as Set
+  }
+
   // --- helpers ---------------------------------------------------------------
 
   private Set<String> expandInline(String property, String op, Object value) {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandJsonbBooleanCastIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandJsonbBooleanCastIT.groovy
@@ -73,7 +73,10 @@ class ValueSetExpandJsonbBooleanCastIT extends TermxIntegTest {
     // 'exists' filter it deterministically reaches the boolean cast: the old code evaluated
     // `(filter_ -> 'value')::boolean` whenever operator = 'exists', and casting a jsonb OBJECT to
     // boolean raises "cannot cast jsonb object to type boolean". A second, clean exists=true filter
-    // gives a positive match so we can also assert the fixed function still expands normally.
+    // sits beside it so the cast path is reached even when a sibling filter matches normally.
+    // NB: since #196 the two filters AND, and the object-valued 'exists' (value is neither 'true' nor
+    // 'false') matches nothing, so the rule expands to the empty set — the point here is purely that
+    // the jsonb->boolean cast no longer throws.
     def cleanExistsFilter = new ValueSetRuleFilter()
         .setProperty(new PropertyReference().setName("method"))
         .setOperator("exists")
@@ -104,9 +107,23 @@ class ValueSetExpandJsonbBooleanCastIT extends TermxIntegTest {
     def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
     def expansion = conceptRepository.expand(versionId)
 
-    then: "no DataIntegrityViolationException / cast error, and the 'exists'-matched concept is returned"
+    then: "no DataIntegrityViolationException / cast error (the object value reaches the exists branch safely)"
     noExceptionThrown()
-    expansion.find { it.concept?.code == "a" } != null
+    expansion != null
+
+    and: "a clean exists=true filter on its own still expands normally — concept 'a' has the property"
+    def cleanRule = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID).setFilters([cleanExistsFilter])
+    def cleanVersion = new ValueSetVersion().setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([cleanRule]))
+    cleanVersion.setValueSet(VS_ID)
+    cleanVersion.setVersion("1.0.1")
+    def cleanRequest = new ValueSetTransactionRequest()
+    cleanRequest.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new com.kodality.commons.model.LocalizedName().add("en", "VsExpand cast regression")))
+    cleanRequest.setVersion(cleanVersion)
+    valueSetService.save(cleanRequest)
+    def cleanVersionId = valueSetVersionService.load(VS_ID, "1.0.1").orElseThrow().getId()
+    conceptRepository.expand(cleanVersionId).find { it.concept?.code == "a" } != null
   }
 
   private org.termx.ts.codesystem.CodeSystem domainCs(String json) {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandMultiFilterIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandMultiFilterIT.groovy
@@ -1,0 +1,155 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.commons.util.JsonUtil
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+
+/**
+ * Issue #196 — multiple filters within a single value set rule must combine with logical AND
+ * (FHIR {@code compose.include[].filter[]} semantics: a concept must satisfy EVERY filter).
+ * Pinned against both expansion paths: stored {@code value_set_expand(bigint)} and inline
+ * {@code value_set_expand(text)}.
+ *
+ * <p>Fixture {@code cs-hierarchy.json}: A → {B → D, C}, plus root X; {@code method} on A and B.
+ * So {@code is-a A} = {A,B,C,D}, {@code exists method} = {A,B}; their AND = {A,B}.
+ * And {@code descendent-of A} = {B,C,D} AND {@code exists method} = {A,B} → {B}.
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandMultiFilterIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptRepository conceptRepository
+
+  static final String CS_ID = "vsexpand-filter-cs"
+  static final String CS_URI = "http://termx-test.local/CodeSystem/vsexpand-filter-cs"
+  static final String VS_ID = "vsexpand-multi-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importHierarchyCs()
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "stored path ANDs two filters in one rule (is-a A AND exists method = A,B)"() {
+    expect:
+    expandStored([f("concept", "is-a", "A"), f("method", "exists", true)]) == ["A", "B"] as Set
+  }
+
+  def "stored path ANDs descendent-of A AND exists method = B"() {
+    expect:
+    expandStored([f("concept", "descendent-of", "A"), f("method", "exists", true)]) == ["B"] as Set
+  }
+
+  def "inline path ANDs two filters in one rule (is-a A AND exists method = A,B)"() {
+    expect:
+    expandInline([[property: "concept", op: "is-a", value: "A"], [property: "method", op: "exists", value: true]]) == ["A", "B"] as Set
+  }
+
+  def "inline path ANDs descendent-of A AND exists method = B"() {
+    expect:
+    expandInline([[property: "concept", op: "descendent-of", value: "A"], [property: "method", op: "exists", value: true]]) == ["B"] as Set
+  }
+
+  def "stored path ORs across multiple include rules (filters AND within a rule, rules OR)"() {
+    given: "rule 1 = (child-of A AND exists method) = {B}; rule 2 = code in X,C = {C,X}"
+    def rule1 = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID)
+        .setFilters([f("concept", "child-of", "A"), f("method", "exists", true)])
+    def rule2 = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID)
+        .setFilters([f("code", "in", "X,C")])
+
+    expect: "the value set is the union of the two rules"
+    expandStoredRules([rule1, rule2]) == ["B", "C", "X"] as Set
+  }
+
+  def "inline path ORs across multiple include blocks"() {
+    given: "include 1 = (child-of A AND exists method) = {B}; include 2 = code in X,C = {C,X}"
+    def include1 = [[property: "concept", op: "child-of", value: "A"], [property: "method", op: "exists", value: true]]
+    def include2 = [[property: "code", op: "in", value: "X,C"]]
+
+    expect:
+    expandInlineIncludes([include1, include2]) == ["B", "C", "X"] as Set
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private Set<String> expandStoredRules(List<ValueSetVersionRule> rules) {
+    def version = new ValueSetVersion().setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules(rules))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Multi filter")))
+    request.setVersion(version)
+    valueSetService.save(request)
+    def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+    return conceptRepository.expand(versionId).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private Set<String> expandInlineIncludes(List includes) {
+    def valueSet = [resourceType: "ValueSet", compose: [inactive: false,
+        include: includes.collect { [system: CS_URI, version: VS_VERSION, filter: it] }]]
+    return conceptRepository.expandFromJson(JsonUtil.toJson(valueSet)).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private Set<String> expandStored(List<ValueSetRuleFilter> filters) {
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID).setFilters(filters)
+    def version = new ValueSetVersion().setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Multi filter")))
+    request.setVersion(version)
+    valueSetService.save(request)
+    def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+    return conceptRepository.expand(versionId).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private Set<String> expandInline(List filters) {
+    def valueSet = [resourceType: "ValueSet", compose: [inactive: false,
+        include: [[system: CS_URI, version: VS_VERSION, filter: filters]]]]
+    return conceptRepository.expandFromJson(JsonUtil.toJson(valueSet)).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private static ValueSetRuleFilter f(String property, String operator, Object value) {
+    return new ValueSetRuleFilter().setProperty(new PropertyReference().setName(property)).setOperator(operator).setValue(value)
+  }
+
+  private void importHierarchyCs() {
+    def stream = getClass().getClassLoader().getResourceAsStream("fhir/vsexpand/cs-hierarchy.json")
+    assert stream != null
+    def json = new String(stream.readAllBytes(), "UTF-8")
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    importService.importCodeSystem(fhirMapper.fromFhirCodeSystem(fhir), [],
+        new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandMultiFilterIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandMultiFilterIT.groovy
@@ -97,6 +97,35 @@ class ValueSetExpandMultiFilterIT extends TermxIntegTest {
     expandInlineIncludes([include1, include2]) == ["B", "C", "X"] as Set
   }
 
+  def "stored path subtracts an exclude rule (include is-a A EXCEPT code = C)"() {
+    given:
+    def include = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID).setFilters([f("concept", "is-a", "A")])
+    def exclude = new ValueSetVersionRule().setType("exclude").setCodeSystem(CS_ID).setFilters([f("code", "=", "C")])
+
+    expect: "{A,B,C,D} minus {C}"
+    expandStoredRules([include, exclude]) == ["A", "B", "D"] as Set
+  }
+
+  def "inline path subtracts an exclude block (include is-a A EXCEPT code = C)"() {
+    given:
+    def valueSet = [resourceType: "ValueSet", compose: [inactive: false,
+        include: [[system: CS_URI, version: VS_VERSION, filter: [[property: "concept", op: "is-a", value: "A"]]]],
+        exclude: [[system: CS_URI, version: VS_VERSION, filter: [[property: "code", op: "=", value: "C"]]]]]]
+
+    expect:
+    conceptRepository.expandFromJson(JsonUtil.toJson(valueSet)).collect { it.concept?.code }.findAll { it != null } as Set == ["A", "B", "D"] as Set
+  }
+
+  def "stored path ANDs two hierarchical filters (is-a A AND is-a B = B,D)"() {
+    expect: "is-a A = {A,B,C,D}; is-a B = {B,D}; their AND = {B,D}"
+    expandStored([f("concept", "is-a", "A"), f("concept", "is-a", "B")]) == ["B", "D"] as Set
+  }
+
+  def "inline path ANDs two hierarchical filters (is-a A AND is-a B = B,D)"() {
+    expect:
+    expandInline([[property: "concept", op: "is-a", value: "A"], [property: "concept", op: "is-a", value: "B"]]) == ["B", "D"] as Set
+  }
+
   // --- helpers ---------------------------------------------------------------
 
   private Set<String> expandStoredRules(List<ValueSetVersionRule> rules) {


### PR DESCRIPTION
Closes #196.

## Problem
When a value set rule carries **multiple filters** (FHIR `compose.include[].filter[]`), they must combine with **logical AND** — a concept is included only if it satisfies *every* filter. Both expansion functions got this wrong:
- `value_set_expand(bigint)` (stored) effectively **OR-ed** the filters (no AND enforcement)
- `value_set_expand(text)` (inline) returned **nothing** for any rule with 2+ filters

## Fix
Each finding already carries the `rn` of the filter that produced it, so AND is enforced in `expression_concepts` with `having count(distinct rn) = fcnt`. In the stored function the `is-not-a` rows are built from a left-joined (NULL) hierarchy row, so rn/fcnt fall back to the filter row (`coalesce(r.rn, t.rn)`) — otherwise their rn would be NULL and the AND check would drop them.

**Multiple include rules still OR** (the AND check is grouped per `rule_id`; rules are unioned) — verified by tests.

## Tests
- `ValueSetExpandMultiFilterIT` — AND within a rule (`is-a A AND exists method = {A,B}`, `descendent-of A AND exists method = {B}`) and OR across rules, on both the stored and inline paths.
- `ValueSetExpandJsonbBooleanCastIT` updated — its two-`exists`-filter rule now correctly ANDs to empty (the object-valued `exists` matches nothing); the jsonb→boolean cast-regression intent is preserved and normal expansion is asserted with a separate single-filter rule.

Full `:terminology:test` and `:termx-integtest:test` suites green.