### PR TITLE
FHIR $expand: emit used-codesystem params; stop echoing the url selection param

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -73,6 +73,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -365,7 +366,13 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     // handing off; fall back to concepts.size() only when the snapshot is
     // un-paginated (e.g. legacy callers).
     expansion.setTotal(snapshot.getConceptsTotal() != null ? snapshot.getConceptsTotal() : concepts.size());
-    expansion.setParameter(toValueSetParameter(param));
+    // expansion.parameter records how the expansion was produced: the echoed control parameters
+    // (activeOnly, excludeNested, count, …) followed by the derived `used-codesystem` entries — one per
+    // distinct code system version that actually contributed a concept. The tx-ecosystem suite asserts
+    // these `used-codesystem` outputs; the selection identifiers (url/valueSet/…) are NOT echoed here.
+    List<ValueSetExpansionParameter> parameters = new ArrayList<>(Optional.ofNullable(toValueSetParameter(param)).orElse(List.of()));
+    parameters.addAll(toUsedCodeSystemParameters(concepts));
+    expansion.setParameter(parameters.isEmpty() ? null : parameters);
     expansion.setTimestamp(snapshot.getCreatedAt());
 
     // Declare the properties that may appear in contains.property: the value set's declared properties,
@@ -386,12 +393,19 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return expansion;
   }
 
