### PR TITLE
fix(fhir-vs): guard nested $expand against cyclic associations

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -524,17 +524,24 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return rootConcepts.stream()
         .map(c -> {
           ValueSetExpansionContains contains = toFhirExpansionContains(c, properties, param);
-          contains.setContains(getChildConcepts(targetCodeConcepts, c.getConcept().getCode(), properties, param));
+          contains.setContains(getChildConcepts(targetCodeConcepts, c.getConcept().getCode(), properties, param, Set.of(c.getConcept().getCode())));
           return contains;
         }).toList();
   }
 
   private static List<ValueSetExpansionContains> getChildConcepts(Map<String, List<ValueSetVersionConcept>> targetCodeConcepts, String targetCode,
-                                                                  List<String> properties, Parameters param) {
+                                                                  List<String> properties, Parameters param, Set<String> ancestors) {
     return targetCodeConcepts.getOrDefault(targetCode, List.of()).stream()
+        // Stop a branch whose concept is already on the path from the root: a cyclic association
+        // (self-loop or A->B->A) would otherwise recurse forever. A concept may still appear under
+        // multiple distinct parents (diamond), only an ancestor-of-itself is cut.
+        .filter(c -> !ancestors.contains(c.getConcept().getCode()))
         .map(c -> {
           ValueSetExpansionContains contains = toFhirExpansionContains(c, properties, param);
-          contains.setContains(getChildConcepts(targetCodeConcepts, c.getConcept().getCode(), properties, param));
+          String code = c.getConcept().getCode();
+          Set<String> branch = new HashSet<>(ancestors);
+          branch.add(code);
+          contains.setContains(getChildConcepts(targetCodeConcepts, code, properties, param, branch));
           return contains;
         }).toList();
   }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
@@ -7,6 +7,7 @@ import org.termx.terminology.terminology.mapset.MapSetService
 import org.termx.terminology.terminology.relatedartifacts.ValueSetRelatedArtifactService
 import org.termx.terminology.terminology.valueset.ValueSetService
 import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemAssociation
 import org.termx.ts.codesystem.Designation
 import org.termx.ts.codesystem.EntityPropertyType
 import org.termx.ts.codesystem.EntityPropertyValue
@@ -18,8 +19,10 @@ import org.termx.ts.valueset.ValueSetVersionConcept.ValueSetVersionConceptValue
 import org.termx.ts.valueset.ValueSetVersionRuleSet
 import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 
 class ValueSetFhirMapperExpansionSpec extends Specification {
   def conceptService = Mock(ConceptService)
@@ -91,5 +94,43 @@ class ValueSetFhirMapperExpansionSpec extends Specification {
 
     and: "every emitted property is declared up front in expansion.property"
     fhir.expansion.property*.code == ["klic", "klickomp", "klicproc", "status"]
+  }
+
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
+  def "nested expansion terminates on cyclic associations instead of recursing forever"() {
+    given: "a root R with a child A that has a self-loop association (R <- A, A <- A)"
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def version = new ValueSetVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-06-17")).setStatus(PublicationStatus.active)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([new ValueSetVersionRule().setType("include").setCodeSystem("cs")]))
+
+    and:
+    def root = concept("R", [])
+    def child = concept("A", [assoc("R"), assoc("A")]) // points at its parent AND itself
+    // nested (non-flat) rendering is the default when excludeNested is not set
+    def snapshot = new ValueSetSnapshot().setValueSet("vs").setConceptsTotal(2).setExpansion([root, child])
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [], snapshot, null)
+    def contains = fhir.expansion.contains
+
+    then: "it returns; R contains A once, and the self-loop under A is cut"
+    contains*.code == ["R"]
+    contains[0].contains*.code == ["A"]
+    contains[0].contains[0].contains == []
+  }
+
+  private static ValueSetVersionConcept concept(String code, List<CodeSystemAssociation> associations) {
+    new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConceptValue().setCode(code).setCodeSystem("cs").setCodeSystemUri("http://cs"))
+        .setDisplay(new Designation().setName(code).setLanguage("en"))
+        .setActive(true).setStatus("active")
+        .setAssociations(associations)
+  }
+
+  private static CodeSystemAssociation assoc(String targetCode) {
+    new CodeSystemAssociation().setTargetCode(targetCode).setAssociationType("is-a")
   }
 }


### PR DESCRIPTION
## Problem

`getChildConcepts` builds the nested `expansion.contains` tree by recursing on association target codes, but tracked no path state. A self-loop (`A -> A`) or an association cycle (`A -> B -> A`) made it recurse forever — hanging the `$expand` request (and eventually `StackOverflowError`).

## Fix

Thread the set of ancestor codes (root → current) through the recursion and skip any child already on that path. A concept can still appear under multiple distinct parents (diamond/DAG shapes); only an ancestor-of-itself is cut, which is exactly the cyclic case.

## Test

Adds a cycle case to `ValueSetFhirMapperExpansionSpec` (root `R` → child `A` with a self-loop) under a `@Timeout(10s)`, so a regression fails fast instead of hanging CI. Asserts the tree terminates: `R → [A → []]`.

Found during a conformance audit of the expansion mapper; unrelated to but adjacent to #210.