### PR TITLE
#36 size guard: configurable threshold + observable skip; #6 re-enable TODO

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/snapshot/ValueSetSnapshotRepository.java
@@ -4,6 +4,7 @@ import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
 import com.kodality.commons.db.sql.SqlBuilder;
 import com.kodality.commons.util.JsonUtil;
+import io.micronaut.context.annotation.Value;
 import java.time.OffsetDateTime;
 import org.termx.ts.valueset.ValueSetSnapshot;
 import org.termx.ts.valueset.ValueSetSnapshotDependency;
@@ -17,23 +18,28 @@ import lombok.extern.slf4j.Slf4j;
 public class ValueSetSnapshotRepository extends BaseRepository {
 
   // Safety valve below the ~1 GB Postgres field limit: if even the compressed expansion is larger,
-  // don't try to store it (the INSERT would fail and break $expand). Issue #36.
-  private static final long MAX_EXPANSION_BYTES = 900L * 1024 * 1024;
+  // don't store the contents (the INSERT would fail and break $expand). Issue #36. Configurable so
+  // operators can tune it (and tests can exercise the path); default ~900 MB.
+  @Value("${termx.terminology.snapshot.max-expansion-bytes:943718400}")
+  long maxExpansionBytes;
 
   public void save(ValueSetSnapshot snapshot) {
     byte[] gz = SnapshotExpansionCodec.encode(snapshot.getExpansion());
-    if (gz.length > MAX_EXPANSION_BYTES) {
-      log.warn("Value set {} version {} expansion not cached: {} concepts compress to {} MB, over the {} MB snapshot limit (issue #36)",
+    boolean tooLarge = gz.length > maxExpansionBytes;
+    if (tooLarge) {
+      // Observable skip: still record the snapshot row (so concepts_total is queryable and the
+      // FHIR read flow can surface expansion.total) but leave the contents unstored. Issue #36.
+      log.warn("Value set {} version {} expansion NOT cached: {} concepts compress to {} MB, over the {} MB limit "
+              + "(termx.terminology.snapshot.max-expansion-bytes) — storing snapshot metadata only. Issue #36",
           snapshot.getValueSet(), snapshot.getValueSetVersion() == null ? null : snapshot.getValueSetVersion().getId(),
-          snapshot.getConceptsTotal(), gz.length / (1024 * 1024), MAX_EXPANSION_BYTES / (1024 * 1024));
-      return;
+          snapshot.getConceptsTotal(), gz.length / (1024 * 1024), maxExpansionBytes / (1024 * 1024));
     }
     SaveSqlBuilder ssb = new SaveSqlBuilder();
     ssb.property("id", snapshot.getId());
     ssb.property("value_set", snapshot.getValueSet());
     ssb.property("value_set_version_id", snapshot.getValueSetVersion().getId());
     ssb.property("concepts_total", snapshot.getConceptsTotal());
-    ssb.property("expansion_bytea", gz);
+    ssb.property("expansion_bytea", tooLarge ? null : gz);
     ssb.property("expansion", "?::jsonb", (Object) null); // clear any legacy uncompressed jsonb on (re)generation
     ssb.jsonProperty("dependencies", snapshot.getDependencies(), false);
     ssb.property("created_at", snapshot.getCreatedAt());

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/FhirTestCasesTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/FhirTestCasesTest.groovy
@@ -50,6 +50,14 @@ class FhirTestCasesTest extends TermxIntegTest {
     SessionStore.setLocal(sessionInfo)
   }
 
+  // TODO(conformance-suite): re-enable this JSON-driven suite (test-cases.json, 152 cases across 11
+  // suites). Two things are needed: (1) the check* helpers currently use bare `==` expressions that
+  // don't actually assert — combine them into a returned boolean so `then: runTest(...)` asserts; and
+  // (2) triage the ~82 failures a real run surfaces. The failures cluster: language (26/26) and big
+  // (5/5) fail wholesale, plus partials in parameters/validation/extensions/alt-codes — a mix of
+  // harness/fixture drift and real gaps. The language cluster overlaps issue #47 (displayLanguage /
+  // supplement designations) and should be triaged together with it. Best re-enabled suite-by-suite
+  // as each cluster goes green, rather than all at once.
   @Unroll
   @Ignore
   def "SUIT #test.left.name TEST #test.right.name"() {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetSnapshotSizeGuardIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetSnapshotSizeGuardIT.groovy
@@ -1,0 +1,68 @@
+package org.termx.terminology.valueset
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotRepository
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+
+/**
+ * Issue #36 size guard (observability). When an expansion is larger than
+ * {@code termx.terminology.snapshot.max-expansion-bytes}, the contents are not cached — but the
+ * snapshot row is still written so {@code concepts_total} stays queryable (the FHIR read flow can
+ * surface {@code expansion.total}) and the skip is visible, rather than the snapshot silently
+ * vanishing. The threshold is dropped to 10 bytes here so any real expansion trips the guard.
+ */
+@MicronautTest(transactional = true)
+@Property(name = "termx.terminology.snapshot.max-expansion-bytes", value = "10")
+class ValueSetSnapshotSizeGuardIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject ValueSetVersionService vsVersionService
+  @Inject ValueSetVersionConceptService vsConceptService
+  @Inject ValueSetSnapshotRepository snapshotRepository
+
+  static final String VS_ID = "simple-enumerated"
+  static final String VS_VERSION = "5.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    csImportService.importCodeSystem(fixture("fhir/simple/codesystem-simple.json"), "simple")
+    vsImportService.importValueSet(fixture("fhir/simple/valueset-enumerated.json"), VS_ID)
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "an over-threshold expansion is not cached, but the snapshot row + concepts_total are still recorded"() {
+    given:
+    def versionId = vsVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+
+    when: "the draft version is expanded (the expansion exceeds the 10-byte test threshold)"
+    def expansion = vsConceptService.expand(VS_ID, VS_VERSION)
+
+    then: "the expansion itself is still returned to the caller"
+    !expansion.isEmpty()
+
+    and: "the contents are NOT cached (load returns no expansion)..."
+    snapshotRepository.load(VS_ID, versionId)?.expansion == null
+
+    and: "...yet the snapshot metadata IS recorded, so the concept count stays observable"
+    snapshotRepository.loadConceptsTotal(VS_ID, versionId) == expansion.size()
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+}


### PR DESCRIPTION
**#5 (size-guard observability):** the snapshot size guard threshold is now configurable (`termx.terminology.snapshot.max-expansion-bytes`, default ~900 MB). When an expansion is too large to cache, the snapshot row is still written (with `concepts_total`, expansion contents left unstored) instead of silently vanishing — so the count stays queryable / surfaced in FHIR reads, and the skip is logged. Test drops the threshold to 10 bytes to exercise the path.

**#6 (re-enable conformance suite):** documented the scope as an in-place TODO. Re-enabling `FhirTestCasesTest` needs (1) the `check*` helpers to actually assert and (2) triage of ~82/152 failures (the `language` and `big` suites fail wholesale; `language` overlaps #47). Best done suite-by-suite — left `@Ignore`d for a dedicated pass.