### PR TITLE
#47: parse the valueset-supplement extension on import

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -89,6 +89,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   private final ValueSetRelatedArtifactService relatedArtifactService;
   private static final String concept_definition = "http://hl7.org/fhir/StructureDefinition/valueset-concept-definition";
   private static final String concept_order = "http://hl7.org/fhir/StructureDefinition/valueset-conceptOrder";
+  private static final String VALUESET_SUPPLEMENT_EXTENSION = "http://hl7.org/fhir/StructureDefinition/valueset-supplement";
 
   public ValueSetFhirMapper(ConceptService conceptService,
                             CodeSystemService codeSystemService, ValueSetService valueSetService, MapSetService mapSetService,
@@ -242,7 +243,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       if (rule.getCodeSystemBaseUri() != null) {
         include.setSystem(rule.getCodeSystemBaseUri());
         include.setVersion(baseVersion);
-        fhirValueSet.addExtension(new Extension("http://hl7.org/fhir/StructureDefinition/valueset-supplement").setValueCanonical(PipeUtil.toPipe(rule.getCodeSystemUri(), version)));
+        fhirValueSet.addExtension(new Extension(VALUESET_SUPPLEMENT_EXTENSION).setValueCanonical(PipeUtil.toPipe(rule.getCodeSystemUri(), version)));
         if (rule.getCodeSystem() != null && rule.getCodeSystemVersion() != null) {
           include.setConcept(toFhirConcept(rule.getConcepts(), conceptService.query(new ConceptQueryParams().setCodeSystem(rule.getCodeSystem()).setCodeSystemVersion(rule.getCodeSystemVersion().getVersion()).all()).getData()));
         }
@@ -657,10 +658,37 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       ruleSet.setLockedDate(valueSet.getCompose().getLockedDate().atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime());
     }
     ruleSet.setRules(fromFhirRules(valueSet.getCompose().getInclude(), valueSet.getCompose().getExclude()));
+    applyValueSetSupplement(valueSet, ruleSet);
     if (CollectionUtils.isNotEmpty(valueSet.getCompose().getProperty())) {
       ruleSet.getRules().forEach(r -> r.setProperties(valueSet.getCompose().getProperty()));
     }
     return ruleSet;
+  }
+
+  /**
+   * Round-trips the {@code valueset-supplement} extension that {@link #toFhirCompose} emits: the
+   * include carries the BASE code system in {@code system}, and the extension carries the supplement
+   * canonical ({@code supplementUri|version}). Bind the include rule to the supplement (recording the
+   * base in {@code codeSystemBaseUri}) so $expand surfaces the supplement's designations. Only the
+   * unambiguous single-supplement / single-include case is mapped; anything else is left untouched
+   * (round-tripping multiple supplements is a TODO — the extension is VS-level so it can't be paired
+   * to a specific include). Issue #47.
+   */
+  private static void applyValueSetSupplement(com.kodality.zmei.fhir.resource.terminology.ValueSet valueSet, ValueSetVersionRuleSet ruleSet) {
+    List<Extension> supplements = valueSet.getExtensions(VALUESET_SUPPLEMENT_EXTENSION).toList();
+    List<ValueSetVersionRule> includes = ruleSet.getRules() == null ? List.of() :
+        ruleSet.getRules().stream().filter(r -> ValueSetVersionRuleType.include.equals(r.getType())).toList();
+    if (supplements.size() != 1 || includes.size() != 1 || StringUtils.isEmpty(supplements.get(0).getValueCanonical())) {
+      return;
+    }
+    String[] parts = PipeUtil.parsePipe(supplements.get(0).getValueCanonical());
+    ValueSetVersionRule rule = includes.get(0);
+    String baseVersion = rule.getCodeSystemVersion() == null ? null : rule.getCodeSystemVersion().getVersion();
+    rule.setCodeSystemBaseUri(rule.getCodeSystemUri());
+    rule.setCodeSystemUri(parts[0]);
+    rule.setCodeSystemVersion(new CodeSystemVersionReference()
+        .setVersion(parts.length > 1 ? parts[1] : null)
+        .setBaseCodeSystemVersion(baseVersion == null ? null : new CodeSystemVersionReference().setVersion(baseVersion)));
   }
 
   private static List<ValueSetVersionRule> fromFhirRules(List<ValueSetComposeInclude> include, List<ValueSetComposeInclude> exclude) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperSupplementSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperSupplementSpec.groovy
