### PR TITLE
#47: round-trip multiple valueset-supplement extensions

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -666,23 +666,34 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   }
 
   /**
-   * Round-trips the {@code valueset-supplement} extension that {@link #toFhirCompose} emits: the
-   * include carries the BASE code system in {@code system}, and the extension carries the supplement
-   * canonical ({@code supplementUri|version}). Bind the include rule to the supplement (recording the
-   * base in {@code codeSystemBaseUri}) so $expand surfaces the supplement's designations. Only the
-   * unambiguous single-supplement / single-include case is mapped; anything else is left untouched
-   * (round-tripping multiple supplements is a TODO — the extension is VS-level so it can't be paired
-   * to a specific include). Issue #47.
+   * Round-trips the {@code valueset-supplement} extension that {@link #toFhirCompose} emits: each
+   * include carries the BASE code system in {@code system}, and one extension per supplement-bound
+   * rule carries the supplement canonical ({@code supplementUri|version}). Binds the include rule(s)
+   * to the supplement (recording the base in {@code codeSystemBaseUri}) so $expand surfaces the
+   * supplement's designations.
+   *
+   * <p>The extension is VS-level and carries no link to a specific include, so it can only be paired
+   * by order — which is safe only when EVERY include is supplement-bound (the export emits one
+   * extension per include in the same order). A mix of plain and supplement includes is ambiguous
+   * (we can't tell which includes the extensions belong to) and is left untouched. Issue #47.
    */
   private static void applyValueSetSupplement(com.kodality.zmei.fhir.resource.terminology.ValueSet valueSet, ValueSetVersionRuleSet ruleSet) {
     List<Extension> supplements = valueSet.getExtensions(VALUESET_SUPPLEMENT_EXTENSION).toList();
     List<ValueSetVersionRule> includes = ruleSet.getRules() == null ? List.of() :
         ruleSet.getRules().stream().filter(r -> ValueSetVersionRuleType.include.equals(r.getType())).toList();
-    if (supplements.size() != 1 || includes.size() != 1 || StringUtils.isEmpty(supplements.get(0).getValueCanonical())) {
+    if (supplements.isEmpty() || includes.size() != supplements.size()) {
       return;
     }
-    String[] parts = PipeUtil.parsePipe(supplements.get(0).getValueCanonical());
-    ValueSetVersionRule rule = includes.get(0);
+    for (int i = 0; i < includes.size(); i++) {
+      bindSupplement(includes.get(i), supplements.get(i).getValueCanonical());
+    }
+  }
+
+  private static void bindSupplement(ValueSetVersionRule rule, String supplementCanonical) {
+    if (StringUtils.isEmpty(supplementCanonical)) {
+      return;
+    }
+    String[] parts = PipeUtil.parsePipe(supplementCanonical);
     String baseVersion = rule.getCodeSystemVersion() == null ? null : rule.getCodeSystemVersion().getVersion();
     rule.setCodeSystemBaseUri(rule.getCodeSystemUri());
     rule.setCodeSystemUri(parts[0]);

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperSupplementSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperSupplementSpec.groovy
@@ -57,6 +57,40 @@ class ValueSetFhirMapperSupplementSpec extends Specification {
     importedRule.codeSystemVersion.baseCodeSystemVersion.version == "1.0"
   }
 
+  def "(#47) multiple supplement-bound rules round-trip when every include is a supplement (paired by order)"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def ruleA = supplementRule("http://example.org/CodeSystem/base-a-lt", "http://example.org/CodeSystem/base-a", "2026", "1.0")
+    def ruleB = supplementRule("http://example.org/CodeSystem/base-b-lt", "http://example.org/CodeSystem/base-b", "2025", "2.0")
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def version = new ValueSetVersion().setVersion("1.0.0").setStatus(PublicationStatus.draft)
+        .setReleaseDate(LocalDate.parse("2026-03-18"))
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([ruleA, ruleB]))
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [])
+    def rules = ValueSetFhirMapper.fromFhirValueSet(fhir).versions.first().ruleSet.rules
+
+    then: "two valueset-supplement extensions are emitted"
+    fhir.extension.findAll { it.url == SUPPLEMENT_EXT }.size() == 2
+
+    and: "both rules' supplement bindings are restored, correctly paired to their base by order"
+    def a = rules.find { it.codeSystemBaseUri == "http://example.org/CodeSystem/base-a" }
+    def b = rules.find { it.codeSystemBaseUri == "http://example.org/CodeSystem/base-b" }
+    a.codeSystemUri == "http://example.org/CodeSystem/base-a-lt"
+    a.codeSystemVersion.version == "2026"
+    b.codeSystemUri == "http://example.org/CodeSystem/base-b-lt"
+    b.codeSystemVersion.version == "2025"
+  }
+
+  private static ValueSetVersionRule supplementRule(String supplementUri, String baseUri, String supplementVersion, String baseVersion) {
+    return new ValueSetVersionRule().setType("include")
+        .setCodeSystemUri(supplementUri).setCodeSystemBaseUri(baseUri)
+        .setCodeSystemVersion(new CodeSystemVersionReference().setVersion(supplementVersion)
+            .setBaseCodeSystemVersion(new CodeSystemVersionReference().setVersion(baseVersion)))
+  }
+
   def "(#47) a plain (non-supplement) include is unaffected"() {
     given:
     conceptService.load(_, _) >> Optional.empty()


### PR DESCRIPTION
Extends the supplement import (#207) from single-supplement to the multi-supplement case. The `valueset-supplement` extension is VS-level and carries no link to a specific include, so it's paired by order — done only when **every** include is supplement-bound (the export emits one extension per include in the same order). A mix of plain + supplement includes stays ambiguous and is left untouched. Round-trip spec covers single, multi, and plain.