### PR TITLE
FHIR $expand: include inactive concepts by default (marked inactive=true)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -227,9 +227,10 @@ public class ValueSetVersionConceptService {
       externalExpansion.addAll(provider.expand(ruleSet, version, preferredLanguage));
     }
     expansion.addAll(externalExpansion);
-    if (!ruleSet.isInactive()) {
-      return expansion.stream().filter(ValueSetVersionConcept::isActive).toList();
-    }
+    // FHIR: inactive concepts are part of the expansion by default (rendered with inactive=true) and are
+    // excluded only at render time when activeOnly=true (see ValueSetFhirMapper.toFhirExpansion). The
+    // snapshot is request-agnostic, so it must carry the superset including inactive concepts; previously
+    // they were dropped here unless compose.inactive was set, which hid them from every consumer.
     return expansion;
   }
 

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInactiveIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInactiveIT.groovy
@@ -1,0 +1,126 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.fhir.valueset.ValueSetFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetSnapshot
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+
+/**
+ * Pins the FHIR-conformant inactive-concept default: a value set expansion CONTAINS inactive concepts
+ * (so {@code $expand} renders them with {@code inactive=true} and {@code $validate-code} can find them),
+ * and they are dropped only at render time when {@code activeOnly=true}. Guards the flip in
+ * {@link ValueSetVersionConceptService#expand} that stopped discarding inactive concepts from the
+ * request-agnostic snapshot.
+ *
+ * <p>Fixture {@code fhir/inactive/codesystem-inactive.json}: codeActive (active), codeInactive
+ * ({@code inactive=true}), codeRetired ({@code status=retired}).
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandInactiveIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptService vsConceptService
+  @Inject ValueSetFhirMapper valueSetFhirMapper
+
+  static final String CS_ID = "inactive"
+  static final String VS_ID = "vsexpand-inactive-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importInactiveCs()
+    saveValueSet()
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "the request-agnostic expansion contains the inactive concepts (no longer silently dropped)"() {
+    when:
+    def expansion = vsConceptService.expand(VS_ID, VS_VERSION)
+    def codes = expansion.collect { it.concept?.code }.findAll { it != null } as Set
+
+    then: "the active concept and both non-active concepts are present"
+    codes == ["codeActive", "codeInactive", "codeRetired"] as Set
+
+    and: "codeRetired (status=retired) is flagged inactive (active=false) on its expansion entry"
+    !expansion.find { it.concept?.code == "codeRetired" }.active
+  }
+
+  def "default \$expand renders the inactive concept marked inactive=true; activeOnly=true drops it"() {
+    given:
+    def version = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow()
+    def valueSet = valueSetService.load(VS_ID)
+    def concepts = vsConceptService.expand(VS_ID, VS_VERSION)
+    def snapshot = new ValueSetSnapshot().setValueSet(VS_ID).setConceptsTotal(concepts.size()).setExpansion(concepts)
+
+    when: "no activeOnly — codeRetired is included and flagged"
+    def fhirDefault = valueSetFhirMapper.toFhir(valueSet, version, [], snapshot, new Parameters())
+    def inactiveEntry = fhirDefault.expansion.contains.find { it.code == "codeRetired" }
+
+    then:
+    inactiveEntry != null
+    inactiveEntry.inactive == true
+    fhirDefault.expansion.contains*.code as Set == ["codeActive", "codeInactive", "codeRetired"] as Set
+
+    when: "activeOnly=true — the inactive (retired) concept is excluded at render time"
+    def activeOnly = new Parameters().setParameter([new ParametersParameter().setName("activeOnly").setValueBoolean(true)])
+    def fhirActive = valueSetFhirMapper.toFhir(valueSet, version, [], snapshot, activeOnly)
+
+    then: "codeRetired is dropped; codeActive (and any concept termx still treats as active) remain"
+    !(fhirActive.expansion.contains*.code.contains("codeRetired"))
+    fhirActive.expansion.contains*.code.contains("codeActive")
+  }
+
+  private void importInactiveCs() {
+    def json = readFixtureString("fhir/inactive/codesystem-inactive.json")
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    def cs = fhirMapper.fromFhirCodeSystem(fhir)
+    importService.importCodeSystem(cs, [], new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private void saveValueSet() {
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID)
+    def version = new ValueSetVersion()
+        .setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Inactive expansion")))
+    request.setVersion(version)
+    valueSetService.save(request)
+  }
+
+  private String readFixtureString(String relativePath) {
+    def stream = getClass().getClassLoader().getResourceAsStream(relativePath)
+    assert stream != null, "fixture not found: ${relativePath}"
+    return new String(stream.readAllBytes(), "UTF-8")
+  }
+}


### PR DESCRIPTION
## Product-decision PR — flips a server-wide default

`ValueSetVersionConceptService.expand` dropped every concept termx computes as **inactive** (retired / deprecated / `inactive`) from the request-agnostic expansion unless `compose.inactive` was explicitly set. That hid inactive codes from **every** consumer of the snapshot: `$expand`, `$validate-code`, ConceptMap building, and code-system validation.

### Change
```diff
-    if (!ruleSet.isInactive()) {
-      return expansion.stream().filter(ValueSetVersionConcept::isActive).toList();
-    }
     return expansion;
```
FHIR puts inactive concepts in the expansion by default and renders them with `inactive=true`; they are excluded only at render time when `activeOnly=true` — which `ValueSetFhirMapper.toFhirExpansion` already implements (and `contains.inactive` marking already exists). This makes the snapshot the request-agnostic superset and lets the render layer govern visibility, matching the tx-ecosystem expectation.

### Tests
- New `ValueSetExpandInactiveIT`: a retired concept is present in the default expansion (flagged `inactive=true`) and excluded under `activeOnly=true`.
- `:terminology:test` — 233 / 0. `:termx-integtest:test` — 106 / 0 (incl. the new IT).

### ⚠️ Why this needs a product call before merge
- **Silent default flip.** No existing test pinned the old exclude-by-default behavior, so the suite stays green — but API consumers WILL see inactive codes appear in default `$expand`/`$validate-code` where they didn't before.
- **Model limitation.** `ValueSetVersionRuleSet.inactive` is a primitive `boolean`, so it cannot represent FHIR's tri-state `compose.inactive` (absent = server default vs. explicit `false` = exclude). A fully-correct implementation that honors an explicit `compose.inactive=false` exclusion would need that field promoted to `Boolean` and threaded through `fromFhir`/persistence — out of scope here.

Builds on #218, #219, #220.