### PR TITLE
Bump kefhir R5.7 → R5.8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.7
+kefhirVersion=R5.8
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev


### PR DESCRIPTION
Adopts kefhir **R5.8**, which carries the batch Bundle robustness fix ([kefhir#7](https://github.com/termx-health/kefhir/pull/7)): a non-`FhirException` in one batch entry no longer aborts the whole batch with HTTP 500 — each failure returns its own `OperationOutcome` entry.

Verified: dependency resolves to `fhir-rest:R5.8`, full app boots and `BatchBundleIT` passes with the new version.

Follow-up: add a per-entry-failure assertion to `BatchBundleIT` now that R5.8 is in.