+  // $expand parameters that identify WHICH value set to expand rather than HOW. FHIR records the "how"
+  // params in expansion.parameter but not the selection identifiers, and the tx-ecosystem suite flags an
+  // echoed `url` (etc.) as an unexpected expansion.parameter. Filtered out of the echo below.
+  private static final Set<String> EXPANSION_SELECTION_PARAMETERS = Set.of("url", "valueSet", "valueSetVersion", "context", "contextDirection");
+
   private static List<ValueSetExpansionParameter> toValueSetParameter(Parameters param) {
     if (param == null || param.getParameter() == null) {
       return null;
     }
 
-    return param.getParameter().stream().map(p -> new ValueSetExpansionParameter().setName(p.getName())
+    return param.getParameter().stream()
+        .filter(p -> !EXPANSION_SELECTION_PARAMETERS.contains(p.getName()))
+        .map(p -> new ValueSetExpansionParameter().setName(p.getName())
         .setValueString(p.getValueString())
         .setValueBoolean(p.getValueBoolean())
         .setValueInteger(p.getValueInteger())
@@ -410,6 +424,35 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return p.getValueString() != null || p.getValueBoolean() != null || p.getValueInteger() != null
         || p.getValueDecimal() != null || p.getValueUri() != null || p.getValueCode() != null
         || p.getValueDateTime() != null;
+  }
+
+  /**
+   * Derives the {@code used-codesystem} expansion parameters: one {@code valueUri} per distinct code
+   * system version that actually contributed a concept to this expansion, formatted as {@code system|version}
+   * (or bare {@code system} when no version is known). Iteration order is preserved (LinkedHashSet) so the
+   * output is stable. This is an output of the expansion — it reports what was used, not what was requested.
+   */
+  private static List<ValueSetExpansionParameter> toUsedCodeSystemParameters(List<ValueSetVersionConcept> concepts) {
+    Set<String> uris = new LinkedHashSet<>();
+    for (ValueSetVersionConcept c : concepts) {
+      ValueSetVersionConceptValue v = c.getConcept();
+      if (v == null) {
+        continue;
+      }
+      // A base concept surfaced through a supplement carries baseCodeSystemUri and no version; a regular
+      // concept carries codeSystemUri plus its applicable code system version(s).
+      String system = v.getBaseCodeSystemUri() != null ? v.getBaseCodeSystemUri() : v.getCodeSystemUri();
+      if (system == null) {
+        continue;
+      }
+      List<String> versions = v.getBaseCodeSystemUri() == null ? v.getCodeSystemVersions() : null;
+      if (CollectionUtils.isEmpty(versions)) {
+        uris.add(system);
+      } else {
+        versions.stream().filter(StringUtils::isNotEmpty).forEach(ver -> uris.add(system + "|" + ver));
+      }
+    }
+    return uris.stream().map(uri -> new ValueSetExpansionParameter().setName("used-codesystem").setValueUri(uri)).collect(toList());
   }
 
   private static ValueSetExpansionContains toFhirExpansionContains(ValueSetVersionConcept c, List<String> allProperties, Parameters param) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperExpansionSpec.groovy
@@ -144,6 +144,45 @@ class ValueSetFhirMapperExpansionSpec extends Specification {
     expansionDesignation.designationType == "alias"
   }
 
+  def "expansion derives used-codesystem params and does not echo the url selection parameter"() {
+    given: "a value set version with two concepts: two share CS version 1.0.0, one comes from a second CS"
+    conceptService.load(_, _) >> Optional.empty()
+    relatedArtifactService.findRelatedArtifacts(_) >> []
+    def valueSet = new ValueSet().setId("vs").setUri("http://fhir.ee/ValueSet/vs").setName("vs").setTitle(new LocalizedName([en: "vs"]))
+    def version = new ValueSetVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-06-17")).setStatus(PublicationStatus.active)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([new ValueSetVersionRule().setType("include").setCodeSystem("cs")]))
+
+    and:
+    def a = new ValueSetVersionConcept().setConcept(new ValueSetVersionConceptValue().setCode("A")
+        .setCodeSystem("cs1").setCodeSystemUri("http://cs1").setCodeSystemVersions(["1.0.0"]))
+        .setDisplay(new Designation().setName("A").setLanguage("en")).setActive(true).setStatus("active")
+    def b = new ValueSetVersionConcept().setConcept(new ValueSetVersionConceptValue().setCode("B")
+        .setCodeSystem("cs1").setCodeSystemUri("http://cs1").setCodeSystemVersions(["1.0.0"]))
+        .setDisplay(new Designation().setName("B").setLanguage("en")).setActive(true).setStatus("active")
+    def c = new ValueSetVersionConcept().setConcept(new ValueSetVersionConceptValue().setCode("C")
+        .setCodeSystem("cs2").setCodeSystemUri("http://cs2").setCodeSystemVersions(["2.1.0"]))
+        .setDisplay(new Designation().setName("C").setLanguage("en")).setActive(true).setStatus("active")
+    def snapshot = new ValueSetSnapshot().setValueSet("vs").setConceptsTotal(3).setExpansion([a, b, c])
+
+    and: "a request carrying the url selection param plus a real excludeNested control param"
+    def param = new com.kodality.zmei.fhir.resource.other.Parameters().setParameter([
+        new com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter().setName("url").setValueUri("http://fhir.ee/ValueSet/vs"),
+        new com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter().setName("excludeNested").setValueBoolean(true),
+    ])
+
+    when:
+    def fhir = mapper.toFhir(valueSet, version, [], snapshot, param)
+    def params = fhir.expansion.parameter
+
+    then: "the url selection identifier is NOT echoed; excludeNested is"
+    params.find { it.name == "url" } == null
+    params.find { it.name == "excludeNested" }.valueBoolean == true
+
+    and: "one used-codesystem per distinct system|version, deduped across the two cs1 concepts, order preserved"
+    params.findAll { it.name == "used-codesystem" }*.valueUri == ["http://cs1|1.0.0", "http://cs2|2.1.0"]
+  }
+
   private static ValueSetVersionConcept concept(String code, List<CodeSystemAssociation> associations) {
     new ValueSetVersionConcept()
         .setConcept(new ValueSetVersionConceptValue().setCode(code).setCodeSystem("cs").setCodeSystemUri("http://cs"))


### PR DESCRIPTION
## What

`expansion.parameter` records *how* an expansion was produced. Two gaps the tx-ecosystem $expand suite flags:

1. termx echoed every request parameter verbatim — including the `url`/`valueSet` **selection identifiers**, which the suite treats as an *unexpected* `expansion.parameter`.
2. termx never emitted `used-codesystem` — the output parameter that reports which code system version(s) the expansion actually drew from.

## Change

In `ValueSetFhirMapper`:
- **Derive `used-codesystem`** from the expanded concepts: one `valueUri` per distinct `system|version` that contributed a concept (deduped, insertion-order preserved). Base/supplement concepts with no version emit a bare `system`.
- **Drop the selection identifiers** (`url`, `valueSet`, `valueSetVersion`, `context`, `contextDirection`) from the echoed parameters.
- Keep echoing the genuine control params (`activeOnly`, `excludeNested`, `count`, `offset`, …).

Expected shape now matches the suite, e.g. `[excludeNested, used-codesystem]` instead of `[excludeNested, url]`.

## Why it's low-risk

`expansion.parameter` is not asserted by any local test (the Groovy harness compares only `total` + `contains`), so this is additive to existing behavior. Builds on #218 (valueless-param fix) and #219 (compose/effectivePeriod drop).

## Tests

- New unit case in `ValueSetFhirMapperExpansionSpec`: two concepts sharing a CS version dedupe to one `used-codesystem`; a second CS adds a second; `url` is not echoed, `excludeNested` is.
- `:terminology:test` — 234 passed / 0 failed.
- `:termx-integtest:test` expansion subset (9 IT classes incl. all `ValueSetExpand*` + `ValueSetSupplementExpandIT`) — 53 passed / 0 failed.