### PR TITLE
#47: end-to-end test — supplement designations in $expand by displayLanguage

### DIFF
--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -1,0 +1,70 @@
+package org.termx.terminology.fhir
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+
+/**
+ * Issue #47 end-to-end. A CodeSystem supplement adds a Lithuanian ("lt") designation to a base
+ * code system's concept; a ValueSet references the supplement via the {@code valueset-supplement}
+ * extension (include.system = base, extension = supplement canonical). $expand with
+ * {@code displayLanguage=lt} must surface the supplement's Lithuanian display.
+ *
+ * Exercises the whole chain: supplement FHIR import (baseEntityVersionId linkage), ValueSet import
+ * parsing the valueset-supplement extension (PR #207) and resolving the rule to the supplement, and
+ * the expansion merging the supplement's own designations.
+ */
+@MicronautTest(transactional = true)
+class ValueSetSupplementExpandIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject ValueSetVersionService vsVersionService
+  @Inject ValueSetVersionConceptService vsConceptService
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    // Base first so the supplement import can link baseEntityVersionId to the base concept version.
+    csImportService.importCodeSystem(fixture("fhir/supplement/cs-base.json"), "suppl-base")
+    csImportService.importCodeSystem(fixture("fhir/supplement/cs-supplement-lt.json"), "suppl-lt")
+    vsImportService.importValueSet(fixture("fhir/supplement/vs-supplement.json"), "suppl-vs")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "the imported valueset-supplement binds the rule to the supplement"() {
+    when:
+    def rule = vsVersionService.load("suppl-vs", "1.0.0").orElseThrow().ruleSet.rules.first()
+
+    then: "the rule resolved to the supplement code system, with the base recorded separately"
+    rule.codeSystemUri == "http://example.org/CodeSystem/suppl-lt"
+    rule.codeSystemBaseUri == "http://example.org/CodeSystem/suppl-base"
+    rule.codeSystem == "suppl-lt"
+  }
+
+  def "\$expand with displayLanguage=lt surfaces the supplement's Lithuanian designation"() {
+    when:
+    def snapshot = vsConceptService.expand("suppl-vs", "1.0.0", "lt", true)
+    def concept = snapshot.expansion.find { it.concept.code == "code1" }
+
+    then: "the concept is expanded with the Lithuanian display from the supplement (issue #47)"
+    concept != null
+    concept.display.language == "lt"
+    concept.display.name == "Gliukozė"
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/supplement/cs-base.json
+++ b/termx-integtest/src/test/resources/fhir/supplement/cs-base.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "suppl-base",
+  "url": "http://example.org/CodeSystem/suppl-base",
+  "version": "1.0.0",
+  "name": "supplBase",
+  "title": "Suppl Base",
+  "status": "active",
+  "content": "complete",
+  "language": "en",
+  "concept": [ { "code": "code1", "display": "Glucose" } ]
+}

--- a/termx-integtest/src/test/resources/fhir/supplement/cs-supplement-lt.json
+++ b/termx-integtest/src/test/resources/fhir/supplement/cs-supplement-lt.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "suppl-lt",
+  "url": "http://example.org/CodeSystem/suppl-lt",
+  "version": "1.0.0",
+  "name": "supplLt",
+  "title": "Suppl LT",
+  "status": "active",
+  "content": "supplement",
+  "supplements": "http://example.org/CodeSystem/suppl-base",
+  "concept": [ { "code": "code1", "designation": [ { "language": "lt", "value": "Gliukozė" } ] } ]
+}

--- a/termx-integtest/src/test/resources/fhir/supplement/vs-supplement.json
+++ b/termx-integtest/src/test/resources/fhir/supplement/vs-supplement.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "ValueSet",
+  "id": "suppl-vs",
+  "url": "http://example.org/ValueSet/suppl-vs",
+  "version": "1.0.0",
+  "name": "supplVs",
+  "title": "Suppl VS",
+  "status": "active",
+  "extension": [ { "url": "http://hl7.org/fhir/StructureDefinition/valueset-supplement", "valueCanonical": "http://example.org/CodeSystem/suppl-lt|1.0.0" } ],
+  "compose": { "include": [ { "system": "http://example.org/CodeSystem/suppl-base", "version": "1.0.0" } ] }
+}


### PR DESCRIPTION
End-to-end coverage for #47, complementing the import round-trip unit test (#207). Imports a base CodeSystem + a `content=supplement` CodeSystem (adds an `lt` designation, links `baseEntityVersionId`) + a ValueSet referencing the supplement via the `valueset-supplement` extension, then asserts:
1. import binds the rule to the supplement (`codeSystemUri`=supplement, `codeSystemBaseUri`=base, `codeSystem` resolved),
2. `$expand(displayLanguage=lt)` returns the supplement's Lithuanian display.

Test-only (the production change shipped in #207).