### PR TITLE
FHIR import robustness + tx-conformance setup loader hardening

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -494,7 +494,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
 
   public CodeSystem fromFhirCodeSystem(com.kodality.zmei.fhir.resource.terminology.CodeSystem fhirCS) {
     CodeSystem codeSystem = new CodeSystem();
-    codeSystem.setId(CodeSystemFhirMapper.parseCompositeId(fhirCS.getId())[0]);
+    codeSystem.setId(CodeSystemFhirMapper.fhirIdOrFromUrl(fhirCS.getId(), fhirCS.getUrl()));
     codeSystem.setUri(fhirCS.getUrl());
     codeSystem.setPublisher(fhirCS.getPublisher());
     codeSystem.setName(fhirCS.getName());

--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
@@ -1,5 +1,8 @@
 package org.termx.terminology.fhir.conformance;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.kodality.commons.util.JsonUtil;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Singleton;
@@ -41,12 +44,18 @@ public class TxConformanceSetupLoader {
   private static final String FHIR_JSON = "application/fhir+json";
 
   private final String packageDir;
+  // Writing setup content requires CodeSystem/ValueSet create+update privileges, but the loader calls the
+  // FHIR endpoint over HTTP — where, unauthenticated, it is a guest and every write is 403 Forbidden. A
+  // bearer token (the dev token locally, a service token on a dedicated conformance instance) authorizes it.
+  private final String authToken;
   private final HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
 
-  public TxConformanceSetupLoader(@Value("${termx.conformance.test-package-dir:}") String packageDir) {
+  public TxConformanceSetupLoader(@Value("${termx.conformance.test-package-dir:}") String packageDir,
+                                  @Value("${termx.conformance.setup-auth-token:}") String authToken) {
     // Default to the FHIR validator's package cache, where txTests downloads the tx-ecosystem fixtures.
     this.packageDir = StringUtils.isNotEmpty(packageDir) ? packageDir
         : System.getProperty("user.home") + "/.fhir/packages/hl7.fhir.uv.tx-ecosystem#current/package/tests";
+    this.authToken = authToken;
   }
 
   /** Loads every setup CodeSystem then ValueSet under the package dir into {@code fhirBaseUrl}. */
@@ -58,17 +67,35 @@ public class TxConformanceSetupLoader {
     }
     List<Path> codeSystems = findSetupFiles(root, "codesystem-");
     List<Path> valueSets = findSetupFiles(root, "valueset-");
+    int total = codeSystems.size() + valueSets.size();
     log.info("tx conformance setup: loading {} CodeSystems and {} ValueSets into {}", codeSystems.size(), valueSets.size(), fhirBaseUrl);
 
+    // Dependency order is not knowable up front: supplement/derived CodeSystems reference a base
+    // CodeSystem, and ValueSets reference CodeSystems and other ValueSets. Rather than topologically
+    // sort, load in repeated passes until a pass resolves nothing new (fixpoint). Each remaining resource
+    // is retried while progress is still being made, so multi-level chains (A←B←C) resolve over passes.
+    List<Path> remaining = new ArrayList<>();
+    codeSystems.forEach(p -> remaining.add(p));
+    valueSets.forEach(p -> remaining.add(p));
     int ok = 0;
-    int failed = 0;
-    for (Path p : codeSystems) {
-      if (send(fhirBaseUrl + "/CodeSystem/" + idOf(p), "PUT", p)) { ok++; } else { failed++; }
+    int pass = 0;
+    boolean progressed = true;
+    while (progressed && !remaining.isEmpty()) {
+      progressed = false;
+      pass++;
+      for (java.util.Iterator<Path> it = remaining.iterator(); it.hasNext(); ) {
+        Path p = it.next();
+        boolean isCs = p.getFileName().toString().toLowerCase().startsWith("codesystem-");
+        String url = isCs ? fhirBaseUrl + "/CodeSystem/" + idOf(p) : fhirBaseUrl + "/ValueSet";
+        if (send(url, isCs ? "PUT" : "POST", p)) {
+          it.remove();
+          ok++;
+          progressed = true;
+        }
+      }
+      log.info("tx conformance setup: pass {} — {}/{} loaded, {} still pending", pass, ok, total, remaining.size());
     }
-    for (Path p : valueSets) {
-      if (send(fhirBaseUrl + "/ValueSet", "POST", p)) { ok++; } else { failed++; }
-    }
-    log.info("tx conformance setup: loaded {} resources ({} failed/duplicate)", ok, failed);
+    log.info("tx conformance setup: loaded {} of {} resources in {} pass(es) ({} unresolved)", ok, total, pass, remaining.size());
   }
 
   /** Setup resources: {@code codesystem-*.json} / {@code valueset-*.json}, excluding test request/response artifacts. */
@@ -96,21 +123,56 @@ public class TxConformanceSetupLoader {
 
   private boolean send(String url, String method, Path body) {
     try {
-      HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+      HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url))
           .timeout(Duration.ofSeconds(60))
           .header("Content-Type", FHIR_JSON)
-          .header("Accept", FHIR_JSON)
-          .method(method, BodyPublishers.ofFile(body))
-          .build();
+          .header("Accept", FHIR_JSON);
+      if (StringUtils.isNotEmpty(authToken)) {
+        b.header("Authorization", "Bearer " + authToken);
+      }
+      HttpRequest req = b.method(method, BodyPublishers.ofString(sanitize(body))).build();
       HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
       if (resp.statusCode() / 100 == 2) {
         return true;
       }
-      log.debug("tx conformance setup: {} {} -> {} (likely already present)", method, url, resp.statusCode());
+      // Honest logging: report the real status + a snippet of the error so an incomplete setup is
+      // diagnosable, instead of the misleading blanket "already present".
+      log.info("tx conformance setup: {} {} -> {}: {}", method, url, resp.statusCode(), summarize(resp.body()));
       return false;
     } catch (Exception e) {
       log.warn("tx conformance setup: {} {} failed: {}", method, url, e.getMessage());
       return false;
     }
+  }
+
+  /**
+   * Reads the fixture and strips metadata termx's resource validation rejects but that has no bearing on
+   * the terminology operations under test — currently {@code versionAlgorithm[x]} (a version-comparison
+   * hint that references code systems termx does not host, failing the whole import on an otherwise valid
+   * resource). Returns the original bytes verbatim if anything goes wrong, so stripping never blocks a load.
+   */
+  static String sanitize(Path body) {
+    try {
+      JsonNode root = JsonUtil.getObjectMapper().readTree(body.toFile());
+      if (root instanceof ObjectNode obj) {
+        obj.remove("versionAlgorithmString");
+        obj.remove("versionAlgorithmCoding");
+      }
+      return JsonUtil.getObjectMapper().writeValueAsString(root);
+    } catch (Exception e) {
+      try {
+        return Files.readString(body);
+      } catch (Exception ignored) {
+        return "";
+      }
+    }
+  }
+
+  private static String summarize(String responseBody) {
+    if (responseBody == null) {
+      return "";
+    }
+    String b = responseBody.replaceAll("\\s+", " ").trim();
+    return b.length() > 200 ? b.substring(0, 200) + "…" : b;
   }
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -712,7 +712,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
 
   public static ValueSet fromFhirValueSet(com.kodality.zmei.fhir.resource.terminology.ValueSet valueSet) {
     ValueSet vs = new ValueSet();
-    vs.setId(ValueSetFhirMapper.parseCompositeId(valueSet.getId())[0]);
+    vs.setId(ValueSetFhirMapper.fhirIdOrFromUrl(valueSet.getId(), valueSet.getUrl()));
     vs.setUri(valueSet.getUrl());
     vs.setPublisher(valueSet.getPublisher());
     vs.setName(valueSet.getName());

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
@@ -1,8 +1,51 @@
 package org.termx.terminology.fhir.conformance
 
+import com.kodality.commons.util.JsonUtil
 import spock.lang.Specification
 
+import java.nio.file.Files
+
 class TxConformanceSetupLoaderTest extends Specification {
+
+  def "sanitize strips versionAlgorithm metadata termx cannot import, preserving the rest"() {
+    given:
+    def f = Files.createTempFile("cs", ".json")
+    f.toFile().text = JsonUtil.toJson([
+        resourceType          : "CodeSystem",
+        id                    : "version",
+        url                   : "http://hl7.org/fhir/test/CodeSystem/version",
+        versionAlgorithmCoding: [system: "http://hl7.org/fhir/version-algorithm", code: "semver"],
+        content               : "complete",
+    ])
+
+    when:
+    def out = JsonUtil.fromJson(TxConformanceSetupLoader.sanitize(f), Map)
+
+    then: "the unimportable hint is gone; identity and content survive"
+    !out.containsKey("versionAlgorithmCoding")
+    out.id == "version"
+    out.url == "http://hl7.org/fhir/test/CodeSystem/version"
+    out.content == "complete"
+
+    cleanup:
+    Files.deleteIfExists(f)
+  }
+
+  def "sanitize also strips the valueString form of versionAlgorithm"() {
+    given:
+    def f = Files.createTempFile("cs", ".json")
+    f.toFile().text = JsonUtil.toJson([resourceType: "CodeSystem", id: "x", versionAlgorithmString: "semver"])
+
+    when:
+    def out = JsonUtil.fromJson(TxConformanceSetupLoader.sanitize(f), Map)
+
+    then:
+    !out.containsKey("versionAlgorithmString")
+    out.id == "x"
+
+    cleanup:
+    Files.deleteIfExists(f)
+  }
 
   def "isSetupFile accepts setup resources of the kind and rejects test artifacts"() {
     expect:

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -132,6 +132,9 @@ termx:
     # Optional: dir holding the tx-ecosystem test fixtures to load when a run requests loadSetup=true.
     # Defaults to the FHIR validator's package cache (~/.fhir/packages/hl7.fhir.uv.tx-ecosystem#current/package/tests).
     test-package-dir: ${TERMX_CONFORMANCE_TEST_PACKAGE_DIR:}
+    # Bearer token the setup loader uses to write fixtures over HTTP (writes need CodeSystem/ValueSet
+    # create+update privileges — unauthenticated guest writes are 403). Locally this is the dev token.
+    setup-auth-token: ${TERMX_CONFORMANCE_SETUP_AUTH_TOKEN:}
   fhir:
     codesystem:
       lookup:

--- a/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
@@ -53,6 +53,9 @@ public abstract class BaseFhirMapper {
   );
 
   public static String[] parseCompositeId(String id) {
+    if (id == null) {
+      return new String[]{null, null};
+    }
     id = URLDecoder.decode(id, StandardCharsets.UTF_8);
     if (!id.contains(SEPARATOR)) {
       return new String[]{id, null};
@@ -60,6 +63,27 @@ public abstract class BaseFhirMapper {
     String one = StringUtils.substringBefore(id, SEPARATOR);
     String two = StringUtils.substringAfter(id, SEPARATOR);
     return new String[]{one, StringUtils.isEmpty(two) ? null : two};
+  }
+
+  /**
+   * Resolves the termx resource id for an incoming FHIR resource. Uses the resource's own {@code id}
+   * (composite-id aware) when present; otherwise derives a stable id from the last path segment of the
+   * canonical {@code url}. FHIR allows id-less resources (identity carried by {@code url}); termx keys on
+   * id, so without this an id-less CodeSystem/ValueSet NPEs in {@code parseCompositeId}. Returns null only
+   * when neither id nor a usable url is present.
+   */
+  public static String fhirIdOrFromUrl(String id, String url) {
+    if (StringUtils.isNotEmpty(id)) {
+      return parseCompositeId(id)[0];
+    }
+    if (StringUtils.isEmpty(url)) {
+      return null;
+    }
+    String last = url.contains("/") ? StringUtils.substringAfterLast(url, "/") : url;
+    // Sanitize to the FHIR id grammar ([A-Za-z0-9-.]{1,64}); replace anything else with '-'.
+    last = last.replaceAll("[^A-Za-z0-9.-]", "-");
+    last = StringUtils.left(last, 64);
+    return StringUtils.isNotEmpty(last) ? last : null;
   }
 
   protected static Integer getOffset(SearchCriterion fhir) {

--- a/termx-core/src/test/groovy/org/termx/core/fhir/BaseFhirMapperSpec.groovy
+++ b/termx-core/src/test/groovy/org/termx/core/fhir/BaseFhirMapperSpec.groovy
@@ -47,4 +47,29 @@ class BaseFhirMapperSpec extends Specification {
     then:
     simple == ['publisher': 'HL7']
   }
+
+  def 'parseCompositeId is null-safe'() {
+    expect:
+    BaseFhirMapper.parseCompositeId(null) == [null, null] as String[]
+  }
+
+  def 'fhirIdOrFromUrl prefers the explicit id'() {
+    expect:
+    BaseFhirMapper.fhirIdOrFromUrl('my-id', 'http://example.org/CodeSystem/ignored') == 'my-id'
+    // composite id still resolves to its first segment
+    BaseFhirMapper.fhirIdOrFromUrl('my-id' + BaseFhirMapper.SEPARATOR + '1.0.0', 'http://x/y') == 'my-id'
+  }
+
+  def 'fhirIdOrFromUrl derives a sanitized id from the url last segment when id is absent'() {
+    expect:
+    BaseFhirMapper.fhirIdOrFromUrl(id, url) == expected
+    where:
+    id   | url                                            || expected
+    null | 'http://hl7.org/fhir/test/CodeSystem/version'  || 'version'
+    ''   | 'http://hl7.org/fhir/test/ValueSet/all-codes'  || 'all-codes'
+    null | 'urn:oid:1.2.3.4'                              || 'urn-oid-1.2.3.4'
+    null | 'simpleword'                                    || 'simpleword'
+    null | null                                            || null
+    null | ''                                              || null
+  }
 }


### PR DESCRIPTION
Groundwork for a trustworthy tx-ecosystem conformance baseline. Surfaced while diagnosing why the conformance score was contaminated: termx's FHIR import was rejecting/crashing on the bulk of the standard R5 fixtures.

## Import robustness (termx core)
- **`parseCompositeId` is null-safe** — it NPE'd (`String.length() because "s" is null`) on a null id.
- **`BaseFhirMapper.fhirIdOrFromUrl`** — FHIR allows id-less resources (identity carried by the canonical `url`), but termx keys on id and NPE'd in `fromFhirCodeSystem`/`fromFhirValueSet`. Now, when `id` is absent, a stable sanitized id is derived from the url's last path segment. This single fix clears **~88 id-less tx-ecosystem fixtures** that previously crashed import (verified: 0 `String.length` NPEs after).

## tx-conformance setup loader hardening
- **Authenticated writes** (`termx.conformance.setup-auth-token`) — the loader writes fixtures over HTTP; unauthenticated, every write is **403** (guest can't create), so a fresh instance loaded nothing.
- **Multi-pass fixpoint load** — supplement/derived CodeSystems and cross-referencing ValueSets have dependency order that isn't knowable up front. Load in repeated passes until one resolves nothing new, replacing the single CS-then-VS sweep.
- **Strip `versionAlgorithm[x]`** — metadata termx's validation rejects (unknown algorithm code system) but irrelevant to the terminology ops under test.
- **Honest failure logging** — real status + error snippet, replacing the misleading blanket "likely already present".

## Tests
- `BaseFhirMapperSpec`: null-safe + id-from-url derivation cases.
- `TxConformanceSetupLoaderTest`: versionAlgorithm stripping.
- `:termx-core:test` 73/0, `:terminology:test` 236/0, FHIR import/round-trip integtests green.

## Status / follow-up
This raises import robustness but does **not** yet yield a fully clean conformance baseline: a tail of root CodeSystem strictness rejections (`Unrecognized property`, supplement `caseSensitive`) still cascades into unresolved value sets, and the `version`-suite value sets (distinct ids sharing one canonical url) need url+version resolution. Tracked as the next conformance step.