### PR TITLE
fix(fhir-vs): bound $expand properties to the declared set; surface coding version + display

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -1,5 +1,6 @@
 package org.termx.terminology.fhir.valueset;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.kodality.commons.exception.ApiClientException;
 import com.kodality.commons.model.LocalizedName;
 import com.kodality.commons.util.DateUtil;
@@ -59,6 +60,7 @@ import com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion;
 import com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains;
 import com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty;
 import com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter;
+import com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionProperty;
 import io.micronaut.context.annotation.Context;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.util.CollectionUtils;
@@ -70,10 +72,12 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
@@ -357,6 +361,16 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     expansion.setParameter(toValueSetParameter(param));
     expansion.setTimestamp(snapshot.getCreatedAt());
 
+    // Declare the properties that may appear in contains.property: the value set's declared properties,
+    // narrowed by any request-level `property` parameter. A contains.property must reference a declared
+    // expansion.property to be valid FHIR.
+    List<String> requestedProperties = (param == null || param.getParameter() == null) ? List.of() :
+        param.getParameter().stream().filter(p -> "property".equals(p.getName())).map(ParametersParameter::getValueString).filter(StringUtils::isNotEmpty).toList();
+    expansion.setProperty(Optional.ofNullable(properties).orElse(List.of()).stream().distinct()
+        .filter(code -> requestedProperties.isEmpty() || requestedProperties.contains(code))
+        .map(code -> new ValueSetExpansionProperty().setCode(code))
+        .collect(toList()));
+
     if (flat) {
       expansion.setContains(concepts.stream().map(c -> toFhirExpansionContains(c, properties, param)).collect(toList()));
     } else {
@@ -418,8 +432,17 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
           extension.setValueString(d.getName());
           return extension;
         }).toList() : null);
