### PR TITLE
FHIR $expand: accept url as valueUri/canonical; never emit valueless expansion.parameter

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -390,10 +390,20 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
         .setValueBoolean(p.getValueBoolean())
         .setValueInteger(p.getValueInteger())
         .setValueDecimal(p.getValueDecimal())
-        .setValueUri(p.getValueUri())
+        // expansion.parameter.value is a uri (not url/canonical), so fold those in — otherwise a
+        // request param like `url` carried as valueUrl/valueCanonical produced an expansion.parameter
+        // with a name but no value, which is invalid FHIR and crashes strict clients (e.g. the validator).
+        .setValueUri(p.getValueUri() != null ? p.getValueUri() : p.getValueUrl() != null ? p.getValueUrl() : p.getValueCanonical())
         .setValueCode(p.getValueCode())
         .setValueDateTime(p.getValueDateTime())
-    ).toList();
+    ).filter(ValueSetFhirMapper::hasValue).toList();
+  }
+
+  /** A FHIR expansion.parameter MUST have a value — drop any that ended up valueless rather than emit invalid output. */
+  private static boolean hasValue(ValueSetExpansionParameter p) {
+    return p.getValueString() != null || p.getValueBoolean() != null || p.getValueInteger() != null
+        || p.getValueDecimal() != null || p.getValueUri() != null || p.getValueCode() != null
+        || p.getValueDateTime() != null;
   }
 
   private static ValueSetExpansionContains toFhirExpansionContains(ValueSetVersionConcept c, List<String> allProperties, Parameters param) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -102,8 +102,14 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       return expandInline(inlineVs, req);
     }
 
-    // 2. Fall back to url-based lookup (existing logic)
-    String url = req.findParameter("url").map(pp -> pp.getValueUrl() != null ? pp.getValueUrl() : pp.getValueString())
+    // 2. Fall back to url-based lookup (existing logic).
+    // `url` is a uri/canonical, so accept valueUri (what the FHIR spec & tx-ecosystem tests send) in
+    // addition to valueUrl/valueString — previously a POSTed `url` as valueUri was missed → 400.
+    String url = req.findParameter("url")
+        .map(pp -> pp.getValueUrl() != null ? pp.getValueUrl()
+            : pp.getValueUri() != null ? pp.getValueUri()
+            : pp.getValueCanonical() != null ? pp.getValueCanonical()
+            : pp.getValueString())
         .orElseThrow(() -> new FhirException(400, IssueType.INVALID, "parameter 'url' or 'valueSet' required"));
     String versionNr = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(null);
 


### PR DESCRIPTION
Two FHIR `$expand` conformance bugs found by triaging the tx-ecosystem suite against a running termx (the first (2) findings from the conformance harness).

## 1. POST `$expand` with `url` as `valueUri` → 400
The handler read `url` only as `valueUrl`/`valueString`, so a POSTed `Parameters` carrying `url` as **`valueUri`** (what the FHIR spec & the tx-ecosystem tests send) returned `400 "parameter 'url' or 'valueSet' required"`. Now also accepts `valueUri`/`valueCanonical`. ([ValueSetExpandOperation](terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java))

## 2. Valueless `expansion.parameter` crashes strict clients
`$expand` echoes request params into `expansion.parameter`, but `expansion.parameter.value` is a **`uri`** — a `url`/`canonical` request param was copied to none of the `value[x]` fields, producing a parameter with a name and **no value**. That's invalid FHIR; the validator NPEs on it. Now folds `url`/`canonical` into `valueUri` and drops any still-valueless parameter. ([ValueSetFhirMapper.toValueSetParameter](terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java))

## Verified
Re-ran `txTests -suite simple-cases` against a local termx (with fixtures loaded) before/after: requests went **400 → executing → producing correct expansion content** (code1/Display1, total 6). Existing `ValueSetExpandOperationTest` + mapper specs still green.

## Remaining (catalogued, follow-up)
Now that requests execute, the residual diffs are cosmetic/completeness gaps — `$expand` adds a top-level `effectivePeriod` the suite doesn't expect; `$expand` emits an extra `compose.include[].valueSet`; `$lookup` returns fewer parameters than expected. Tractable next steps for the conformance push.