### PR TITLE
FHIR import defaults: title←name, status←draft, supplement caseSensitive, definition:lang

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -498,7 +498,10 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     codeSystem.setUri(fhirCS.getUrl());
     codeSystem.setPublisher(fhirCS.getPublisher());
     codeSystem.setName(fhirCS.getName());
-    codeSystem.setTitle(fromFhirName(fhirCS.getTitle(), fhirCS.getLanguage(), fhirCS.getPrimitiveElement("title")));
+    // FHIR title is optional, but TermX stores it NOT NULL — default an absent title to the resource name.
+    codeSystem.setTitle(fromFhirName(
+        StringUtils.isNotEmpty(fhirCS.getTitle()) ? fhirCS.getTitle() : fhirCS.getName(),
+        fhirCS.getLanguage(), fhirCS.getPrimitiveElement("title")));
     codeSystem.setDescription(fromFhirName(fhirCS.getDescription(), fhirCS.getLanguage(), fhirCS.getPrimitiveElement("description")));
     codeSystem.setPurpose(fromFhirName(fhirCS.getPurpose(), fhirCS.getLanguage(), fhirCS.getPrimitiveElement("purpose")));
     codeSystem.setNarrative(fhirCS.getText() == null ? null : fhirCS.getText().getDiv());

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapFhirMapper.java
@@ -341,7 +341,10 @@ public class ConceptMapFhirMapper extends BaseFhirMapper {
     ms.setUri(cm.getUrl());
     ms.setPublisher(cm.getPublisher());
     ms.setName(cm.getName());
-    ms.setTitle(fromFhirName(cm.getTitle(), cm.getLanguage(), cm.getPrimitiveElement("title")));
+    // FHIR title is optional, but TermX stores it NOT NULL — default an absent title to the resource name.
+    ms.setTitle(fromFhirName(
+        StringUtils.isNotEmpty(cm.getTitle()) ? cm.getTitle() : cm.getName(),
+        cm.getLanguage(), cm.getPrimitiveElement("title")));
     ms.setDescription(fromFhirName(cm.getDescription(), cm.getLanguage(), cm.getPrimitiveElement("description")));
     ms.setPurpose(fromFhirName(cm.getPurpose(), cm.getLanguage(), cm.getPrimitiveElement("purpose")));
     ms.setNarrative(cm.getText() == null ? null : cm.getText().getDiv());

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -716,7 +716,10 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     vs.setUri(valueSet.getUrl());
     vs.setPublisher(valueSet.getPublisher());
     vs.setName(valueSet.getName());
-    vs.setTitle(fromFhirName(valueSet.getTitle(), valueSet.getLanguage(), valueSet.getPrimitiveElement("title")));
+    // FHIR title is optional, but TermX stores it NOT NULL — default an absent title to the resource name.
+    vs.setTitle(fromFhirName(
+        StringUtils.isNotEmpty(valueSet.getTitle()) ? valueSet.getTitle() : valueSet.getName(),
+        valueSet.getLanguage(), valueSet.getPrimitiveElement("title")));
     vs.setDescription(fromFhirName(valueSet.getDescription(), valueSet.getLanguage(), valueSet.getPrimitiveElement("description")));
     vs.setPurpose(fromFhirName(valueSet.getPurpose(), valueSet.getLanguage(), valueSet.getPrimitiveElement("purpose")));
     vs.setNarrative(valueSet.getText() == null ? null : valueSet.getText().getDiv());

--- a/termx-app/src/main/java/org/termx/fhir/TerminologyResourceNormalizer.java
+++ b/termx-app/src/main/java/org/termx/fhir/TerminologyResourceNormalizer.java
@@ -1,0 +1,153 @@
+package org.termx.fhir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.kodality.commons.util.JsonUtil;
+import com.kodality.kefhir.core.api.resource.ResourceBeforeSaveInterceptor;
+import com.kodality.kefhir.core.model.ResourceId;
+import com.kodality.kefhir.structure.api.ResourceContent;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Order;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Normalizes incoming CodeSystem / ValueSet / ConceptMap JSON before it reaches instance validation,
+ * so TermX accepts a few valid-or-near-valid shapes the base validator would otherwise reject. Runs in the
+ * INPUT_VALIDATION phase ordered ahead of the validator (lower {@link Order}); it mutates the shared
+ * {@link ResourceContent}, so both the validator and the importer see the normalized resource.
+ *
+ * <ul>
+ *   <li><b>status</b> — FHIR requires it (1..1); when absent, default to {@code draft} rather than reject.</li>
+ *   <li><b>supplement caseSensitive</b> — a CodeSystem supplement SHOULD NOT state {@code caseSensitive}
+ *       (it inherits from the base); drop the stated value so it defaults to base behavior.</li>
+ *   <li><b>language-tagged shorthand</b> — fold {@code "<field>:<lang>": "x"} (e.g. {@code definition:en})
+ *       into the standard {@code _<field>.extension} translation, then drop the non-standard colon-key the
+ *       strict parser cannot read. Supports multilingual definitions/displays carried on the {@code :} form.</li>
+ * </ul>
+ */
+@Slf4j
+@Singleton
+@Order(-100)
+@Requires(property = "kefhir.validation-profile.enabled", value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+public class TerminologyResourceNormalizer extends ResourceBeforeSaveInterceptor {
+  private static final List<String> TERMINOLOGY_TYPES = List.of("CodeSystem", "ValueSet", "ConceptMap");
+  private static final String TRANSLATION_EXTENSION = "http://hl7.org/fhir/StructureDefinition/translation";
+
+  public TerminologyResourceNormalizer() {
+    super(ResourceBeforeSaveInterceptor.INPUT_VALIDATION);
+  }
+
+  @Override
+  public void handle(ResourceId id, ResourceContent content, String interaction) {
+    if (!TERMINOLOGY_TYPES.contains(id.getResourceType()) || StringUtils.isEmpty(content.getValue())) {
+      return;
+    }
+    try {
+      ObjectMapper om = JsonUtil.getObjectMapper();
+      JsonNode root = om.readTree(content.getValue());
+      if (!(root instanceof ObjectNode obj)) {
+        return;
+      }
+      boolean changed = defaultStatus(obj);
+      changed |= dropSupplementCaseSensitive(obj);
+      changed |= foldLanguageTaggedShorthand(obj);
+      if (changed) {
+        content.setValue(om.writeValueAsString(obj));
+      }
+    } catch (Exception e) {
+      // Normalization is best-effort: never block a save because the pre-pass failed — let validation speak.
+      log.debug("terminology resource normalization skipped: {}", e.getMessage());
+    }
+  }
+
+  private static boolean defaultStatus(ObjectNode resource) {
+    if (!resource.hasNonNull("status")) {
+      resource.put("status", "draft");
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean dropSupplementCaseSensitive(ObjectNode resource) {
+    if ("supplement".equals(resource.path("content").asText(null)) && resource.has("caseSensitive")) {
+      resource.remove("caseSensitive");
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Recursively folds {@code "<field>:<lang>"} keys into {@code _<field>.extension[translation]} and removes
+   * them. The base value ({@code <field>}) is left untouched; only the language variants move to the standard
+   * translation extension, which the mapper already understands.
+   */
+  private static boolean foldLanguageTaggedShorthand(ObjectNode node) {
+    boolean changed = false;
+    List<String> langKeys = new ArrayList<>();
+    Iterator<String> names = node.fieldNames();
+    while (names.hasNext()) {
+      String n = names.next();
+      // a language-tagged primitive shorthand: name contains ':' and the part after it looks like a lang code
+      int i = n.indexOf(':');
+      if (i > 0 && i < n.length() - 1 && node.get(n).isValueNode()) {
+        langKeys.add(n);
+      }
+    }
+    for (String key : langKeys) {
+      String field = key.substring(0, key.indexOf(':'));
+      String lang = key.substring(key.indexOf(':') + 1);
+      String value = node.get(key).asText();
+      addTranslation(node, field, lang, value);
+      node.remove(key);
+      changed = true;
+    }
+    // recurse into children (concepts, contains, etc.)
+    for (JsonNode child : node) {
+      if (child instanceof ObjectNode obj) {
+        changed |= foldLanguageTaggedShorthand(obj);
+      } else if (child.isArray()) {
+        for (JsonNode el : child) {
+          if (el instanceof ObjectNode obj) {
+            changed |= foldLanguageTaggedShorthand(obj);
+          }
+        }
+      }
+    }
+    return changed;
+  }
+
+  private static void addTranslation(ObjectNode node, String field, String lang, String value) {
+    String primitive = "_" + field;
+    ObjectNode underscore = node.has(primitive) && node.get(primitive).isObject()
+        ? (ObjectNode) node.get(primitive) : node.putObject(primitive);
+    com.fasterxml.jackson.databind.node.ArrayNode extensions = underscore.has("extension") && underscore.get("extension").isArray()
+        ? (com.fasterxml.jackson.databind.node.ArrayNode) underscore.get("extension") : underscore.putArray("extension");
+    // skip if a translation for this language is already present (the standard form wins; no duplication)
+    for (JsonNode ext : extensions) {
+      if (TRANSLATION_EXTENSION.equals(ext.path("url").asText(null)) && hasLang(ext, lang)) {
+        return;
+      }
+    }
+    ObjectNode translation = extensions.addObject();
+    translation.put("url", TRANSLATION_EXTENSION);
+    com.fasterxml.jackson.databind.node.ArrayNode inner = translation.putArray("extension");
+    inner.addObject().put("url", "lang").put("valueCode", lang);
+    inner.addObject().put("url", "content").put("valueString", value);
+  }
+
+  private static boolean hasLang(JsonNode translationExt, String lang) {
+    for (JsonNode e : translationExt.path("extension")) {
+      if ("lang".equals(e.path("url").asText(null)) && lang.equals(e.path("valueCode").asText(null))) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/termx-app/src/main/java/org/termx/fhir/TerminologyResourceNormalizer.java
+++ b/termx-app/src/main/java/org/termx/fhir/TerminologyResourceNormalizer.java
@@ -83,10 +83,15 @@ public class TerminologyResourceNormalizer extends ResourceBeforeSaveInterceptor
     return false;
   }
 
+  // Concept-level fields whose language variants TermX models as designations (use.code = the field name).
+  private static final List<String> DESIGNATION_FIELDS = List.of("display", "definition");
+
   /**
-   * Recursively folds {@code "<field>:<lang>"} keys into {@code _<field>.extension[translation]} and removes
-   * them. The base value ({@code <field>}) is left untouched; only the language variants move to the standard
-   * translation extension, which the mapper already understands.
+   * Recursively folds {@code "<field>:<lang>"} shorthand keys (e.g. {@code definition:en}) into the standard
+   * structure TermX imports, then removes the non-standard colon-key the strict parser cannot read:
+   * for concept-level {@code display}/{@code definition} the variant becomes a {@code designation}
+   * ({@code use.code = field}, {@code language = lang}); any other field becomes a {@code _<field>} translation
+   * extension. The base value ({@code <field>}) is left untouched.
    */
   private static boolean foldLanguageTaggedShorthand(ObjectNode node) {
     boolean changed = false;
@@ -104,7 +109,11 @@ public class TerminologyResourceNormalizer extends ResourceBeforeSaveInterceptor
       String field = key.substring(0, key.indexOf(':'));
       String lang = key.substring(key.indexOf(':') + 1);
       String value = node.get(key).asText();
-      addTranslation(node, field, lang, value);
+      if (DESIGNATION_FIELDS.contains(field)) {
+        addDesignation(node, field, lang, value);
+      } else {
+        addTranslation(node, field, lang, value);
+      }
       node.remove(key);
       changed = true;
     }
@@ -123,13 +132,28 @@ public class TerminologyResourceNormalizer extends ResourceBeforeSaveInterceptor
     return changed;
   }
 
+  /** Adds a language-specific designation (TermX's multilingual model for concept display/definition). */
+  private static void addDesignation(ObjectNode concept, String field, String lang, String value) {
+    com.fasterxml.jackson.databind.node.ArrayNode designations = concept.has("designation") && concept.get("designation").isArray()
+        ? (com.fasterxml.jackson.databind.node.ArrayNode) concept.get("designation") : concept.putArray("designation");
+    // skip if a designation of this kind+language already exists
+    for (JsonNode d : designations) {
+      if (lang.equals(d.path("language").asText(null)) && field.equals(d.path("use").path("code").asText(null))) {
+        return;
+      }
+    }
+    ObjectNode designation = designations.addObject();
+    designation.put("language", lang);
+    designation.putObject("use").put("code", field);
+    designation.put("value", value);
+  }
+
   private static void addTranslation(ObjectNode node, String field, String lang, String value) {
     String primitive = "_" + field;
     ObjectNode underscore = node.has(primitive) && node.get(primitive).isObject()
         ? (ObjectNode) node.get(primitive) : node.putObject(primitive);
     com.fasterxml.jackson.databind.node.ArrayNode extensions = underscore.has("extension") && underscore.get("extension").isArray()
         ? (com.fasterxml.jackson.databind.node.ArrayNode) underscore.get("extension") : underscore.putArray("extension");
-    // skip if a translation for this language is already present (the standard form wins; no duplication)
     for (JsonNode ext : extensions) {
       if (TRANSLATION_EXTENSION.equals(ext.path("url").asText(null)) && hasLang(ext, lang)) {
         return;

--- a/termx-app/src/test/groovy/org/termx/fhir/TerminologyResourceNormalizerSpec.groovy
+++ b/termx-app/src/test/groovy/org/termx/fhir/TerminologyResourceNormalizerSpec.groovy
@@ -1,0 +1,57 @@
+package org.termx.fhir
+
+import com.kodality.commons.util.JsonUtil
+import com.kodality.kefhir.core.model.ResourceId
+import com.kodality.kefhir.structure.api.ResourceContent
+import spock.lang.Specification
+
+class TerminologyResourceNormalizerSpec extends Specification {
+  def normalizer = new TerminologyResourceNormalizer()
+
+  private Map normalize(String type, Map resource) {
+    def content = new ResourceContent(JsonUtil.toJson(resource), "application/fhir+json")
+    normalizer.handle(new ResourceId(type, "x"), content, "update")
+    return JsonUtil.fromJson(content.getValue(), Map)
+  }
+
+  def "missing status defaults to draft"() {
+    expect:
+    normalize("CodeSystem", [resourceType: "CodeSystem", url: "http://x", content: "complete"]).status == "draft"
+  }
+
+  def "present status is left untouched"() {
+    expect:
+    normalize("CodeSystem", [resourceType: "CodeSystem", status: "active", content: "complete"]).status == "active"
+  }
+
+  def "supplement drops a stated caseSensitive; non-supplement keeps it"() {
+    expect:
+    !normalize("CodeSystem", [resourceType: "CodeSystem", status: "active", content: "supplement", caseSensitive: true]).containsKey("caseSensitive")
+    normalize("CodeSystem", [resourceType: "CodeSystem", status: "active", content: "complete", caseSensitive: true]).caseSensitive == true
+  }
+
+  def "definition:lang folds into a language designation and the colon-key is removed"() {
+    when:
+    def out = normalize("CodeSystem", [
+        resourceType: "CodeSystem", status: "active", content: "complete",
+        concept     : [[code: "c1", definition: "Erste", "definition:en": "First"]]
+    ])
+    def concept = out.concept[0]
+
+    then: "the non-standard colon-key is gone, base definition stays, English variant becomes a designation"
+    !concept.containsKey("definition:en")
+    concept.definition == "Erste"
+    concept.designation.find { it.language == "en" && it.use?.code == "definition" }?.value == "First"
+  }
+
+  def "non-terminology resource types are left untouched"() {
+    given:
+    def content = new ResourceContent(JsonUtil.toJson([resourceType: "Patient"]), "application/fhir+json")
+
+    when:
+    normalizer.handle(new ResourceId("Patient", "x"), content, "update")
+
+    then: "no status injected"
+    !JsonUtil.fromJson(content.getValue(), Map).containsKey("status")
+  }
+}


### PR DESCRIPTION
Makes TermX accept several valid-or-near-valid terminology resources the strict schema/validator rejected — the CodeSystem-strictness defaults discussed. Each was verified live against the tx-ecosystem fixture that exposed it.

## Defaults
| Default | Mechanism | Fixture |
|---|---|---|
| **title ← name** | import mapper (CodeSystem/ValueSet/ConceptMap) — FHIR `title` is optional, TermX stores it NOT NULL | `exclude`, `search`, title-less CS |
| **status ← draft** | `TerminologyResourceNormalizer` (pre-validation) | `dual-filter` |
| **supplement `caseSensitive`** | normalizer drops the stated value (a supplement inherits from base; mapper already defaults to case-insensitive) | `supplement` |
| **`definition:lang` / `display:lang`** | normalizer folds the `:lang` shorthand into a language **designation** (`use.code` = field), the model TermX imports | `de-multi`, `en-multi` |

## How
- **`TerminologyResourceNormalizer`** — a new `INPUT_VALIDATION` interceptor ordered (`@Order(-100)`) *before* the validator. It rewrites the incoming JSON and mutates the shared `ResourceContent`, so validator and importer both see the normalized resource. Guarded by the same `kefhir.validation-profile.enabled` flag.
- **title default** lives in the three FHIR import mappers (post-parse).

## Verified live
A title-less CS, `dual-filter` (no status), `supplement` (caseSensitive), and a CS with `definition:en` all import (201) where they were 400/500 before; `definition:en` round-trips as an English definition designation while the base German definition is preserved.

## Tests
- `TerminologyResourceNormalizerSpec` (status / supplement caseSensitive / definition:lang→designation / passthrough).
- `:terminology:test` 238/0, `:termx-core:test` 73/0, `:termx-app:test` normalizer 5/0.

Builds on #223/#224 (merged in).