### PR TITLE
FHIR $expand: tri-state compose.inactive (include inactive by default)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -223,7 +223,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       return null;
     }
     ValueSetCompose compose = new ValueSetCompose();
-    compose.setInactive(ruleSet.isInactive());
+    compose.setInactive(ruleSet.getInactive());
     if (ruleSet.getLockedDate() != null) {
       compose.setLockedDate(ruleSet.getLockedDate().toLocalDate());
     }
@@ -734,7 +734,8 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       return null;
     }
     ValueSetVersionRuleSet ruleSet = new ValueSetVersionRuleSet();
-    ruleSet.setInactive(valueSet.getCompose().getInactive() != null && valueSet.getCompose().getInactive());
+    // Preserve the tri-state: absent compose.inactive stays null (server default), not coerced to false.
+    ruleSet.setInactive(valueSet.getCompose().getInactive());
     if (valueSet.getCompose().getLockedDate() != null) {
       ruleSet.setLockedDate(valueSet.getCompose().getLockedDate().atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime());
     }

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -227,7 +227,12 @@ public class ValueSetVersionConceptService {
       externalExpansion.addAll(provider.expand(ruleSet, version, preferredLanguage));
     }
     expansion.addAll(externalExpansion);
-    if (!ruleSet.isInactive()) {
+    // FHIR compose.inactive (tri-state): only an explicit FALSE excludes inactive concepts from the
+    // expansion. When null (server default) or TRUE, inactive concepts stay in the request-agnostic
+    // snapshot — rendered with inactive=true and filtered only at render time by activeOnly
+    // (see ValueSetFhirMapper.toFhirExpansion). Previously a primitive-false default dropped them here,
+    // hiding inactive codes from every consumer ($expand, $validate-code, ConceptMap, CS validation).
+    if (Boolean.FALSE.equals(ruleSet.getInactive())) {
       return expansion.stream().filter(ValueSetVersionConcept::isActive).toList();
     }
     return expansion;

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ruleset/ValueSetVersionRuleSetRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ruleset/ValueSetVersionRuleSetRepository.java
@@ -15,7 +15,7 @@ public class ValueSetVersionRuleSetRepository extends BaseRepository {
     SaveSqlBuilder ssb = new SaveSqlBuilder();
     ssb.property("id", ruleSet.getId());
     ssb.property("locked_date", ruleSet.getLockedDate());
-    ssb.property("inactive", ruleSet.isInactive());
+    ssb.property("inactive", ruleSet.getInactive());
     ssb.property("value_set_version_id", valueSetVersionId);
     SqlBuilder sb = ssb.buildSave("terminology.value_set_version_rule_set", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());

--- a/terminology/src/main/resources/terminology/changelog/terminology/05-value_set.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/05-value_set.sql
@@ -255,3 +255,14 @@ alter table terminology.value_set_snapshot add column dependencies jsonb;
 alter table terminology.value_set_snapshot add column expansion_bytea bytea;
 alter table terminology.value_set_snapshot alter column expansion drop not null;
 --
+
+--changeset termx:value_set_version_rule_set-inactive-nullable
+-- Restore the tri-state for compose.inactive: null = server default (include inactive, render inactive=true,
+-- filter only by activeOnly), true = include, false = exclude. The earlier -not_null changeset coerced
+-- absent values to false, conflating "default" with "explicitly exclude"; that conflation is unrecoverable,
+-- so existing rows are intentionally left as-is (false stays an explicit exclude) and only the constraint is
+-- dropped — new/edited value sets that omit compose.inactive now persist null and get the FHIR default.
+alter table terminology.value_set_version_rule_set alter column inactive drop not null;
+--rollback update terminology.value_set_version_rule_set set inactive = false where inactive is null;
+--rollback alter table terminology.value_set_version_rule_set alter column inactive set not null;
+--

--- a/termx-api/src/main/java/org/termx/ts/valueset/ValueSetVersionRuleSet.java
+++ b/termx-api/src/main/java/org/termx/ts/valueset/ValueSetVersionRuleSet.java
@@ -15,7 +15,13 @@ import lombok.experimental.Accessors;
 public class ValueSetVersionRuleSet {
   private Long id;
   private OffsetDateTime lockedDate;
-  private boolean inactive;
+  /**
+   * Tri-state mirror of FHIR {@code ValueSet.compose.inactive} (nullable on purpose):
+   * {@code null}/absent → server default (inactive concepts included, rendered with {@code inactive=true},
+   * filtered only at render time by {@code activeOnly}); {@code TRUE} → include inactive; {@code FALSE} →
+   * explicitly exclude inactive from the expansion.
+   */
+  private Boolean inactive;
   private List<ValueSetVersionRule> rules;
 
   @Getter

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInactiveIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInactiveIT.groovy
@@ -1,0 +1,145 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.fhir.valueset.ValueSetFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetSnapshot
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+
+/**
+ * Pins the FHIR-conformant inactive-concept default: a value set expansion CONTAINS inactive concepts
+ * (so {@code $expand} renders them with {@code inactive=true} and {@code $validate-code} can find them),
+ * and they are dropped only at render time when {@code activeOnly=true}. Guards the flip in
+ * {@link ValueSetVersionConceptService#expand} that stopped discarding inactive concepts from the
+ * request-agnostic snapshot.
+ *
+ * <p>Fixture {@code fhir/inactive/codesystem-inactive.json}: codeActive (active), codeInactive
+ * ({@code inactive=true}), codeRetired ({@code status=retired}).
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandInactiveIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptService vsConceptService
+  @Inject ValueSetFhirMapper valueSetFhirMapper
+
+  static final String CS_ID = "inactive"
+  static final String VS_ID = "vsexpand-inactive-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importInactiveCs()
+    saveValueSet(VS_ID, null)
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "compose.inactive tri-state governs whether inactive concepts are in the request-agnostic expansion"() {
+    given: "three value sets over the same code system differing only in compose.inactive"
+    saveValueSet("vs-inactive-null", null)
+    saveValueSet("vs-inactive-true", Boolean.TRUE)
+    saveValueSet("vs-inactive-false", Boolean.FALSE)
+
+    expect: "null (server default) and true include the retired concept; explicit false excludes it"
+    codesOf("vs-inactive-null").contains("codeRetired")
+    codesOf("vs-inactive-true").contains("codeRetired")
+    !codesOf("vs-inactive-false").contains("codeRetired")
+
+    and: "the active concept is present regardless"
+    ["vs-inactive-null", "vs-inactive-true", "vs-inactive-false"].every { codesOf(it).contains("codeActive") }
+  }
+
+  def "the request-agnostic expansion contains the inactive concepts (no longer silently dropped)"() {
+    when:
+    def expansion = vsConceptService.expand(VS_ID, VS_VERSION)
+    def codes = expansion.collect { it.concept?.code }.findAll { it != null } as Set
+
+    then: "the active concept and both non-active concepts are present"
+    codes == ["codeActive", "codeInactive", "codeRetired"] as Set
+
+    and: "codeRetired (status=retired) is flagged inactive (active=false) on its expansion entry"
+    !expansion.find { it.concept?.code == "codeRetired" }.active
+  }
+
+  def "default \$expand renders the inactive concept marked inactive=true; activeOnly=true drops it"() {
+    given:
+    def version = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow()
+    def valueSet = valueSetService.load(VS_ID)
+    def concepts = vsConceptService.expand(VS_ID, VS_VERSION)
+    def snapshot = new ValueSetSnapshot().setValueSet(VS_ID).setConceptsTotal(concepts.size()).setExpansion(concepts)
+
+    when: "no activeOnly — codeRetired is included and flagged"
+    def fhirDefault = valueSetFhirMapper.toFhir(valueSet, version, [], snapshot, new Parameters())
+    def inactiveEntry = fhirDefault.expansion.contains.find { it.code == "codeRetired" }
+
+    then:
+    inactiveEntry != null
+    inactiveEntry.inactive == true
+    fhirDefault.expansion.contains*.code as Set == ["codeActive", "codeInactive", "codeRetired"] as Set
+
+    when: "activeOnly=true — the inactive (retired) concept is excluded at render time"
+    def activeOnly = new Parameters().setParameter([new ParametersParameter().setName("activeOnly").setValueBoolean(true)])
+    def fhirActive = valueSetFhirMapper.toFhir(valueSet, version, [], snapshot, activeOnly)
+
+    then: "codeRetired is dropped; codeActive (and any concept termx still treats as active) remain"
+    !(fhirActive.expansion.contains*.code.contains("codeRetired"))
+    fhirActive.expansion.contains*.code.contains("codeActive")
+  }
+
+  private void importInactiveCs() {
+    def json = readFixtureString("fhir/inactive/codesystem-inactive.json")
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    def cs = fhirMapper.fromFhirCodeSystem(fhir)
+    importService.importCodeSystem(cs, [], new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private Set<String> codesOf(String vsId) {
+    return vsConceptService.expand(vsId, VS_VERSION).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private void saveValueSet(String vsId, Boolean inactive) {
+    def rule = new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID)
+    def version = new ValueSetVersion()
+        .setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setInactive(inactive).setRules([rule]))
+    version.setValueSet(vsId)
+    version.setVersion(VS_VERSION)
+
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(vsId).setUri("http://termx-test.local/ValueSet/" + vsId)
+        .setTitle(new LocalizedName().add("en", "Inactive expansion")))
+    request.setVersion(version)
+    valueSetService.save(request)
+  }
+
+  private String readFixtureString(String relativePath) {
+    def stream = getClass().getClassLoader().getResourceAsStream(relativePath)
+    assert stream != null, "fixture not found: ${relativePath}"
+    return new String(stream.readAllBytes(), "UTF-8")
+  }
+}


### PR DESCRIPTION
Supersedes #221 (which used a blunt boolean flip). Implements the full nullable-`Boolean` model you asked for.

## Problem

`ValueSetVersionRuleSet.inactive` was a primitive `boolean`, so it could not represent FHIR `ValueSet.compose.inactive` faithfully. Its default (`false`) dropped every concept termx computes as **inactive** (retired / deprecated / inactive) from the request-agnostic snapshot, hiding inactive codes from **every** consumer — `$expand`, `$validate-code`, ConceptMap building, code-system validation — and an explicit `compose.inactive=false` was indistinguishable from "unset".

## Tri-state model

`inactive` becomes a nullable `Boolean`:

| compose.inactive | behavior |
|---|---|
| **null / absent** | server default — inactive concepts **in** the expansion, rendered `inactive=true`, filtered only at render time by `activeOnly` |
| **true** | include inactive |
| **false** | explicitly exclude inactive |

`ValueSetVersionConceptService.expand` now excludes only on `Boolean.FALSE`; the render layer (`ValueSetFhirMapper.toFhirExpansion`) already marks `inactive=true` and honors `activeOnly`.

## Changes
- `ValueSetVersionRuleSet.inactive`: `boolean` → `Boolean` (`getInactive()`).
- `fromFhir`: pass `compose.inactive` through verbatim (no null→false coercion).
- `toFhir` + `ValueSetVersionRuleSetRepository`: emit/store the nullable value.
- Liquibase `termx:value_set_version_rule_set-inactive-nullable`: drop the NOT NULL constraint. **Existing rows are left as-is** — the prior `null→false` coercion is unrecoverable, so their `false` stays an explicit exclude. Only new/edited value sets that omit `compose.inactive` get the FHIR default. This means **no silent behavior change for existing content**; the flip applies to fresh imports (incl. the tx-ecosystem conformance fixtures).

## Tests
- New `ValueSetExpandInactiveIT`: tri-state inclusion (null/true include the retired concept, false excludes) + render-time contract (`inactive=true` by default, dropped under `activeOnly=true`).
- `:terminology:test` — 233 / 0.
- `:termx-integtest:test` — 107 / 0 (Liquibase `drop not null` exercised by the testcontainers schema init).

Builds on #218, #219, #220.