@@ -1,0 +1,81 @@
+package org.termx.terminology.fhir.valueset
+
+import com.kodality.commons.model.LocalizedName
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.mapset.MapSetService
+import org.termx.terminology.terminology.relatedartifacts.ValueSetRelatedArtifactService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemVersionReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+class ValueSetFhirMapperSupplementSpec extends Specification {
+  def conceptService = Mock(ConceptService)
+  def codeSystemService = Mock(CodeSystemService)
+  def valueSetService = Mock(ValueSetService)
+  def mapSetService = Mock(MapSetService)
+  def relatedArtifactService = Mock(ValueSetRelatedArtifactService)
+
+  def mapper = new ValueSetFhirMapper(conceptService, codeSystemService, valueSetService, mapSetService, relatedArtifactService)
+
+  static final String SUPPLEMENT_EXT = "http://hl7.org/fhir/StructureDefinition/valueset-supplement"
+
+  def "(#47) a supplement-bound rule round-trips through toFhir -> fromFhir"() {
+    given: "a value set whose include rule binds a supplement, with the base recorded separately"
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def rule = new ValueSetVersionRule()
+        .setType("include")
+        .setCodeSystemUri("http://example.org/CodeSystem/base-supplement-lt")
+        .setCodeSystemBaseUri("http://example.org/CodeSystem/base")
+        .setCodeSystemVersion(new CodeSystemVersionReference().setVersion("2026")
+            .setBaseCodeSystemVersion(new CodeSystemVersionReference().setVersion("1.0")))
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def version = new ValueSetVersion().setVersion("1.0.0").setStatus(PublicationStatus.draft)
+        .setReleaseDate(LocalDate.parse("2026-03-18"))
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [])
+    def importedRule = ValueSetFhirMapper.fromFhirValueSet(fhir).versions.first().ruleSet.rules.first()
+
+    then: "export puts the base on include.system and the supplement in the valueset-supplement extension"
+    fhir.compose.include.first().system == "http://example.org/CodeSystem/base"
+    fhir.extension.any { it.url == SUPPLEMENT_EXT && it.valueCanonical == "http://example.org/CodeSystem/base-supplement-lt|2026" }
+
+    and: "import restores the supplement binding instead of discarding it (issue #47)"
+    importedRule.codeSystemUri == "http://example.org/CodeSystem/base-supplement-lt"
+    importedRule.codeSystemBaseUri == "http://example.org/CodeSystem/base"
+    importedRule.codeSystemVersion.version == "2026"
+    importedRule.codeSystemVersion.baseCodeSystemVersion.version == "1.0"
+  }
+
+  def "(#47) a plain (non-supplement) include is unaffected"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def rule = new ValueSetVersionRule().setType("include")
+        .setCodeSystemUri("http://example.org/CodeSystem/plain")
+        .setCodeSystemVersion(new CodeSystemVersionReference().setVersion("1.0"))
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def version = new ValueSetVersion().setVersion("1.0.0").setStatus(PublicationStatus.draft)
+        .setReleaseDate(LocalDate.parse("2026-03-18"))
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [])
+    def importedRule = ValueSetFhirMapper.fromFhirValueSet(fhir).versions.first().ruleSet.rules.first()
+
+    then: "no supplement extension, and the rule still binds the original code system"
+    !fhir.extension.any { it.url == SUPPLEMENT_EXT }
+    importedRule.codeSystemUri == "http://example.org/CodeSystem/plain"
+    importedRule.codeSystemBaseUri == null
+  }
+}


### PR DESCRIPTION
## #47 — valueset-supplement

What already worked: $expand's `displayLanguage` parameter, and merging a CodeSystem supplement's designations into expansion (via `baseEntityVersionId`). The gap was **import**: export emits the `valueset-supplement` extension (include.system = base CS, extension canonical = `supplementUri|version`), but `fromFhirCompose` discarded it — so the supplement binding was lost on round-trip.

`fromFhirCompose` now parses the extension (single-supplement / single-include case, mirroring the export) and restores the rule's supplement binding (`codeSystemUri`=supplement, `codeSystemBaseUri`=base, supplement + base versions). Round-trip test (`ValueSetFhirMapperSupplementSpec`) covers export→import; a plain include is asserted unaffected.

**Out of scope / TODO:** multi-supplement round-trip (the extension is VS-level so it can't be paired to a specific include); a full DB integration test with a real supplement pulling e.g. Lithuanian designations through $expand (overlaps the `language` conformance suite tracked in the #6 TODO).