### PR TITLE
fix(fhir-vs): preserve designation type on ValueSet import

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -681,7 +681,8 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return new ValueSetSnapshot().setExpansion(expansion.setTimestamp(expansion.getTimestamp()).getContains().stream().map(c -> new ValueSetVersionConcept()
         .setConcept(new ValueSetVersionConceptValue().setCode(c.getCode()).setCodeSystemUri(c.getSystem()))
         .setDisplay(new Designation().setName(c.getDisplay()).setLanguage(Optional.ofNullable(valueSet.getLanguage()).orElse(Language.en)))
-        .setAdditionalDesignations(Optional.ofNullable(c.getDesignation()).orElse(List.of()).stream().map(d -> new Designation().setName(d.getValue()).setLanguage(d.getLanguage())).toList())
+        .setAdditionalDesignations(Optional.ofNullable(c.getDesignation()).orElse(List.of()).stream()
+            .map(d -> new Designation().setName(d.getValue()).setLanguage(d.getLanguage()).setDesignationType(fromFhirDesignationType(d))).toList())
         .setActive(c.getInactive() == null || !c.getInactive())
     ).toList());
   }
@@ -797,9 +798,17 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return designation.stream().map(d -> new Designation()
         .setLanguage(d.getLanguage() == null ? Language.en : d.getLanguage())
         .setName(d.getValue())
+        .setDesignationType(fromFhirDesignationType(d))
         .setDesignationKind("text")
         .setCaseSignificance(CaseSignificance.entire_term_case_insensitive)
         .setStatus(PublicationStatus.active)).toList();
+  }
+
+  /** Recover the designation type from a FHIR designation's {@code use} code. Only the code is read
+   *  (the bare-Coding shape TermX emits, see toFhir*); a missing use leaves the type unset rather than
+   *  fabricating "display". */
+  private static String fromFhirDesignationType(ValueSetComposeIncludeConceptDesignation d) {
+    return d.getUse() == null ? null : d.getUse().getCode();
   }
 
   private static List<ValueSetRuleFilter> fromFhirFilters(List<ValueSetComposeIncludeFilter> filters) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
@@ -122,6 +122,28 @@ class ValueSetFhirMapperExpansionSpec extends Specification {
     contains[0].contains[0].contains == []
   }
 
+  def "fromFhir preserves designation.use code as designationType (compose + expansion)"() {
+    given: "a FHIR ValueSet whose concept carries a typed designation, in both compose and expansion"
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.ValueSet().setId("vs").setUrl("http://fhir.ee/ValueSet/vs").setName("vs").setLanguage("en")
+    def designation = new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation()
+        .setValue("alias name").setLanguage("en").setUse(new com.kodality.zmei.fhir.datatypes.Coding("alias"))
+    fhir.setCompose(new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetCompose().setInclude([
+        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude().setSystem("http://cs")
+            .setConcept([new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConcept().setCode("A").setDisplay("A").setDesignation([designation])])]))
+    fhir.setExpansion(new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion().setContains([
+        new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains().setSystem("http://cs").setCode("A").setDisplay("A").setDesignation([designation])]))
+
+    when:
+    def imported = ValueSetFhirMapper.fromFhirValueSet(fhir)
+    def composeDesignation = imported.versions.first().ruleSet.rules.first().concepts.first().additionalDesignations.first()
+    def expansionDesignation = imported.versions.first().snapshot.expansion.first().additionalDesignations.first()
+
+    then: "the designation type is recovered from use.code, not dropped"
+    composeDesignation.name == "alias name"
+    composeDesignation.designationType == "alias"
+    expansionDesignation.designationType == "alias"
+  }
+
   private static ValueSetVersionConcept concept(String code, List<CodeSystemAssociation> associations) {
     new ValueSetVersionConcept()
         .setConcept(new ValueSetVersionConceptValue().setCode(code).setCodeSystem("cs").setCodeSystemUri("http://cs"))


### PR DESCRIPTION
## Problem

ValueSet `fromFhir` dropped `designation.use` entirely. Both import paths — compose (`fromFhirDesignations`) and expansion (`fromFhirExpansion`) — built `Designation` objects with only `name` + `language`, so importing a FHIR ValueSet with typed designations **lost the designation type** on round-trip. `CodeSystemFhirMapper` already reads `use.getCode()` into `designationType`; the value set mapper did not.

## Fix

Read `use.getCode()` into `designationType` in both paths, via a small `fromFhirDesignationType` helper. Only the **code** is read (the bare-Coding shape TermX emits on export); a missing `use` leaves the type unset rather than fabricating `"display"`.

## Notes

Surfaced during the designation.use audit. Deliberately *not* touching the export side: TermX designation types are custom per-code-system properties, not codes in any canonical "designation use" system, so stamping a canonical `system` URI would assert false codeset membership. Bare Coding stays.

## Test

`ValueSetFhirMapperExpansionSpec` gains a round-trip case asserting the type survives import for both compose and expansion designations.

## Validation

`ValueSetFhirMapperExpansionSpec` (3 tests) green.