### PR TITLE
FHIR tx-ecosystem conformance test runner (Phases 2, 3, 5)

### DIFF
--- a/.github/workflows/tx-conformance.yml
+++ b/.github/workflows/tx-conformance.yml
@@ -1,0 +1,75 @@
+name: FHIR tx conformance
+
+# Runs the official HL7 tx-ecosystem terminology test suite against a deployed termx FHIR endpoint
+# and publishes the TestReport, so the conformance score is tracked over time. This points at an
+# already-running server (the way the HL7 ecosystem comparison works) rather than booting termx in CI.
+
+on:
+  schedule:
+    # Daily 04:00 UTC
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      tx_url:
+        description: "FHIR base URL of the termx server under test (e.g. https://demo.termx.org/api/fhir)"
+        required: false
+      suite:
+        description: "Optional: run only this suite (e.g. simple-cases)"
+        required: false
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    name: tx-ecosystem conformance
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Resolve target server
+        id: target
+        run: |
+          TX_URL="${{ github.event.inputs.tx_url }}"
+          if [ -z "$TX_URL" ]; then TX_URL="${{ vars.TX_CONFORMANCE_URL }}"; fi
+          if [ -z "$TX_URL" ]; then
+            echo "::error::No target FHIR URL. Set the 'tx_url' input or the TX_CONFORMANCE_URL repo variable."
+            exit 1
+          fi
+          echo "tx_url=$TX_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Download FHIR validator
+        run: curl -fsSL -o validator_cli.jar https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar
+
+      - name: Run tx-ecosystem tests
+        id: run
+        continue-on-error: true
+        run: |
+          SUITE_ARG=""
+          if [ -n "${{ github.event.inputs.suite }}" ]; then SUITE_ARG="-suite ${{ github.event.inputs.suite }}"; fi
+          java -jar validator_cli.jar txTests -tx "${{ steps.target.outputs.tx_url }}" $SUITE_ARG -output report | tee run.log
+
+      - name: Summarize score
+        if: always()
+        run: |
+          if [ -f report/report.json ]; then
+            result=$(jq -r '.result // "?"' report/report.json)
+            score=$(jq -r '.score // "?"' report/report.json)
+            total=$(jq '[.test[]?] | length' report/report.json)
+            passed=$(jq '[.test[]? | select(.action[0].operation.result == "pass")] | length' report/report.json)
+            server=$(jq -r '.participant[0].uri // "?"' report/report.json)
+            echo "::notice::tx conformance result=$result score=$score passed=$passed/$total against $server"
+          else
+            echo "::warning::no report.json produced — see run.log"
+          fi
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tx-conformance-report
+          path: |
+            report/
+            run.log
+          if-no-files-found: warn

--- a/terminology/build.gradle.kts
+++ b/terminology/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     api(project(":termx-api"))
     api(project(":termx-core"))
     api(project(":task"))
