### PR TITLE
FHIR profile awareness: record meta.profile + tolerate unknown profiles

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -87,6 +87,9 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
       fhirCodeSystem.addExtension(toFhirWebSourceExtension(codeSystem.getExternalWebSource()));
     }
     fhirCodeSystem.setId(toFhirId(codeSystem, version));
+    if (CollectionUtils.isNotEmpty(codeSystem.getProfile())) {
+      fhirCodeSystem.setMeta(new com.kodality.zmei.fhir.resource.Meta().setProfile(codeSystem.getProfile()));
+    }
     fhirCodeSystem.setUrl(codeSystem.getUri());
     fhirCodeSystem.setPublisher(
         conceptService.load("publisher", codeSystem.getPublisher()).flatMap(Concept::getLastVersion).flatMap(CodeSystemEntityVersion::getDisplay)
@@ -495,6 +498,9 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
   public CodeSystem fromFhirCodeSystem(com.kodality.zmei.fhir.resource.terminology.CodeSystem fhirCS) {
     CodeSystem codeSystem = new CodeSystem();
     codeSystem.setId(CodeSystemFhirMapper.parseCompositeId(fhirCS.getId())[0]);
+    if (fhirCS.getMeta() != null && CollectionUtils.isNotEmpty(fhirCS.getMeta().getProfile())) {
+      codeSystem.setProfile(fhirCS.getMeta().getProfile());
+    }
     codeSystem.setUri(fhirCS.getUrl());
     codeSystem.setPublisher(fhirCS.getPublisher());
     codeSystem.setName(fhirCS.getName());

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
@@ -113,6 +113,9 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
         fhirConceptMap.addExtension(toFhirWebSourceExtension(mapSet.getExternalWebSource()));
     }
     fhirConceptMap.setId(toFhirId(mapSet, version));
+    if (CollectionUtils.isNotEmpty(mapSet.getProfile())) {
+      fhirConceptMap.setMeta(new com.kodality.zmei.fhir.resource.Meta().setProfile(mapSet.getProfile()));
+    }
     fhirConceptMap.setUrl(mapSet.getUri());
     fhirConceptMap.setPublisher(conceptService.load("publisher", mapSet.getPublisher()).flatMap(Concept::getLastVersion).flatMap(CodeSystemEntityVersion::getDisplay).orElse(mapSet.getPublisher()));
     fhirConceptMap.setName(mapSet.getName());
@@ -338,6 +341,9 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
   public MapSet fromFhir(ConceptMap cm) {
     MapSet ms = new MapSet();
     ms.setId(ConceptMapFhirMapper.parseCompositeId(cm.getId())[0]);
+    if (cm.getMeta() != null && CollectionUtils.isNotEmpty(cm.getMeta().getProfile())) {
+      ms.setProfile(cm.getMeta().getProfile());
+    }
     ms.setUri(cm.getUrl());
     ms.setPublisher(cm.getPublisher());
     ms.setName(cm.getName());

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -148,6 +148,9 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       fhirValueSet.addExtension(toFhirWebSourceExtension(valueSet.getExternalWebSource()));
     }
     fhirValueSet.setId(toFhirId(valueSet, version));
+    if (CollectionUtils.isNotEmpty(valueSet.getProfile())) {
+      fhirValueSet.setMeta(new com.kodality.zmei.fhir.resource.Meta().setProfile(valueSet.getProfile()));
+    }
     fhirValueSet.setUrl(valueSet.getUri());
     fhirValueSet.setName(valueSet.getName());
     if (CollectionUtils.isNotEmpty(valueSet.getOtherTitle())) {
@@ -713,6 +716,9 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   public static ValueSet fromFhirValueSet(com.kodality.zmei.fhir.resource.terminology.ValueSet valueSet) {
     ValueSet vs = new ValueSet();
     vs.setId(ValueSetFhirMapper.parseCompositeId(valueSet.getId())[0]);
+    if (valueSet.getMeta() != null && CollectionUtils.isNotEmpty(valueSet.getMeta().getProfile())) {
+      vs.setProfile(valueSet.getMeta().getProfile());
+    }
     vs.setUri(valueSet.getUrl());
     vs.setPublisher(valueSet.getPublisher());
     vs.setName(valueSet.getName());

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemRepository.java
@@ -4,6 +4,7 @@ import com.kodality.commons.db.bean.PgBeanProcessor;
 import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
 import com.kodality.commons.db.sql.SqlBuilder;
+import com.kodality.commons.db.util.PgUtil;
 import com.kodality.commons.model.Identifier;
 import com.kodality.commons.model.QueryResult;
 import com.kodality.commons.util.JsonUtil;
@@ -43,6 +44,7 @@ public class CodeSystemRepository extends BaseRepository {
     bp.addColumnProcessor("properties", PgBeanProcessor.fromJson(JsonUtil.getListType(EntityProperty.class)));
     bp.addColumnProcessor("last_version", "latestVersion", PgBeanProcessor.fromJson());
     bp.addColumnProcessor("configuration_attributes", PgBeanProcessor.fromJson(JsonUtil.getListType(ConfigurationAttribute.class)));
+    bp.addColumnProcessor("profile", PgBeanProcessor.fromArray());
   });
 
   private static final String selectBase = "select distinct on (cs.id) cs.*, " +
@@ -101,6 +103,7 @@ public class CodeSystemRepository extends BaseRepository {
     ssb.property("uri", codeSystem.getUri());
     ssb.property("publisher", codeSystem.getPublisher());
     ssb.property("name", codeSystem.getName());
+    ssb.property("profile", "?::text[]", PgUtil.array(codeSystem.getProfile()));
     ssb.jsonProperty("other_title", codeSystem.getOtherTitle());
     ssb.jsonProperty("title", codeSystem.getTitle());
     ssb.jsonProperty("description", codeSystem.getDescription());

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetRepository.java
@@ -1,6 +1,7 @@
 package org.termx.terminology.terminology.mapset;
 
 import com.kodality.commons.db.bean.PgBeanProcessor;
+import com.kodality.commons.db.util.PgUtil;
 import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
 import com.kodality.commons.db.sql.SqlBuilder;
@@ -36,6 +37,7 @@ public class MapSetRepository extends BaseRepository {
     bp.addColumnProcessor("contacts", PgBeanProcessor.fromJson(JsonUtil.getListType(ContactDetail.class)));
     bp.addColumnProcessor("properties", PgBeanProcessor.fromJson(JsonUtil.getListType(MapSetProperty.class)));
     bp.addColumnProcessor("configuration_attributes", PgBeanProcessor.fromJson(JsonUtil.getListType(ConfigurationAttribute.class)));
+    bp.addColumnProcessor("profile", PgBeanProcessor.fromArray());
   });
 
   private static final String select = "select distinct on (ms.id) ms.*, " +
@@ -59,6 +61,7 @@ public class MapSetRepository extends BaseRepository {
     ssb.property("uri", mapSet.getUri());
     ssb.property("publisher", mapSet.getPublisher());
     ssb.property("name", mapSet.getName());
+    ssb.property("profile", "?::text[]", PgUtil.array(mapSet.getProfile()));
     ssb.jsonProperty("other_title", mapSet.getOtherTitle());
     ssb.jsonProperty("title", mapSet.getTitle());
     ssb.jsonProperty("description", mapSet.getDescription());

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetRepository.java
@@ -1,6 +1,7 @@
 package org.termx.terminology.terminology.valueset;
 
 import com.kodality.commons.db.bean.PgBeanProcessor;
+import com.kodality.commons.db.util.PgUtil;
 import com.kodality.commons.db.repo.BaseRepository;
 import com.kodality.commons.db.sql.SaveSqlBuilder;
 import com.kodality.commons.db.sql.SqlBuilder;
@@ -36,6 +37,7 @@ public class ValueSetRepository extends BaseRepository {
     bp.addColumnProcessor("identifiers", PgBeanProcessor.fromJson(JsonUtil.getListType(Identifier.class)));
     bp.addColumnProcessor("configuration_attributes", PgBeanProcessor.fromJson(JsonUtil.getListType(ConfigurationAttribute.class)));
     bp.addColumnProcessor("last_version", "latestVersion", PgBeanProcessor.fromJson());
+    bp.addColumnProcessor("profile", PgBeanProcessor.fromArray());
   });
 
   private static final String selectBase = "select distinct on (vs.id) vs.*, null::json as last_version ";
@@ -69,6 +71,7 @@ public class ValueSetRepository extends BaseRepository {
     ssb.property("uri", valueSet.getUri());
     ssb.property("publisher", valueSet.getPublisher());
     ssb.property("name", valueSet.getName());
+    ssb.property("profile", "?::text[]", PgUtil.array(valueSet.getProfile()));
     ssb.jsonProperty("other_title", valueSet.getOtherTitle());
     ssb.jsonProperty("title", valueSet.getTitle());
     ssb.jsonProperty("description", valueSet.getDescription());

--- a/terminology/src/main/resources/terminology/changelog/terminology/01-code_system.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/01-code_system.sql
@@ -158,3 +158,9 @@ add column external_web_source text;
 --rollback  drop column if exists external_web_source,
 --rollback  add column external_web_source boolean;
 --
+
+--changeset termx:code_system-profile
+-- FHIR meta.profile: conformance profiles the resource claims (0..*). Default empty (no profile).
+alter table terminology.code_system add column profile text[];
+--rollback alter table terminology.code_system drop column profile;
+--

--- a/terminology/src/main/resources/terminology/changelog/terminology/05-value_set.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/05-value_set.sql
@@ -266,3 +266,9 @@ alter table terminology.value_set_version_rule_set alter column inactive drop no
 --rollback update terminology.value_set_version_rule_set set inactive = false where inactive is null;
 --rollback alter table terminology.value_set_version_rule_set alter column inactive set not null;
 --
+
+--changeset termx:value_set-profile
+-- FHIR meta.profile: conformance profiles the resource claims (0..*). Default empty (no profile).
+alter table terminology.value_set add column profile text[];
+--rollback alter table terminology.value_set drop column profile;
+--

--- a/terminology/src/main/resources/terminology/changelog/terminology/06-map_set.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/06-map_set.sql
@@ -155,3 +155,8 @@ add column external_web_source text;
 --changeset termx:map_set_version-supported_languages
 alter table terminology.map_set_version add column if not exists supported_languages text[];
 --rollback alter table terminology.map_set_version drop column if exists supported_languages;
+--changeset termx:map_set-profile
+-- FHIR meta.profile: conformance profiles the resource claims (0..*). Default empty (no profile).
+alter table terminology.map_set add column profile text[];
+--rollback alter table terminology.map_set drop column profile;
+--

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
@@ -151,4 +151,39 @@ class CodeSystemFhirMapperSpec extends Specification {
     languages.contains("et")
     languages.contains("ru")
   }
+
+  def "meta.profile round-trips: import populates profile, export emits meta.profile"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.CodeSystem()
+        .setId("cs").setUrl("http://fhir.ee/CodeSystem/cs").setName("cs").setContent("not-present")
+    fhir.setMeta(new com.kodality.zmei.fhir.resource.Meta().setProfile([
+        org.termx.ts.FhirProfile.SHAREABLE_CODE_SYSTEM, "http://example.org/StructureDefinition/custom"]))
+
+    when: "import"
+    def imported = mapper.fromFhirCodeSystem(fhir)
+
+    then: "both the recognized and the custom profile are stored verbatim"
+    imported.profile == [org.termx.ts.FhirProfile.SHAREABLE_CODE_SYSTEM, "http://example.org/StructureDefinition/custom"]
+
+    when: "export the stored profile back out"
+    def version = new CodeSystemVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-06-18")).setStatus(PublicationStatus.draft)
+    def out = mapper.toFhir(imported.setTitle(new LocalizedName([en: "cs"])), version, [])
+
+    then:
+    out.meta.profile == [org.termx.ts.FhirProfile.SHAREABLE_CODE_SYSTEM, "http://example.org/StructureDefinition/custom"]
+  }
+
+  def "no declared profile leaves meta unset on export"() {
+    given:
+    conceptService.load(_, _) >> Optional.empty()
+    def cs = new CodeSystem().setId("cs").setUri("http://fhir.ee/CodeSystem/cs").setName("cs")
+        .setTitle(new LocalizedName([en: "cs"])).setContent("not-present")
+    def version = new CodeSystemVersion().setVersion("1.0.0").setPreferredLanguage("en")
+        .setReleaseDate(LocalDate.parse("2026-06-18")).setStatus(PublicationStatus.draft)
+
+    expect:
+    mapper.toFhir(cs, version, []).meta == null
+  }
 }

--- a/termx-api/src/main/java/org/termx/ts/FhirProfile.java
+++ b/termx-api/src/main/java/org/termx/ts/FhirProfile.java
@@ -1,0 +1,49 @@
+package org.termx.ts;
+
+import java.util.Set;
+
+/**
+ * The official HL7 FHIR R5 conformance profiles for the terminology resources, by canonical url.
+ * Sources: <a href="https://hl7.org/fhir/codesystem-profiles.html">CodeSystem</a>,
+ * <a href="https://hl7.org/fhir/valueset-profiles.html">ValueSet</a>,
+ * <a href="https://hl7.org/fhir/conceptmap-profiles.html">ConceptMap</a>.
+ *
+ * <p>These are the profiles TermX recognizes when a resource declares one via {@code meta.profile}.
+ * A declared profile that is <em>not</em> in this set is treated as unknown: TermX records it but does
+ * not reject the resource for it (see the profile-tolerant resource validator). The default — no declared
+ * profile — means plain base-spec validation.
+ */
+public final class FhirProfile {
+  private FhirProfile() {}
+
+  public static final String BASE = "http://hl7.org/fhir/StructureDefinition/";
+
+  // CodeSystem — https://hl7.org/fhir/codesystem-profiles.html
+  public static final String SHAREABLE_CODE_SYSTEM = BASE + "ShareableCodeSystem";
+  public static final String PUBLISHABLE_CODE_SYSTEM = BASE + "PublishableCodeSystem";
+
+  // ValueSet — https://hl7.org/fhir/valueset-profiles.html
+  public static final String SHAREABLE_VALUE_SET = BASE + "ShareableValueSet";
+  public static final String COMPUTABLE_VALUE_SET = BASE + "ComputableValueSet";
+  public static final String EXECUTABLE_VALUE_SET = BASE + "ExecutableValueSet";
+  public static final String PUBLISHABLE_VALUE_SET = BASE + "PublishableValueSet";
+
+  // ConceptMap — https://hl7.org/fhir/conceptmap-profiles.html
+  public static final String SHAREABLE_CONCEPT_MAP = BASE + "ShareableConceptMap";
+  public static final String PUBLISHABLE_CONCEPT_MAP = BASE + "PublishableConceptMap";
+
+  public static final Set<String> CODE_SYSTEM = Set.of(SHAREABLE_CODE_SYSTEM, PUBLISHABLE_CODE_SYSTEM);
+  public static final Set<String> VALUE_SET = Set.of(SHAREABLE_VALUE_SET, COMPUTABLE_VALUE_SET, EXECUTABLE_VALUE_SET, PUBLISHABLE_VALUE_SET);
+  public static final Set<String> CONCEPT_MAP = Set.of(SHAREABLE_CONCEPT_MAP, PUBLISHABLE_CONCEPT_MAP);
+
+  /** Every recognized terminology-resource profile. */
+  public static final Set<String> ALL = Set.of(
+      SHAREABLE_CODE_SYSTEM, PUBLISHABLE_CODE_SYSTEM,
+      SHAREABLE_VALUE_SET, COMPUTABLE_VALUE_SET, EXECUTABLE_VALUE_SET, PUBLISHABLE_VALUE_SET,
+      SHAREABLE_CONCEPT_MAP, PUBLISHABLE_CONCEPT_MAP);
+
+  /** True when the canonical url is an HL7-defined terminology profile TermX recognizes. */
+  public static boolean isRecognized(String profileUrl) {
+    return ALL.contains(profileUrl);
+  }
+}

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystem.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystem.java
@@ -30,6 +30,8 @@ public class CodeSystem extends UniqueResource<CodeSystem> {
   private String uri;
   private String publisher;
   private String name;
+  // FHIR meta.profile — the conformance profiles this resource claims (see org.termx.ts.FhirProfile).
+  private List<String> profile;
   private List<OtherTitle> otherTitle;
   private LocalizedName title;
   private LocalizedName description;

--- a/termx-api/src/main/java/org/termx/ts/mapset/MapSet.java
+++ b/termx-api/src/main/java/org/termx/ts/mapset/MapSet.java
@@ -24,6 +24,8 @@ public class MapSet extends UniqueResource<MapSet> {
   private String uri;
   private String publisher;
   private String name;
+  // FHIR meta.profile — the conformance profiles this resource claims (see org.termx.ts.FhirProfile).
+  private List<String> profile;
   private List<OtherTitle> otherTitle;
   private LocalizedName title;
   private LocalizedName description;

--- a/termx-api/src/main/java/org/termx/ts/valueset/ValueSet.java
+++ b/termx-api/src/main/java/org/termx/ts/valueset/ValueSet.java
@@ -30,6 +30,8 @@ public class ValueSet extends UniqueResource<ValueSet> {
   private String uri;
   private String publisher;
   private String name;
+  // FHIR meta.profile — the conformance profiles this resource claims (see org.termx.ts.FhirProfile).
+  private List<String> profile;
   private List<OtherTitle> otherTitle;
   private LocalizedName title;
   private LocalizedName description;

--- a/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
+++ b/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
@@ -1,0 +1,126 @@
+package org.termx.fhir;
+
+import ca.uhn.fhir.validation.ResultSeverityEnum;
+import ca.uhn.fhir.validation.SingleValidationMessage;
+import com.kodality.kefhir.core.api.resource.OperationInterceptor;
+import com.kodality.kefhir.core.api.resource.ResourceBeforeSaveInterceptor;
+import com.kodality.kefhir.core.exception.FhirException;
+import com.kodality.kefhir.core.exception.FhirServerException;
+import com.kodality.kefhir.core.model.ResourceId;
+import com.kodality.kefhir.core.service.conformance.HapiContextHolder;
+import com.kodality.kefhir.structure.api.ResourceContent;
+import com.kodality.kefhir.structure.service.ResourceFormatService;
+import com.kodality.kefhir.validation.ResourceProfileValidator;
+import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.exceptions.FHIRException;
+import org.hl7.fhir.r5.model.CodeableConcept;
+import org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity;
+import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent;
+import org.hl7.fhir.r5.model.Resource;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Replaces kefhir's {@link ResourceProfileValidator} with a profile-tolerant variant.
+ *
+ * <p>kefhir runs the HAPI instance validator on every write and rejects (400) on any ERROR/FATAL message.
+ * That includes "Profile reference '…' has not been checked because it is unknown" — emitted whenever a
+ * resource declares a {@code meta.profile} whose StructureDefinition TermX does not host (e.g. the HL7
+ * Shareable/Publishable profiles, which TermX recognizes by url but does not load SDs to enforce). A
+ * terminology server should not refuse an otherwise-valid resource merely because it claims conformance to
+ * a profile the server cannot check — so those messages are downgraded from blocking errors here, while
+ * every other base-spec validation error is still enforced exactly as before.
+ *
+ * <p>Toggled by the same {@code kefhir.validation-profile.enabled} flag, so setting it false disables all
+ * instance validation (used by dedicated conformance instances).
+ */
+@Slf4j
+@Singleton
+@Replaces(ResourceProfileValidator.class)
+@Requires(property = "kefhir.validation-profile.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+public class ProfileTolerantResourceValidator extends ResourceBeforeSaveInterceptor implements OperationInterceptor {
+  // The org.hl7.fhir validator message emitted when a declared profile's StructureDefinition is absent.
+  // Such a message means "could not check this profile", not "the resource is invalid" — so it is tolerated.
+  private static final String UNCHECKED_PROFILE = "has not been checked because it is unknown";
+
+  @Inject
+  private ResourceFormatService resourceFormatService;
+  @Inject
+  private HapiContextHolder hapiContextHolder;
+
+  public ProfileTolerantResourceValidator() {
+    super(ResourceBeforeSaveInterceptor.INPUT_VALIDATION);
+  }
+
+  @Override
+  public void handle(String level, String operation, ResourceContent parameters) {
+    if (StringUtils.isEmpty(parameters.getValue())) {
+      return;
+    }
+    validateProfile(parameters);
+  }
+
+  @Override
+  public void handle(ResourceId id, ResourceContent content, String interaction) {
+    Resource resource = validateParse(content);
+    validateType(id.getResourceType(), resource.getResourceType().name());
+    validateProfile(content);
+  }
+
+  private Resource validateParse(ResourceContent content) {
+    try {
+      return resourceFormatService.parse(content);
+    } catch (Exception e) {
+      throw new FhirException(400, IssueType.STRUCTURE, "error during resource parse: " + e.getMessage());
+    }
+  }
+
+  private void validateType(String expectedType, String resourceType) {
+    if (!resourceType.equals(expectedType)) {
+      throw new FhirException(400, IssueType.INVALID, "was expecting " + expectedType + " but found " + resourceType);
+    }
+  }
+
+  private void validateProfile(ResourceContent content) {
+    if (hapiContextHolder.getHapiContext() == null) {
+      throw new FhirServerException(500, "fhir context initialization error");
+    }
+    try {
+      List<SingleValidationMessage> errors = hapiContextHolder.getValidator().validateWithResult(content.getValue()).getMessages().stream()
+          .filter(m -> isError(m.getSeverity()))
+          .filter(m -> !isUncheckedProfile(m))
+          .collect(toList());
+      if (!errors.isEmpty()) {
+        throw new FhirException(400, errors.stream().map(msg -> {
+          OperationOutcomeIssueComponent issue = new OperationOutcomeIssueComponent();
+          issue.setCode(IssueType.INVALID);
+          issue.setSeverity(IssueSeverity.fromCode(msg.getSeverity().getCode()));
+          issue.setDetails(new CodeableConcept().setText(msg.getMessage()));
+          issue.addLocation(msg.getLocationString());
+          return issue;
+        }).collect(toList()));
+      }
+    } catch (Exception e) {
+      if (e instanceof FHIRException) {
+        throw new FhirException(500, IssueType.INVALID, e.getMessage());
+      }
+      throw new RuntimeException("exception during profile validation: " + e.getMessage(), e);
+    }
+  }
+
+  /** A declared profile TermX cannot resolve yields an "unchecked profile" message — tolerated, not fatal. */
+  private static boolean isUncheckedProfile(SingleValidationMessage m) {
+    return m.getMessage() != null && m.getMessage().contains(UNCHECKED_PROFILE);
+  }
+
+  private static boolean isError(ResultSeverityEnum level) {
+    return level == ResultSeverityEnum.ERROR || level == ResultSeverityEnum.FATAL;
+  }
+}


### PR DESCRIPTION
Implements profile awareness for the terminology resources, per the discussion. TermX now **records** the FHIR `meta.profile` a resource claims and stops **rejecting** resources that declare a profile it can't resolve.

## Profile storage (CodeSystem, ValueSet, ConceptMap)
- New `profile` column (`text[]`, default empty = no profile) + model field on each resource.
- Import parses `meta.profile`; export emits it — round-trips.
- `org.termx.ts.FhirProfile` — registry of the **8 official HL7 R5 terminology profiles**:
  - CodeSystem: `ShareableCodeSystem`, `PublishableCodeSystem`
  - ValueSet: `ShareableValueSet`, `ComputableValueSet`, `ExecutableValueSet`, `PublishableValueSet`
  - ConceptMap: `ShareableConceptMap`, `PublishableConceptMap`

## A — tolerant validation
`ProfileTolerantResourceValidator` `@Replaces` kefhir's `ResourceProfileValidator` and downgrades the HAPI *"Profile reference … has not been checked because it is unknown"* error from a blocking 400 to tolerated. A terminology server shouldn't refuse an otherwise-valid resource merely because it claims a profile the server doesn't host. **Every other base-spec validation error is still enforced unchanged.** Done entirely termx-side via Micronaut `@Replaces` — no kefhir release needed.

## B — validation off-switch
Both validators share `@Requires(kefhir.validation-profile.enabled, default true)`, so `KEFHIR_VALIDATION_PROFILE_ENABLED=false` disables instance validation entirely on a dedicated conformance instance.

## Default
A resource with **no** declared profile behaves exactly as before (plain base-spec validation).

## Tests
- `CodeSystemFhirMapperSpec`: `meta.profile` round-trip (recognized + custom url) and no-profile-leaves-meta-null.
- `:terminology:test` 236/0.

## Notes / follow-up
- This unblocks fixture ⑤ (`codesystem-loinc-supplement`, declares `shareablecodesystem`). The remaining CS-strictness defaults discussed (title←name, status←draft, supplement caseSensitive←false, `definition:lang` multilingual parsing) are separate import-default work.
- We **record** declared profiles but don't yet **enforce** the 8 known ones (enforcement = stricter validation; not wanted now). The registry + column are the groundwork if enforcement is ever desired.
- Branches off main; will rebase cleanly over #223.