+    Set<String> seenProperties = new HashSet<>();
     contains.setProperty(c.getPropertyValues() == null ? new ArrayList<>() :
-        c.getPropertyValues().stream().filter(p -> CollectionUtils.isEmpty(properties) || properties.contains(p.getEntityProperty())).map(p -> {
+        c.getPropertyValues().stream()
+            // Only surface properties the value set declares (compose.property); a request-level `property`
+            // parameter narrows it further. Without this, every internal property leaks into the expansion
+            // as an undeclared `contains.property`, which bloats the response and is not valid per FHIR.
+            .filter(p -> allProperties.contains(p.getEntityProperty()))
+            .filter(p -> CollectionUtils.isEmpty(properties) || properties.contains(p.getEntityProperty()))
+            // Guard against duplicate property rows carried by legacy snapshots.
+            .filter(p -> seenProperties.add(p.getEntityProperty() + "|" + p.getValue()))
+            .map(p -> {
           ValueSetExpansionContainsProperty property = new ValueSetExpansionContainsProperty();
           property.setCode(p.getEntityProperty());
           switch (p.getEntityPropertyType()) {
@@ -429,8 +452,21 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
             case EntityPropertyType.decimal -> property.setValueDecimal(new BigDecimal(String.valueOf(p.getValue())));
             case EntityPropertyType.integer -> property.setValueInteger(Integer.valueOf(String.valueOf(p.getValue())));
             case EntityPropertyType.coding -> {
-              Concept concept = JsonUtil.getObjectMapper().convertValue(p.getValue(), Concept.class);
-              property.setValueCoding(new Coding(concept.getCodeSystem(), concept.getCode()));
+              // Canonical coding shape (code + codeSystem + display + version). The coding-refresh
+              // enrichment (PR #109/#111, bd73af4f) resolves and persists the target version; surface it
+              // on the FHIR Coding the same way CodeSystemFhirMapper does. Legacy shapes (raw Concept)
+              // round-trip without a version, which is acceptable.
+              var coding = p.asCodingValue();
+              if (coding != null && coding.getCodeSystem() != null && coding.getCode() != null) {
+                Coding valueCoding = new Coding(coding.getCodeSystem(), coding.getCode()).setVersion(coding.getVersion());
+                // Surface the localized display the coding-refresh enrichment resolved onto the value
+                // (stored as a list of {name, language, use}); pick the requested language, same as CodeSystemFhirMapper.
+                if (coding.getDisplay() != null) {
+                  String displayStr = coding.getDisplay() instanceof String s ? s : JsonUtil.toJson(coding.getDisplay());
+                  valueCoding.setDisplay(codingDisplay(displayStr, lang));
+                }
+                property.setValueCoding(valueCoding);
+              }
             }
             case EntityPropertyType.dateTime -> {
               if (p.getValue() instanceof OffsetDateTime odt) {
@@ -453,6 +489,27 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   private static void addAssociations(ValueSetVersionConcept c, List<String> allProperties, List<String> properties, ValueSetExpansionContains contains, String key) {
     if (allProperties.contains(key) && (CollectionUtils.isEmpty(properties) || properties.contains(key)) && c.getAssociations() != null) {
       c.getAssociations().forEach(a -> contains.getProperty().add(new ValueSetExpansionContainsProperty().setCode(key).setValueCode(a.getTargetCode())));
+    }
+  }
+
+  private record CodingDisplay(String language, String name) {}
+
+  /** Resolve a coding value's display (a serialised list of {name, language, ...}) to the name for the requested language. */
+  private static String codingDisplay(String display, String language) {
+    if (display == null) {
+      return null;
+    }
+    try {
+      List<CodingDisplay> names = JsonUtil.getObjectMapper().readValue(display, JsonUtil.getListType(CodingDisplay.class));
+      if (names.isEmpty()) {
+        return null;
+      }
+      if (language == null) {
+        return names.get(0).name();
+      }
+      return names.stream().filter(n -> language.equals(n.language())).map(CodingDisplay::name).findFirst().orElseGet(() -> names.get(0).name());
+    } catch (JsonProcessingException e) {
+      return display;
     }
   }
 

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
@@ -1,0 +1,95 @@
+package org.termx.terminology.fhir.valueset
+
+import com.kodality.commons.model.LocalizedName
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.terminology.terminology.mapset.MapSetService
+import org.termx.terminology.terminology.relatedartifacts.ValueSetRelatedArtifactService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.Designation
+import org.termx.ts.codesystem.EntityPropertyType
+import org.termx.ts.codesystem.EntityPropertyValue
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetSnapshot
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionConcept
+import org.termx.ts.valueset.ValueSetVersionConcept.ValueSetVersionConceptValue
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+class ValueSetFhirMapperExpansionSpec extends Specification {
+  def conceptService = Mock(ConceptService)
+  def codeSystemService = Mock(CodeSystemService)
+  def valueSetService = Mock(ValueSetService)
+  def mapSetService = Mock(MapSetService)
+  def relatedArtifactService = Mock(ValueSetRelatedArtifactService)
+
+  def mapper = new ValueSetFhirMapper(conceptService, codeSystemService, valueSetService, mapSetService, relatedArtifactService)
+
+  static final String CS_URI = "https://www.dastacr.cz/dasta/nclp_data/ds_NCLP/all/nclppol.xml"
+
+  def "expansion only surfaces declared properties, deduped, with coding version and declared expansion.property"() {
+    given: "a value set version that declares exactly klic, klickomp and status"
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem("nclp-id-NCLPPOL").setProperties(["klic", "klickomp", "klicproc", "status"])
+    def version = new ValueSetVersion().setVersion("2.92.01").setPreferredLanguage("cs")
+        .setReleaseDate(LocalDate.parse("2025-05-15")).setStatus(PublicationStatus.active)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+
+    and: "a snapshot with one concept carrying a duplicate klic, a coding klickomp (version 0.1.1), and an UNDECLARED nazev"
+    def concept = new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConceptValue().setConceptVersionId(4795762L).setCode("03861")
+            .setCodeSystem("nclp-id-NCLPPOL").setCodeSystemUri(CS_URI).setCodeSystemVersions(["2.92.01"]))
+        .setDisplay(new Designation().setName("Alfa-2-globulin").setLanguage("cs"))
+        .setActive(true).setStatus("active")
+        .setPropertyValues([
+            new EntityPropertyValue().setEntityProperty("klic").setEntityPropertyType(EntityPropertyType.string).setValue("03861"),
+            new EntityPropertyValue().setEntityProperty("klic").setEntityPropertyType(EntityPropertyType.string).setValue("03861"),
+            new EntityPropertyValue().setEntityProperty("klickomp").setEntityPropertyType(EntityPropertyType.coding)
+                .setValue([code: "A2GSQ", codeSystem: "NCLPKOMP", version: "0.1.1"]),
+            new EntityPropertyValue().setEntityProperty("klicproc").setEntityPropertyType(EntityPropertyType.coding)
+                .setValue([code: "ACCELP", codeSystem: "NCLPPROC", version: "0.1.1",
+                           display: [[name: "Elektroforéza-acetylcelulóza", language: "cs", use: "display"]]]),
+            new EntityPropertyValue().setEntityProperty("nazev").setEntityPropertyType(EntityPropertyType.string).setValue("Alfa-2-globulin (...)"),
+        ])
+    def snapshot = new ValueSetSnapshot().setValueSet("vs").setConceptsTotal(1).setExpansion([concept])
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [], snapshot, null)
+    def contains = fhir.expansion.contains
+    def props = contains[0].property
+
+    then: "the concept maps cleanly"
+    contains.size() == 1
+    contains[0].code == "03861"
+    contains[0].system == CS_URI
+    contains[0].version == "2.92.01"
+
+    and: "only declared properties surface; the undeclared nazev is dropped and the duplicate klic is collapsed"
+    props*.code == ["klic", "klickomp", "klicproc", "status"]
+
+    and: "the coding-refresh version is preserved on the value coding"
+    def klickomp = props.find { it.code == "klickomp" }
+    klickomp.valueCoding.code == "A2GSQ"
+    klickomp.valueCoding.system == "NCLPKOMP"
+    klickomp.valueCoding.version == "0.1.1"
+
+    and: "the coding-refresh localized display is preserved (resolved to the requested-less default language)"
+    def klicproc = props.find { it.code == "klicproc" }
+    klicproc.valueCoding.code == "ACCELP"
+    klicproc.valueCoding.version == "0.1.1"
+    klicproc.valueCoding.display == "Elektroforéza-acetylcelulóza"
+
+    and: "the concept status property is surfaced"
+    props.find { it.code == "status" }.valueCode == "active"
+
+    and: "every emitted property is declared up front in expansion.property"
+    fhir.expansion.property*.code == ["klic", "klickomp", "klicproc", "status"]
+  }
+}


### PR DESCRIPTION
## Problem

FHIR ValueSet `$expand` emitted **every** internal property value into `expansion.contains.property` whenever the request carried no `property` parameter — including all the internal NCLP properties (`klicsyst`, `klickomp`, …) and their duplicate rows from legacy snapshots. None were declared in `expansion.property`, so the response was both enormous and not spec-conformant.

Two coding-refresh fields (`version`, localized `display`) that `CodeSystemFhirMapper` already surfaces were also being dropped by the expansion mapper.

## Changes

- **`toFhirExpansionContains`** — only emit properties the value set declares (`compose.property`), narrowed further by any request-level `property` parameter (same gating `status`/`parent`/`groupedBy` already use); drop duplicate property rows.
- **`toFhirExpansion`** — declare every emitted property in `expansion.property`, so each `contains.property.code` resolves to a declaration.
- **coding properties** — read the canonical coding value via `asCodingValue()` and surface the refreshed `version` and localized `display` (parity with `CodeSystemFhirMapper`).
- **test** — `ValueSetFhirMapperExpansionSpec` locks the whitelist, dedup, `expansion.property` declarations, and the coding `version`/`display` + concept `status` surfacing (this path previously had no test — `ValueSetExpandOperationTest` mocks the mapper).

## Notes

- `targetEffectiveTime` stays internal-only (per `bd73af4f`); `valueCoding.system` remains the internal code-system id, unchanged and matching `CodeSystemFhirMapper`.
- Behavioural change: properties now surface in `$expand` only when declared on the value set.

## Validation

`:terminology:compileJava` clean; `ValueSetFhirMapperExpansionSpec`, `ValueSetFhirMapperLanguageSpec`, and `ValueSetExpandOperationTest` pass.