### PR TITLE
FHIR $expand: drop compose & effectivePeriod from the expansion response

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -334,6 +334,12 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     // The set of languages carried by the expansion is advertised as repeated `supported-language`
     // extensions on the resource (added in the base toFhir from version.supportedLanguages).
     fhirValueSet.setExpansion(toFhirExpansion(snapshot, fhirValueSet.getCompose().getProperty(), param));
+    // An $expand response is a rendered view, not the value-set definition. The expansion replaces the
+    // compose, and termx stamps an effectivePeriod (defaulting start to the import date) — both are flagged
+    // as unexpected properties by the tx-ecosystem expand tests. Drop them from the expansion view
+    // (compose is read AFTER, above, for declared properties; the read path keeps both).
+    fhirValueSet.setCompose(null);
+    fhirValueSet.setEffectivePeriod(null);
     return fhirValueSet;
   }
 


### PR DESCRIPTION
Continues the tx-ecosystem conformance triage (after #218).

A `$expand` response is a **rendered view**, not the value-set definition — the expansion replaces the compose. termx echoed the full `compose` (with definitional sub-properties like `include.version`, `compose.inactive`) and an always-stamped `effectivePeriod`, both flagged as **unexpected properties** by the expand tests. Now cleared on the expansion view in `ValueSetFhirMapper` (compose is still read first for declared properties; `GET /ValueSet` reads keep both).

## Verified (live walk of simple-cases)
Each fix peels a layer: `400 → NPE (#218) → effectivePeriod → compose → expansion.total/parameter`. After this PR the expand responses are past the effectivePeriod and compose diffs; remaining diffs are finer (`expansion.total`, `expansion.parameter` naming, `$lookup` completeness, the inline-`contained` path).

Existing `:terminology:` (233) and `:termx-integtest:` (104) suites remain green — no regression.