+    implementation(project(":bob")) // tx-conformance: custom test-bundle storage (MinIO/Bob)
 
     implementation("com.kodality.commons:commons-util:${rootProject.extra["commonsVersion"]}")
     implementation("com.kodality.commons:commons-db:${rootProject.extra["commonsVersion"]}")

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceBobContainerAuthorizer.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceBobContainerAuthorizer.java
@@ -1,0 +1,34 @@
+package org.termx.terminology.fhir.conformance;
+
+import jakarta.inject.Singleton;
+import org.termx.bob.BobContainerAuthorizer;
+import org.termx.bob.BobObject;
+import org.termx.core.auth.SessionInfo;
+
+/**
+ * Authorizes the {@code tx-conformance} Bob container, where custom tx-ecosystem test bundles are
+ * uploaded (via the generic {@code POST /bob/objects}) before being run with {@code -input}.
+ * Without this bean the generic Bob endpoints treat the container as forbidden.
+ *
+ * <p>Conformance testing is a server-level operation, so it is gated on the system (Space) privilege,
+ * matching {@code TxConformanceController}.
+ */
+@Singleton
+public class TxConformanceBobContainerAuthorizer implements BobContainerAuthorizer {
+  public static final String CONTAINER = "tx-conformance";
+
+  @Override
+  public String getContainer() {
+    return CONTAINER;
+  }
+
+  @Override
+  public void checkRead(SessionInfo session, BobObject object) {
+    session.checkPermitted("*", "Space", "read");
+  }
+
+  @Override
+  public void checkWrite(SessionInfo session, BobObject object) {
+    session.checkPermitted("*", "Space", "write");
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceController.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceController.java
@@ -1,0 +1,31 @@
+package org.termx.terminology.fhir.conformance;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import lombok.RequiredArgsConstructor;
+import org.termx.core.Privilege;
+import org.termx.core.auth.Authorized;
+import org.termx.sys.lorque.LorqueProcess;
+import org.termx.ts.conformance.TxConformanceRunRequest;
+
+/**
+ * Triggers a tx-ecosystem conformance run against this server. Returns the async {@link LorqueProcess}
+ * immediately; poll {@code GET /lorque-processes/{id}} for status and the FHIR {@code TestReport}.
+ *
+ * <p>This is the "static, callable resource" — usable from CLI/CI ({@code curl}) and from the UI.
+ * Custom test bundles are uploaded via the generic {@code POST /bob/objects} (container
+ * {@code tx-conformance}) and referenced here by {@code archiveUuid}.
+ */
+@Controller("/tx-conformance")
+@RequiredArgsConstructor
+public class TxConformanceController {
+  private final TxConformanceService txConformanceService;
+
+  @Authorized(Privilege.S_WRITE)
+  @Post("/runs")
+  public LorqueProcess run(@Nullable @Body TxConformanceRunRequest request) {
+    return txConformanceService.run(request == null ? new TxConformanceRunRequest() : request);
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceRunner.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceRunner.java
@@ -1,0 +1,156 @@
+package org.termx.terminology.fhir.conformance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kodality.commons.util.JsonUtil;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.termx.ts.conformance.TxConformanceRunRequest;
+
+/**
+ * Runs the HL7 FHIR terminology ("tx-ecosystem") test suite against a terminology server by shelling
+ * out to the FHIR validator's {@code txTests} command, mirroring {@code SnomedDeltaGeneratorRuntime}'s
+ * subprocess pattern.
+ *
+ * <pre>java -jar &lt;validator&gt; txTests -tx &lt;server&gt;/fhir -output &lt;tmp&gt; [-suite ..][-filter ..][-mode ..][-input ..]</pre>
+ *
+ * <p>The validator (~180MB) is NOT bundled in the repo; its path is configured via
+ * {@code termx.conformance.validator-jar} (the deployment provides it). The bundled tx-ecosystem
+ * test cases are loaded by the validator itself — nothing is vendored here.
+ *
+ * <p>The command's exit code reflects test pass/fail, so it is NOT treated as an error; the produced
+ * {@code report.json} (a FHIR {@code TestReport}) is the result, and only a missing report is fatal.
+ */
+@Slf4j
+@Singleton
+public class TxConformanceRunner {
+  private static final String XMX = "-Xmx2G";
+
+  private final String validatorJar;
+  private final String txUrl;
+
+  public TxConformanceRunner(
+      @Value("${termx.conformance.validator-jar:}") String validatorJar,
+      @Value("${termx.conformance.tx-url:http://localhost:8200/fhir}") String txUrl) {
+    this.validatorJar = validatorJar;
+    this.txUrl = txUrl;
+  }
+
+  /** Runs the suite and returns the raw {@code report.json} (a FHIR {@code TestReport}). */
+  public String run(TxConformanceRunRequest req, Path inputBundle) throws IOException, InterruptedException {
+    if (StringUtils.isEmpty(validatorJar)) {
+      throw new IllegalStateException("termx.conformance.validator-jar is not configured");
+    }
+    Path jar = Path.of(validatorJar);
+    if (!Files.exists(jar)) {
+      throw new IllegalStateException("validator jar not found at " + validatorJar);
+    }
+    Path output = Files.createTempDirectory("termx-txtests-");
+    List<String> cmd = buildCommand(jar, output, req, inputBundle);
+    log.info("Launching tx conformance tests: {}", String.join(" ", cmd));
+
+    long started = System.currentTimeMillis();
+    Process p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+    StringBuilder out = new StringBuilder();
+    try (BufferedReader r = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+      String line;
+      while ((line = r.readLine()) != null) {
+        out.append(line).append('\n');
+      }
+    }
+    int exit = p.waitFor();
+    long durationMs = System.currentTimeMillis() - started;
+
+    Path reportFile = output.resolve("report.json");
+    if (!Files.exists(reportFile)) {
+      throw new IOException("tx conformance run produced no report.json (exit " + exit + "). Log tail:\n" + tail(out.toString(), 40));
+    }
+    String report = Files.readString(reportFile);
+    log.info("tx conformance run finished in {} ms (exit {}): {}", durationMs, exit, summarize(report));
+    return report;
+  }
+
+  /** Builds the validator command line. Package-private for unit testing. */
+  List<String> buildCommand(Path jar, Path output, TxConformanceRunRequest req, Path inputBundle) {
+    List<String> cmd = new ArrayList<>();
+    cmd.add(javaBinary());
+    cmd.add(XMX);
+    cmd.add("-jar");
+    cmd.add(jar.toAbsolutePath().toString());
+    cmd.add("txTests");
+    cmd.add("-tx");
+    cmd.add(txUrl);
+    cmd.add("-output");
+    cmd.add(output.toAbsolutePath().toString());
+    if (req != null) {
+      if (StringUtils.isNotEmpty(req.getSuite())) {
+        cmd.add("-suite");
+        cmd.add(req.getSuite());
+      }
+      if (StringUtils.isNotEmpty(req.getFilter())) {
+        cmd.add("-filter");
+        cmd.add(req.getFilter());
+      }
+      if (StringUtils.isNotEmpty(req.getMode())) {
+        cmd.add("-mode");
+        cmd.add(req.getMode());
+      }
+    }
+    if (inputBundle != null) {
+      cmd.add("-input");
+      cmd.add(inputBundle.toAbsolutePath().toString());
+    }
+    return cmd;
+  }
+
+  /** One-line pass/fail summary from a FHIR TestReport. Package-private for unit testing. */
+  static String summarize(String reportJson) {
+    try {
+      JsonNode n = JsonUtil.getObjectMapper().readTree(reportJson);
+      int passed = 0;
+      int failed = 0;
+      JsonNode tests = n.get("test");
+      if (tests != null && tests.isArray()) {
+        for (JsonNode t : tests) {
+          JsonNode actions = t.get("action");
+          String result = null;
+          if (actions != null && actions.isArray() && !actions.isEmpty()) {
+            JsonNode op = actions.get(0).get("operation");
+            if (op != null && op.get("result") != null) {
+              result = op.get("result").asText();
+            }
+          }
+          if ("pass".equals(result)) {
+            passed++;
+          } else {
+            failed++;
+          }
+        }
+      }
+      String result = n.path("result").asText("");
+      double score = n.path("score").asDouble(0);
+      return String.format("result=%s score=%.3f passed=%d failed=%d", result, score, passed, failed);
+    } catch (Exception e) {
+      return "unparseable report: " + e.getMessage();
+    }
+  }
+
+  private static String javaBinary() {
+    return Path.of(System.getProperty("java.home"), "bin", "java").toString();
+  }
+
+  private static String tail(String s, int lines) {
+    String[] arr = s.split("\n");
+    int from = Math.max(0, arr.length - lines);
+    return String.join("\n", List.of(arr).subList(from, arr.length));
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceService.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceService.java
@@ -1,0 +1,75 @@
+package org.termx.terminology.fhir.conformance;
+
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.termx.bob.BobObject;
+import org.termx.bob.BobObjectService;
+import org.termx.core.sys.lorque.LorqueProcessService;
+import org.termx.sys.lorque.LorqueProcess;
+import org.termx.sys.lorque.ProcessResult;
+import org.termx.ts.conformance.TxConformanceRunRequest;
+
+/**
+ * Orchestrates a tx-ecosystem conformance run as an async {@link LorqueProcess} (process name
+ * {@code tx-conformance}); the FHIR {@code TestReport} is stored as the process result (JSON), so
+ * callers fetch status/results via {@code GET /lorque-processes/{id}} — same pattern as SNOMED
+ * import-from-archive. A custom test bundle (optional {@code archiveUuid}) is streamed out of the
+ * {@code tx-conformance} Bob container to a temp file and passed to the runner as {@code -input}.
+ */
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class TxConformanceService {
+  private final TxConformanceRunner runner;
+  private final LorqueProcessService lorqueProcessService;
+  private final BobObjectService bobObjectService;
+
+  public LorqueProcess run(TxConformanceRunRequest request) {
+    return lorqueProcessService.run("tx-conformance", request, req -> {
+      Path bundle = null;
+      try {
+        if (StringUtils.isNotEmpty(req.getArchiveUuid())) {
+          bundle = downloadBundle(req.getArchiveUuid());
+        }
+        String report = runner.run(req, bundle);
+        return new ProcessResult().setContent(report.getBytes(StandardCharsets.UTF_8)).setContentType("application/json");
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("tx conformance run interrupted", e);
+      } catch (Exception e) {
+        throw new RuntimeException(e.getMessage(), e);
+      } finally {
+        if (bundle != null) {
+          try {
+            Files.deleteIfExists(bundle);
+          } catch (Exception e) {
+            log.warn("failed to delete temp test bundle {}", bundle, e);
+          }
+        }
+      }
+    });
+  }
+
+  private Path downloadBundle(String uuid) throws Exception {
+    BobObject obj = bobObjectService.load(uuid);
+    if (obj == null) {
+      throw new IllegalArgumentException("test bundle not found: " + uuid);
+    }
+    if (obj.getStorage() == null || !TxConformanceBobContainerAuthorizer.CONTAINER.equals(obj.getStorage().getContainer())) {
+      throw new IllegalArgumentException("archive " + uuid + " is not in the '" + TxConformanceBobContainerAuthorizer.CONTAINER + "' container");
+    }
+    Path tmp = Files.createTempFile("txtests-bundle-", ".bundle");
+    try (InputStream is = bobObjectService.loadContentStream(obj)) {
+      Files.copy(is, tmp, StandardCopyOption.REPLACE_EXISTING);
+    }
+    log.info("downloaded custom test bundle {} ({} bytes) for tx conformance run", uuid, Files.size(tmp));
+    return tmp;
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceService.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceService.java
@@ -3,7 +3,6 @@ package org.termx.terminology.fhir.conformance;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Singleton;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -39,7 +38,9 @@ public class TxConformanceService {
           bundle = downloadBundle(req.getArchiveUuid());
         }
         String report = runner.run(req, bundle);
-        return new ProcessResult().setContent(report.getBytes(StandardCharsets.UTF_8)).setContentType("application/json");
+        // Store as 'text' so LorqueProcessService.decorate populates resultText (the UI JSON.parses it);
+        // the content is the FHIR TestReport JSON. Matches the SNOMED import-from-archive convention.
+        return ProcessResult.text(report);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new RuntimeException("tx conformance run interrupted", e);

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceRunnerTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceRunnerTest.groovy
@@ -1,0 +1,57 @@
+package org.termx.terminology.fhir.conformance
+
+import org.termx.ts.conformance.TxConformanceRunRequest
+import spock.lang.Specification
+
+import java.nio.file.Path
+
+class TxConformanceRunnerTest extends Specification {
+  def runner = new TxConformanceRunner("/opt/validator_cli.jar", "http://termx.local/fhir")
+
+  def "buildCommand wires txTests with -tx, -output and the optional flags"() {
+    given:
+    def req = new TxConformanceRunRequest().setSuite("simple-cases").setMode("general")
+
+    when:
+    def cmd = runner.buildCommand(Path.of("/opt/validator_cli.jar"), Path.of("/tmp/out"), req, null)
+
+    then:
+    cmd.contains("-jar")
+    cmd.contains("/opt/validator_cli.jar")
+    cmd.contains("txTests")
+    cmd[cmd.indexOf("-tx") + 1] == "http://termx.local/fhir"
+    cmd[cmd.indexOf("-output") + 1] == "/tmp/out"
+    cmd[cmd.indexOf("-suite") + 1] == "simple-cases"
+    cmd[cmd.indexOf("-mode") + 1] == "general"
+    !cmd.contains("-filter")
+    !cmd.contains("-input")
+  }
+
+  def "buildCommand adds -input when a custom bundle is supplied"() {
+    when:
+    def cmd = runner.buildCommand(Path.of("/opt/validator_cli.jar"), Path.of("/tmp/out"),
+        new TxConformanceRunRequest(), Path.of("/tmp/bundle.tgz"))
+
+    then:
+    cmd[cmd.indexOf("-input") + 1] == "/tmp/bundle.tgz"
+  }
+
+  def "summarize counts passed/failed and reads result+score from a FHIR TestReport"() {
+    given:
+    def report = '''{
+      "resourceType":"TestReport","result":"fail","score":0.6667,
+      "test":[
+        {"name":"a","action":[{"operation":{"result":"pass"}}]},
+        {"name":"b","action":[{"operation":{"result":"pass"}}]},
+        {"name":"c","action":[{"operation":{"result":"fail"}}]}
+      ]}'''
+
+    expect:
+    TxConformanceRunner.summarize(report) == "result=fail score=0.667 passed=2 failed=1"
+  }
+
+  def "summarize is null-safe on a malformed report"() {
+    expect:
+    TxConformanceRunner.summarize("not json").startsWith("unparseable report")
+  }
+}

--- a/termx-api/src/main/java/org/termx/ts/conformance/TxConformanceRunRequest.java
+++ b/termx-api/src/main/java/org/termx/ts/conformance/TxConformanceRunRequest.java
@@ -1,0 +1,27 @@
+package org.termx.ts.conformance;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Request to run the HL7 FHIR terminology ("tx-ecosystem") conformance suite against this server's
+ * own FHIR endpoint via the validator's {@code txTests} command.
+ *
+ * <p>All fields are optional. With none set, the full bundled suite runs. {@code archiveUuid} points
+ * at a custom test bundle previously uploaded to the {@code tx-conformance} Bob container
+ * (via {@code POST /bob/objects}); it is passed to the runner as an additional {@code -input} loader.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+public class TxConformanceRunRequest {
+  /** Run only this suite (validator {@code -suite}). */
+  private String suite;
+  /** Filter test names (validator {@code -filter}). */
+  private String filter;
+  /** Test modes, e.g. {@code general} (validator {@code -mode}). */
+  private String mode;
+  /** UUID of a {@code bob.object} in the {@code tx-conformance} container holding a custom test bundle. */
+  private String archiveUuid;
+}

--- a/termx-app/Dockerfile
+++ b/termx-app/Dockerfile
@@ -33,6 +33,16 @@ ENV PR_NUMBER=$PR_NUMBER
 # isn't bound (dev runs without a mount).
 RUN mkdir -p /app/logs
 
+# FHIR terminology conformance testing (tx-ecosystem): bake in the HL7 FHIR validator so
+# POST /tx-conformance/runs works out of the box. The jar is ~180MB and is NOT committed to the repo
+# — it is fetched here. Pin VALIDATOR_CLI_URL to a specific release for a reproducible image; the
+# default tracks the latest validator. TERMX_CONFORMANCE_VALIDATOR_JAR points the app at it.
+ARG VALIDATOR_CLI_URL="https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar"
+RUN curl -fsSL -o /app/validator_cli.jar "${VALIDATOR_CLI_URL}"
+ENV TERMX_CONFORMANCE_VALIDATOR_JAR=/app/validator_cli.jar
+# This server's own FHIR base, used as the -tx target of the conformance run (override per deployment).
+ENV TERMX_CONFORMANCE_TX_URL=http://localhost:8200/fhir
+
 ENV JVM_OOM_OPTS="-XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/app/logs/"
 
 COPY build/libs/*-all.jar terminology.jar

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -123,6 +123,12 @@ chef.url: https://demo.termx.org/chef
 termx:
   web-url: https://demo.termx.org
   api-url: https://demo.termx.org/api
+  # FHIR terminology conformance testing (tx-ecosystem suite via the FHIR validator's txTests).
+  # validator-jar: absolute path to validator_cli.jar (NOT bundled — provided by the deployment, e.g.
+  # downloaded in the Dockerfile). tx-url: this server's externally-reachable FHIR base for -tx.
+  conformance:
+    validator-jar: ${TERMX_CONFORMANCE_VALIDATOR_JAR:}
+    tx-url: ${TERMX_CONFORMANCE_TX_URL:`http://localhost:8200/fhir`}
   fhir:
     codesystem:
       lookup:


### PR DESCRIPTION
Server-side of the tx-conformance feature — run the official HL7 `tx-ecosystem` terminology suite against this server and expose it over REST, plus deployment + CI. (Phase-1 spike verified the mechanism: 15/15 on `simple-cases` vs tx.fhir.org. Phase 4 = `termx-web` UI is a separate PR.)

## Phase 2 — backend + REST
- **`TxConformanceRunner`** — subprocess à la `SnomedDeltaGeneratorRuntime`: `java -jar <validator> txTests -tx <self>/fhir -output <tmp> [-suite/-filter/-mode/-input]`; reads `report.json` (FHIR `TestReport`). Test failures are not a process error; a missing report is.
- **`TxConformanceService`** — async `LorqueProcess` (`tx-conformance`), stores the `TestReport` as the result → **no new table**; poll `GET /lorque-processes/{id}`.
- **`TxConformanceController`** — `POST /tx-conformance/runs` (`S_WRITE`).

## Phase 3 — custom bundle via MinIO/Bob
Upload to the new `tx-conformance` Bob container (generic `POST /bob/objects`), reference by `archiveUuid` → streamed to temp → `-input`. `TxConformanceBobContainerAuthorizer` governs it.

## Phase 5 — deployment + CI
- **Dockerfile**: fetches `validator_cli.jar` (`ARG VALIDATOR_CLI_URL`, pinnable) and sets `TERMX_CONFORMANCE_VALIDATOR_JAR` / `TERMX_CONFORMANCE_TX_URL` so the endpoint works out of the box.
- **`.github/workflows/tx-conformance.yml`**: daily (+ dispatch) run against a deployed termx URL (`vars.TX_CONFORMANCE_URL`), uploads the `TestReport` artifact, surfaces result/score.

## Choices / verification
- ~180MB validator jar **not committed** — config path / image-fetched.
- `terminology` now depends on `:bob` (no cycle; full app compiles).
- Unit tests (command build + report summary) green; context boots with new beans.
- Not done here (needs deployment): an actual end-to-end run requires the validator jar + a running server.