### PR TITLE
ValueSet expansion follow-ups: parent=→child-of, scalar custom-property matching, perf diagnostic

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
@@ -260,10 +260,12 @@ expressions as (
                           -- not guaranteed. ->> gives '{"code":"X",…}' for objects, 'true'/'false' for
                           -- JSON booleans — comparison is then a plain text equality, never throws.
                           (t.filter_ ->> 'operator')::text = 'exists' and (t.filter_ ->> 'value')::text = 'true' or
-                          (t.filter_ ->> 'operator')::text = '=' and (epv.value::jsonb = (t.filter_ -> 'value') or (epv.value ->> 'code')::text = (t.filter_ ->> 'value')::text) or
-                          (t.filter_ ->> 'operator')::text = 'regex' and (epv.value::text = any(regexp_match(epv.value::text, (t.filter_ ->> 'value')::text||'$')) or (epv.value ->> 'code')::text = any(regexp_match((epv.value ->> 'code')::text, (t.filter_ ->> 'value')::text||'$'))) or
-                          (t.filter_ ->> 'operator')::text = 'in' and (epv.value::text = any(string_to_array((t.filter_ ->> 'value')::text, ',')) or (epv.value ->> 'code')::text = any(string_to_array((t.filter_ ->> 'value')::text, ','))) or
-                          (t.filter_ ->> 'operator')::text = 'not-in' and (epv.value::text != all(string_to_array((t.filter_ ->> 'value')::text, ',')) and (epv.value ->> 'code')::text != all(string_to_array((t.filter_ ->> 'value')::text, ',')))
+                          -- scalar values are read with `#>> '{}'` (UNQUOTED text); `::text` would keep
+                          -- the jsonb quotes and never match a plain string. Coding values via ->> 'code'.
+                          (t.filter_ ->> 'operator')::text = '=' and (epv.value::jsonb = (t.filter_ -> 'value') or (epv.value #>> '{}') = (t.filter_ ->> 'value')::text or (epv.value ->> 'code')::text = (t.filter_ ->> 'value')::text) or
+                          (t.filter_ ->> 'operator')::text = 'regex' and ((epv.value #>> '{}') = any(regexp_match((epv.value #>> '{}'), (t.filter_ ->> 'value')::text||'$')) or (epv.value ->> 'code')::text = any(regexp_match((epv.value ->> 'code')::text, (t.filter_ ->> 'value')::text||'$'))) or
+                          (t.filter_ ->> 'operator')::text = 'in' and ((epv.value #>> '{}') = any(string_to_array((t.filter_ ->> 'value')::text, ',')) or (epv.value ->> 'code')::text = any(string_to_array((t.filter_ ->> 'value')::text, ','))) or
+                          (t.filter_ ->> 'operator')::text = 'not-in' and ((epv.value #>> '{}') != all(string_to_array((t.filter_ ->> 'value')::text, ',')) and coalesce(epv.value ->> 'code', '') != all(string_to_array((t.filter_ ->> 'value')::text, ',')))
                      ))
           -- Same text-vs-boolean swap as above; symmetric for 'exists = false'.
           or (t.filter_ ->> 'operator')::text = 'exists' and (t.filter_ ->> 'value')::text = 'false' and

--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -283,22 +283,30 @@ WITH recursive vs AS (
               (t.filter_ ->> 'op') = 'not-in' and con.code != all(string_to_array((t.filter_ ->> 'value')::text, ','))
          ))
          or
-         -- custom property with '=', 'in', 'regex' (loose match preserved, incl. Coding-shaped values)
+         -- custom property with '=', 'in', 'regex'. A scalar (string/number) value is compared via
+         -- `epv.value #>> '{}'` (the UNQUOTED text form — `::text` would keep the jsonb quotes and never
+         -- match a plain string); a Coding value via `epv.value ->> 'code'`. The filter value may itself
+         -- be a scalar or a Coding object ({"code":…}), so both forms are accepted. No cross-joined
+         -- unnest (which previously produced zero rows, hence no match, for scalar filter values).
          ((t.filter_ ->> 'property') not in ('code', 'concept') and (t.filter_ ->> 'op') in ('=','in','regex') and
           exists (select 1
-                    from terminology.entity_property_value epv, terminology.entity_property ep,
-                        unnest(string_to_array(t.filter_ ->> 'value', ',')) AS pattern1,
-                        unnest(string_to_array(t.filter_ -> 'value' ->> 'code', ',')) AS pattern2
+                    from terminology.entity_property_value epv, terminology.entity_property ep
                   where epv.sys_status = 'A' and csev.id = epv.code_system_entity_version_id
                     and ep.sys_status = 'A' and ep.code_system = con.code_system and ep.id = epv.entity_property_id
                     and (t.filter_ ->> 'property') = ep.name
-                    and (
-                         ep.type <> 'Coding' and ((t.filter_ ->> 'value') is null or (t.filter_ -> 'value') = epv.value::jsonb or
-                         (epv.value ->> 'code')::text ~ trim(pattern1))
-                         or
-                         ep.type = 'Coding' and  ((t.filter_ -> 'value' ->> 'code') is null or (t.filter_ -> 'value' -> 'code') = epv.value::jsonb or
-                         (epv.value ->> 'code')::text ~ trim(pattern2))
-                    )
+                    and ((t.filter_ ->> 'value') is null
+                         or (t.filter_ ->> 'op') = '=' and (
+                              epv.value::jsonb = (t.filter_ -> 'value')
+                              or (epv.value #>> '{}') = (t.filter_ ->> 'value')
+                              or (epv.value ->> 'code') = (t.filter_ ->> 'value')
+                              or (epv.value ->> 'code') = (t.filter_ -> 'value' ->> 'code'))
+                         or (t.filter_ ->> 'op') = 'in' and (
+                              (epv.value #>> '{}') = any(string_to_array((t.filter_ ->> 'value'), ','))
+                              or (epv.value ->> 'code') = any(string_to_array((t.filter_ ->> 'value'), ','))
+                              or (epv.value ->> 'code') = any(string_to_array((t.filter_ -> 'value' ->> 'code'), ',')))
+                         or (t.filter_ ->> 'op') = 'regex' and (
+                              (epv.value #>> '{}') ~ (t.filter_ ->> 'value')
+                              or (epv.value ->> 'code') ~ (t.filter_ ->> 'value')))
                  ))
          or
          -- custom property with 'exists' (value true => has >=1 value; value false => has none)
@@ -316,15 +324,15 @@ WITH recursive vs AS (
                      and (t.filter_ ->> 'property') = ep.name)
          ))
          or
-         -- custom property with 'not-in' (the concept has no value of the property in the set)
+         -- custom property with 'not-in' (no value of the property is in the set)
          ((t.filter_ ->> 'property') not in ('code', 'concept') and (t.filter_ ->> 'op') = 'not-in' and
           not exists (select 1
-                        from terminology.entity_property_value epv, terminology.entity_property ep,
-                            unnest(string_to_array(t.filter_ ->> 'value', ',')) AS pattern1
+                        from terminology.entity_property_value epv, terminology.entity_property ep
                        where epv.sys_status = 'A' and csev.id = epv.code_system_entity_version_id
                          and ep.sys_status = 'A' and ep.code_system = con.code_system and ep.id = epv.entity_property_id
                          and (t.filter_ ->> 'property') = ep.name
-                         and (epv.value::text = trim(pattern1) or (epv.value ->> 'code')::text = trim(pattern1))))
+                         and ((epv.value #>> '{}') = any(string_to_array((t.filter_ ->> 'value'), ','))
+                              or (epv.value ->> 'code') = any(string_to_array((t.filter_ ->> 'value'), ',')))))
   )
 )
 , d as (

--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -346,13 +346,14 @@ WITH recursive vs AS (
          '(' || replace(pattern, ',', '|') || ')')
 )
 , hier as (
-  -- Forward-hierarchy descendants, shaped per operator: child-of keeps only level 1,
-  -- descendent-leaf keeps only descendants that have no child of their own, is-not-a is
-  -- handled by complement below (excluded here). Membership in the rule's version is enforced.
+  -- Forward-hierarchy descendants, shaped per operator: child-of (and the legacy `parent =`
+  -- shorthand) keep only level 1 — direct children; descendent-leaf keeps only descendants that have
+  -- no child of their own; is-not-a is handled by the complement below (excluded here). Membership in
+  -- the rule's version is enforced. NB: operator '=' reaches `r` only via `parent =`.
   select z.rn, z.rule_id, z.type, z.fcnt, z."codeSystem", z.code_system_version_id, z.csev_id, z.code, z."codeSystemUri", z."baseCodeSystemUri"
     from r z
    where z.operator <> 'is-not-a'
-     and (z.operator <> 'child-of' or z.level = 1)
+     and (z.operator not in ('child-of', '=') or z.level = 1)
      and (z.operator <> 'descendent-leaf' or not exists (
             select 1 from r r1 where r1.rule_id = z.rule_id and r1."codeSystem" = z."codeSystem" and r1.parent = z.csev_id))
      and exists (select 1 from terminology.entity_version_code_system_version_membership m

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandExplainTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandExplainTest.groovy
@@ -1,0 +1,157 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.commons.util.JsonUtil
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+import spock.lang.IgnoreIf
+
+import javax.sql.DataSource
+
+/**
+ * EXPLAIN (ANALYZE, BUFFERS) of is-a expansion over a large hierarchy, for both engines — to locate
+ * the dominant cost behind the superlinear scaling seen in {@link ValueSetExpandPerfTest}.
+ *
+ * <p>Runs transactional and reuses the transaction-bound connection for the EXPLAIN so it sees the
+ * data imported in the same transaction. Gated behind {@code PERF}; size via {@code PERF_N} /
+ * {@code PERF_B}:
+ * <pre>
+ *   ./gradlew :termx-integtest:test --tests '*ValueSetExpandExplainTest' PERF=true PERF_N=20000
+ * </pre>
+ */
+@MicronautTest(transactional = true)
+@IgnoreIf({ env.PERF == null })
+class ValueSetExpandExplainTest extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject DataSource dataSource
+
+  static final String CS_ID = "explain-hier-cs"
+  static final String CS_URI = "http://termx-test.local/CodeSystem/explain-hier-cs"
+  static final String VS_ID = "explain-hier-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "EXPLAIN ANALYZE is-a expansion (stored fn01 + inline fn37)"() {
+    given:
+    int n = (System.getenv('PERF_N') ?: '20000') as int
+    int b = (System.getenv('PERF_B') ?: '6') as int
+    importHierarchy(n, b)
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID)
+        .setFilters([new ValueSetRuleFilter().setProperty(new PropertyReference().setName("concept")).setOperator("is-a").setValue("c1")])
+    saveDraftValueSet(rule)
+    def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+    def inlineJson = JsonUtil.toJson([resourceType: "ValueSet", compose: [inactive: false,
+        include: [[system: CS_URI, version: VS_VERSION, filter: [[property: "concept", op: "is-a", value: "c1"]]]]]])
+
+    when:
+    def storedPlan = explain("select * from terminology.value_set_expand(${versionId}::bigint)", null)
+    // EXPLAIN the function BODY directly (param inlined) so the inner CTE node tree is visible — the
+    // function-scan EXPLAIN above only shows the opaque outer call.
+    def body = fetchBigintBody().replace("p_value_set_version_id", versionId.toString())
+    def innerPlan = explain(body, null)
+
+    then:
+    println "\n===================== EXPLAIN stored value_set_expand(bigint)  n=${n} b=${b} =====================\n" + storedPlan
+    println "\n===================== EXPLAIN INNER body of value_set_expand(bigint)  n=${n} b=${b} =====================\n" + innerPlan
+    true
+  }
+
+  private String fetchBigintBody() {
+    def conn = org.springframework.jdbc.datasource.DataSourceUtils.getConnection(dataSource)
+    try {
+      def rs = conn.createStatement().executeQuery(
+          "select prosrc from pg_proc p where proname = 'value_set_expand' and pg_get_function_arguments(p.oid) like '%bigint%'")
+      rs.next()
+      return rs.getString(1)
+    } finally {
+      org.springframework.jdbc.datasource.DataSourceUtils.releaseConnection(conn, dataSource)
+    }
+  }
+
+  private String explain(String sql, String textParam) {
+    // Reuse the connection bound to the test's transaction so the EXPLAIN sees the data imported in
+    // the same transaction (and so Micronaut's connection management is satisfied).
+    def conn = org.springframework.jdbc.datasource.DataSourceUtils.getConnection(dataSource)
+    try {
+      def full = "EXPLAIN (ANALYZE, BUFFERS, VERBOSE) " + sql
+      def rs
+      if (textParam == null) {
+        rs = conn.createStatement().executeQuery(full)
+      } else {
+        def ps = conn.prepareStatement(full)
+        ps.setString(1, textParam)
+        rs = ps.executeQuery()
+      }
+      def sb = new StringBuilder()
+      while (rs.next()) {
+        sb.append(rs.getString(1)).append("\n")
+      }
+      return sb.toString()
+    } finally {
+      org.springframework.jdbc.datasource.DataSourceUtils.releaseConnection(conn, dataSource)
+    }
+  }
+
+  private void importHierarchy(int n, int b) {
+    Map<Integer, List<Integer>> children = [:].withDefault { [] }
+    for (int i = 2; i <= n; i++) {
+      children[((i - 2).intdiv(b)) + 1] << i
+    }
+    Closure<Map> buildConcept
+    buildConcept = { int i ->
+      def c = [code: "c${i}".toString(), display: "Concept ${i}".toString()]
+      def kids = children[i]
+      if (kids) {
+        c.concept = kids.collect { buildConcept(it) }
+      }
+      return c
+    }
+    def cs = [resourceType: "CodeSystem", id: CS_ID, url: CS_URI, version: "1.0.0", name: "ExplainHierCs",
+              title: "Explain hierarchy code system", status: "active", content: "complete",
+              caseSensitive: true, hierarchyMeaning: "is-a", concept: [buildConcept(1)]]
+    def fhir = FhirMapper.fromJson(JsonUtil.toJson(cs), com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    importService.importCodeSystem(fhirMapper.fromFhirCodeSystem(fhir), [],
+        new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private void saveDraftValueSet(ValueSetVersionRule rule) {
+    def version = new ValueSetVersion().setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Explain hierarchy")))
+    request.setVersion(version)
+    valueSetService.save(request)
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandFilterOperatorIT.groovy
@@ -130,6 +130,21 @@ class ValueSetExpandFilterOperatorIT extends TermxIntegTest {
     expand(filter("method", "=", "CHROM")) == ["A", "B"] as Set
   }
 
+  def "'in' on a string custom property matches concepts whose property is in the set"() {
+    expect:
+    expand(filter("method", "in", "CHROM,OTHER")) == ["A", "B"] as Set
+  }
+
+  def "'=' on a Coding custom property matches by code"() {
+    expect: "coded.code = cd-a on A"
+    expand(filter("coded", "=", "cd-a")) == ["A"] as Set
+  }
+
+  def "'in' on a Coding custom property matches by code"() {
+    expect:
+    expand(filter("coded", "in", "cd-a,cd-b")) == ["A", "B"] as Set
+  }
+
   // --- helpers ---------------------------------------------------------------
 
   private Set<String> expand(ValueSetRuleFilter... filters) {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
@@ -115,9 +115,9 @@ class ValueSetExpandInlineFilterOperatorIT extends TermxIntegTest {
   // UI/FHIR import produces). The stored path matches it via jsonb equality. Tracked as a follow-up
   // inconsistency; not asserted here so as not to pin buggy behaviour.
 
-  def "legacy 'parent =' shorthand returns the descendants of the value (no self)"() {
-    expect: "preserved backwards-compatible behaviour: descendants of A"
-    expandInline("parent", "=", "A") == ["B", "C", "D"] as Set
+  def "legacy 'parent =' shorthand returns the direct children of the value (child-of semantics)"() {
+    expect: "parent = A => direct children of A only (B, C), not deeper descendants"
+    expandInline("parent", "=", "A") == ["B", "C"] as Set
   }
 
   // --- helpers ---------------------------------------------------------------

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
@@ -110,10 +110,30 @@ class ValueSetExpandInlineFilterOperatorIT extends TermxIntegTest {
     expandInline("method", "exists", false) == ["C", "D", "X"] as Set
   }
 
-  // NB: a string-valued custom-property '=' (e.g. method = "CHROM") returns empty on the inline path —
-  // value_set_expand(text) expects Coding-OBJECT values for custom-property filters (the only form the
-  // UI/FHIR import produces). The stored path matches it via jsonb equality. Tracked as a follow-up
-  // inconsistency; not asserted here so as not to pin buggy behaviour.
+  def "'=' on a string custom property matches concepts whose property equals the value"() {
+    expect: "method = CHROM on A and B"
+    expandInline("method", "=", "CHROM") == ["A", "B"] as Set
+  }
+
+  def "'in' on a string custom property matches concepts whose property is in the set"() {
+    expect:
+    expandInline("method", "in", "CHROM,OTHER") == ["A", "B"] as Set
+  }
+
+  def "'=' on a Coding custom property matches by code (scalar value)"() {
+    expect: "coded.code = cd-a on A"
+    expandInline("coded", "=", "cd-a") == ["A"] as Set
+  }
+
+  def "'=' on a Coding custom property matches by code (Coding-object value)"() {
+    expect:
+    expandInline("coded", "=", [code: "cd-a"]) == ["A"] as Set
+  }
+
+  def "'in' on a Coding custom property matches by code"() {
+    expect:
+    expandInline("coded", "in", "cd-a,cd-b") == ["A", "B"] as Set
+  }
 
   def "legacy 'parent =' shorthand returns the direct children of the value (child-of semantics)"() {
     expect: "parent = A => direct children of A only (B, C), not deeper descendants"

--- a/termx-integtest/src/test/resources/fhir/vsexpand/cs-hierarchy.json
+++ b/termx-integtest/src/test/resources/fhir/vsexpand/cs-hierarchy.json
@@ -11,18 +11,19 @@
   "caseSensitive": true,
   "hierarchyMeaning": "is-a",
   "property": [
-    {"code": "method", "type": "string"}
+    {"code": "method", "type": "string"},
+    {"code": "coded", "type": "Coding"}
   ],
   "concept": [
     {
       "code": "A",
       "display": "Alpha",
-      "property": [{"code": "method", "valueString": "CHROM"}],
+      "property": [{"code": "method", "valueString": "CHROM"}, {"code": "coded", "valueCoding": {"code": "cd-a"}}],
       "concept": [
         {
           "code": "B",
           "display": "Bravo",
-          "property": [{"code": "method", "valueString": "CHROM"}],
+          "property": [{"code": "method", "valueString": "CHROM"}, {"code": "coded", "valueCoding": {"code": "cd-b"}}],
           "concept": [
             {"code": "D", "display": "Delta"}
           ]


### PR DESCRIPTION
Follow-ups from the #197 / #196 expansion work. Three independent changes:

## 1. `parent =` shorthand now means child-of (direct children)
The legacy `parent = X` shorthand on the inline path returned **all descendants**; it now returns **direct children only** (FHIR `child-of` semantics). `ValueSetExpandInlineFilterOperatorIT`: `parent = A` → `{B, C}`.

## 2. Scalar custom-property `=`/`in`/`regex`/`not-in` now match
A string-valued custom-property filter (`method = "CHROM"`, `method in "A,B"`) matched **nothing**:
- `value_set_expand(text)` cross-joined `unnest(value -> 'code')`, which is empty for a scalar value → no rows.
- both functions compared `epv.value::text` (which keeps jsonb quotes, e.g. `"CHROM"`) against the bare filter text → never matched a plain string.

Now scalar values are read with `epv.value #>> '{}'` (unquoted) and Coding values with `epv.value ->> 'code'`; the filter value is accepted as a scalar **or** a Coding object. **Stored and inline paths now agree.** Fixes the inconsistency tracked in the prior PR. Tests: string + Coding `=`/`in` on both paths (fixture extended with a Coding property).

## 3. Perf diagnostic
`ValueSetExpandExplainTest` — PERF-gated `EXPLAIN (ANALYZE, BUFFERS)` harness. Finding: the dominant cost is the recursive hierarchy CTE (planner can't estimate recursion depth → O(N²)); the obvious predicate-removal regressed, so the live SQL is unchanged and large expansions rely on the materialized snapshot.

Full `:terminology:`, `:termx-integtest:`, `:snomed:` suites green.