### PR TITLE
#4: bump kefhir → R5.9 (failing batch entry keeps its HTTP status)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.8
+kefhirVersion=R5.9
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/BatchBundleIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/BatchBundleIT.groovy
@@ -140,9 +140,9 @@ class BatchBundleIT extends TermxIntegTest {
     body.get("type").asText() == "batch-response"
     body.get("entry").size() == 2
 
-    and: "the forbidden entry is its own OperationOutcome (error status), and the permitted entry still ran"
+    and: "the forbidden entry is its own OperationOutcome with the right status (403, not a blanket 500), and the permitted entry still ran"
     resourceOfType(body, "OperationOutcome") != null
-    responseStatusOf(body, "OperationOutcome") == "500"
+    responseStatusOf(body, "OperationOutcome") == "403"
     resourceOfType(body, "Parameters") != null
   }
 


### PR DESCRIPTION
Adopts kefhir **R5.9** ([kefhir#8](https://github.com/termx-health/kefhir/pull/8)): a non-`FhirException` batch entry now reports its real HTTP status (403 for a `ForbiddenException`) instead of a blanket 500. `BatchBundleIT` is updated to assert the forbidden entry → 403. Verified: resolves `fhir-rest:R5.9`, both batch cases green.