### PR TITLE
tx-conformance: optional setup-content auto-loading (loadSetup)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceRunner.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceRunner.java
@@ -45,6 +45,11 @@ public class TxConformanceRunner {
     this.txUrl = txUrl;
   }
 
+  /** The FHIR base URL this server is tested at ({@code -tx}); also the target for setup loading. */
+  public String getTxUrl() {
+    return txUrl;
+  }
+
   /** Runs the suite and returns the raw {@code report.json} (a FHIR {@code TestReport}). */
   public String run(TxConformanceRunRequest req, Path inputBundle) throws IOException, InterruptedException {
     if (StringUtils.isEmpty(validatorJar)) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceService.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceService.java
@@ -29,11 +29,15 @@ public class TxConformanceService {
   private final TxConformanceRunner runner;
   private final LorqueProcessService lorqueProcessService;
   private final BobObjectService bobObjectService;
+  private final TxConformanceSetupLoader setupLoader;
 
   public LorqueProcess run(TxConformanceRunRequest request) {
     return lorqueProcessService.run("tx-conformance", request, req -> {
       Path bundle = null;
       try {
+        if (req.isLoadSetup()) {
+          setupLoader.load(runner.getTxUrl());
+        }
         if (StringUtils.isNotEmpty(req.getArchiveUuid())) {
           bundle = downloadBundle(req.getArchiveUuid());
         }

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
@@ -1,0 +1,116 @@
+package org.termx.terminology.fhir.conformance;
+
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Loads the HL7 tx-ecosystem test fixtures (the {@code http://hl7.org/fhir/test/…} CodeSystems and
+ * ValueSets the suites expand/validate against) into the server under test, before a conformance run.
+ *
+ * <p>The HL7 test runner assumes the server already hosts this content (tx.fhir.org does); an empty
+ * termx instead returns "not found" for every test. This loader closes that gap so a run is
+ * self-contained. It loads ALL setup resources (the "server hosts the content" model), reading them
+ * from the FHIR validator's package cache — files named {@code codesystem-*.json} / {@code valueset-*.json}
+ * (the {@code *-request*}/{@code *-response*} files are test artifacts, not content).
+ *
+ * <p>CodeSystems are sent with {@code PUT} (idempotent upsert — termx enables CodeSystem update);
+ * ValueSets with {@code POST} (termx only enables ValueSet create) — duplicates on re-run are
+ * tolerated. Per-resource failures are logged, not fatal.
+ *
+ * <p>NB: it does NOT raise the pass rate by itself — it only makes the content present; genuine
+ * termx FHIR conformance gaps still fail. It also writes test content into the target server, so it
+ * is opt-in (the {@code loadSetup} flag) and meant for dedicated conformance instances.
+ */
+@Slf4j
+@Singleton
+public class TxConformanceSetupLoader {
+  private static final String FHIR_JSON = "application/fhir+json";
+
+  private final String packageDir;
+  private final HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+  public TxConformanceSetupLoader(@Value("${termx.conformance.test-package-dir:}") String packageDir) {
+    // Default to the FHIR validator's package cache, where txTests downloads the tx-ecosystem fixtures.
+    this.packageDir = StringUtils.isNotEmpty(packageDir) ? packageDir
+        : System.getProperty("user.home") + "/.fhir/packages/hl7.fhir.uv.tx-ecosystem#current/package/tests";
+  }
+
+  /** Loads every setup CodeSystem then ValueSet under the package dir into {@code fhirBaseUrl}. */
+  public void load(String fhirBaseUrl) {
+    Path root = Path.of(packageDir);
+    if (!Files.isDirectory(root)) {
+      throw new IllegalStateException("tx-ecosystem test package not found at " + packageDir
+          + " — run the suite once (the validator downloads it) or set termx.conformance.test-package-dir");
+    }
+    List<Path> codeSystems = findSetupFiles(root, "codesystem-");
+    List<Path> valueSets = findSetupFiles(root, "valueset-");
+    log.info("tx conformance setup: loading {} CodeSystems and {} ValueSets into {}", codeSystems.size(), valueSets.size(), fhirBaseUrl);
+
+    int ok = 0;
+    int failed = 0;
+    for (Path p : codeSystems) {
+      if (send(fhirBaseUrl + "/CodeSystem/" + idOf(p), "PUT", p)) { ok++; } else { failed++; }
+    }
+    for (Path p : valueSets) {
+      if (send(fhirBaseUrl + "/ValueSet", "POST", p)) { ok++; } else { failed++; }
+    }
+    log.info("tx conformance setup: loaded {} resources ({} failed/duplicate)", ok, failed);
+  }
+
+  /** Setup resources: {@code codesystem-*.json} / {@code valueset-*.json}, excluding test request/response artifacts. */
+  static List<Path> findSetupFiles(Path root, String prefix) {
+    try (Stream<Path> s = Files.walk(root)) {
+      return s.filter(Files::isRegularFile)
+          .filter(p -> isSetupFile(p.getFileName().toString(), prefix))
+          .sorted(Comparator.comparing(Path::toString))
+          .toList();
+    } catch (Exception e) {
+      throw new RuntimeException("failed scanning test package " + root, e);
+    }
+  }
+
+  /** True for a setup resource file of the given kind (prefix); false for request/response test files. */
+  static boolean isSetupFile(String name, String prefix) {
+    String n = name.toLowerCase();
+    return n.startsWith(prefix) && n.endsWith(".json") && !n.contains("-request") && !n.contains("-response");
+  }
+
+  private static String idOf(Path p) {
+    String n = p.getFileName().toString();
+    return n.substring(0, n.length() - ".json".length());
+  }
+
+  private boolean send(String url, String method, Path body) {
+    try {
+      HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+          .timeout(Duration.ofSeconds(60))
+          .header("Content-Type", FHIR_JSON)
+          .header("Accept", FHIR_JSON)
+          .method(method, BodyPublishers.ofFile(body))
+          .build();
+      HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+      if (resp.statusCode() / 100 == 2) {
+        return true;
+      }
+      log.debug("tx conformance setup: {} {} -> {} (likely already present)", method, url, resp.statusCode());
+      return false;
+    } catch (Exception e) {
+      log.warn("tx conformance setup: {} {} failed: {}", method, url, e.getMessage());
+      return false;
+    }
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
@@ -1,0 +1,25 @@
+package org.termx.terminology.fhir.conformance
+
+import spock.lang.Specification
+
+class TxConformanceSetupLoaderTest extends Specification {
+
+  def "isSetupFile accepts setup resources of the kind and rejects test artifacts"() {
+    expect:
+    TxConformanceSetupLoader.isSetupFile(name, prefix) == expected
+
+    where:
+    name                                          | prefix         || expected
+    "codesystem-simple.json"                      | "codesystem-"  || true
+    "codesystem-noversion.json"                   | "codesystem-"  || true
+    "valueset-all.json"                           | "valueset-"    || true
+    "valueset-filter-isa.json"                    | "valueset-"    || true
+    // test request/response artifacts are NOT content
+    "simple-expand-all-request-parameters.json"   | "valueset-"    || false
+    "simple-expand-all-response-valueSet.json"    | "valueset-"    || false
+    "valueset-all-response.json"                  | "valueset-"    || false
+    // wrong kind / wrong extension
+    "valueset-all.json"                           | "codesystem-"  || false
+    "codesystem-simple.xml"                       | "codesystem-"  || false
+  }
+}

--- a/termx-api/src/main/java/org/termx/ts/conformance/TxConformanceRunRequest.java
+++ b/termx-api/src/main/java/org/termx/ts/conformance/TxConformanceRunRequest.java
@@ -24,4 +24,10 @@ public class TxConformanceRunRequest {
   private String mode;
   /** UUID of a {@code bob.object} in the {@code tx-conformance} container holding a custom test bundle. */
   private String archiveUuid;
+  /**
+   * When true, load the tx-ecosystem test fixtures (the {@code http://hl7.org/fhir/test/…} CodeSystems
+   * and ValueSets the suites reference) into this server before running — so a run is self-contained.
+   * Writes test content into the server; intended for dedicated conformance instances. Default false.
+   */
+  private boolean loadSetup;
 }

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -129,6 +129,9 @@ termx:
   conformance:
     validator-jar: ${TERMX_CONFORMANCE_VALIDATOR_JAR:}
     tx-url: ${TERMX_CONFORMANCE_TX_URL:`http://localhost:8200/fhir`}
+    # Optional: dir holding the tx-ecosystem test fixtures to load when a run requests loadSetup=true.
+    # Defaults to the FHIR validator's package cache (~/.fhir/packages/hl7.fhir.uv.tx-ecosystem#current/package/tests).
+    test-package-dir: ${TERMX_CONFORMANCE_TEST_PACKAGE_DIR:}
   fhir:
     codesystem:
       lookup:


### PR DESCRIPTION
Follow-up (Phase 6) to the tx-conformance feature (#208). Makes a conformance run **self-contained** by optionally loading the tx-ecosystem test fixtures into the server under test first.

## Why
A run against an instance that doesn't host the `http://hl7.org/fhir/test/…` CodeSystems/ValueSets fails *every* test with "not found" (verified against a local build and dev.termx.org — both 0/15, all `not-found`). tx.fhir.org passes because it pre-loads that content. This loads it for you.

## What
- **`TxConformanceSetupLoader`** loads all setup resources (`codesystem-*.json` then `valueset-*.json`, excluding `*-request*`/`*-response*` test artifacts) from the FHIR validator's package cache into the target FHIR base. CodeSystems via `PUT` (idempotent upsert — termx enables CodeSystem update); ValueSets via `POST` (termx only enables create) — duplicates/per-resource failures are tolerated and logged. Source dir configurable via `termx.conformance.test-package-dir` (defaults to `~/.fhir/packages/hl7.fhir.uv.tx-ecosystem#current/package/tests`).
- **`TxConformanceRunRequest.loadSetup`** (default false) opts in; `TxConformanceService` runs the loader before the suite; `TxConformanceRunner.getTxUrl()` is the target.

## Verified
- Unit test for the setup-vs-test-artifact classification; `:terminology:test` + `:termx-app` compile green.
- The end-to-end load mechanics were confirmed manually (loading the `simple/` fixtures into a live termx moved the failures from `not-found` to genuine content diffs).

## Important caveat (drives the next work)
`loadSetup` only makes the content **present** — it does **not** raise the pass rate. With fixtures loaded, termx still fails on **real conformance gaps**:
- POST `$expand` (Parameters body) returns 400 (GET-by-url works)
- `$lookup` returns 5 parameters vs expected 14
- `$expand` emits an extra `valueSet` in `compose.include`

Fixing those is the **(2) conformance-triage** work to do next, now that we have a working harness pointing at them. It also writes test content into the target server, so it's opt-in and meant for dedicated conformance instances.