### PR TITLE
docs: README for the REST Client terminology suites

### DIFF
--- a/docs/rest-client/README.md
+++ b/docs/rest-client/README.md
@@ -1,0 +1,36 @@
+# TermX FHIR terminology — REST Client suites
+
+Ready-to-run [`REST Client`](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
+(`humao.rest-client`) request suites for the TermX FHIR terminology API. They double as living
+examples you can share with integrators to verify a server behaves correctly.
+
+## Suites
+
+| File | What it covers |
+|------|----------------|
+| [`fhir-terminology-supplement.http`](fhir-terminology-supplement.http) | A base CodeSystem + Estonian/Russian **supplements**, **stored ("static") ValueSets** referencing them via the `valueset-supplement` extension, expanded with `displayLanguage`; `$validate-code`; and **inline** `$expand`. |
+
+## Using a suite
+
+1. Install the **REST Client** extension in VS Code.
+2. Open the `.http` file and set the two variables at the top:
+   - `@fhir` — your server's FHIR base URL, no trailing slash (e.g. `https://demo.termx.org/fhir`; some deployments expose it under `/api/fhir`).
+   - `@token` — a Bearer token with write access (needed to create the CodeSystems/ValueSets).
+     On a local dev server (`auth.dev.allowed=true`) you can use the shortcut `yupi{"privileges":["*.*.*"]}`; against a real server use an actual token.
+3. Click **Send Request** above each request, **top to bottom** — the `SETUP` block creates the
+   resources the later tests depend on.
+4. Each request has an `# expect:` comment describing the correct response, so you can verify
+   correctness at a glance.
+
+The setup requests are idempotent (resources are upserted by id/url), so the whole suite can be
+re-run safely.
+
+## Good to know
+
+- **Stored vs inline.** A *stored* ValueSet expands through the full pipeline — it honours
+  `displayLanguage` and resolves the `valueset-supplement` extension, so supplement translations
+  show up. *Inline* `$expand` (passing the ValueSet in the request body) runs the server's JSON
+  expand: it returns the composed concepts but does **not** re-pick `displayLanguage` or resolve
+  supplements. Use a stored ValueSet to demonstrate supplement/language behaviour.
+- **Cleanup.** The suite leaves its `tx-rest-demo-*` resources on the server. Cancel/retire them
+  from the UI (or your own DELETE requests) if you don't want them to linger on a shared instance.


### PR DESCRIPTION
Companion `docs/rest-client/README.md` for the `.http` suite (#215): usage (set `@fhir`/`@token`, run top-to-bottom), what it covers, and the stored-vs-inline expansion difference.