### PR TITLE
CSV/Excel import-export: colon-based designation separators

### DIFF
--- a/docs/features/codesystem-concept-export-specification.md
+++ b/docs/features/codesystem-concept-export-specification.md
@@ -1,7 +1,7 @@
 # CodeSystem Concept Export Specification
 
 ## Version
-**1.0.2** (Breaking Change - New Format with Validation and Column Ordering)
+**1.1.0** (Designation columns use the FHIR-aligned `:` separator; `#` remains import-only for backward compatibility)
 
 ## Overview
 
@@ -23,23 +23,25 @@ The CodeSystem Concept Export functionality exports concepts from a CodeSystem v
 - `code` - The concept code (always first column)
 
 ### Designation Columns
-Format: `{designationType}#{language}##{order}` (when multiple) or `{designationType}#{language}` (when single)
+Format: `{designationType}:{language}::{order}` (when multiple) or `{designationType}:{language}` (when single)
+
+The `:` separator matches the FHIR language-tagged shorthand (e.g. `definition:et`). Prior versions emitted `#` (e.g. `definition#et`); that separator is no longer produced by export but is still accepted on import for backward compatibility.
 
 - `{designationType}` - The designation type (e.g., "display", "definition")
 - `{language}` - The language code (e.g., "en", "ru", "ru-RU"). Empty string if language is null
-- `{order}` - **Optional** sequential number starting from 1 for multiple designations of the same type and language. Skipped when there's only one designation of that type#language combination (when maxCount == 1).
+- `{order}` - **Optional** sequential number starting from 1 for multiple designations of the same type and language. Skipped when there's only one designation of that type:language combination (when maxCount == 1).
 
 **Examples:**
-- `display#en` - Single English display designation (order suffix skipped)
-- `display#en##1`, `display#en##2` - Multiple English display designations (order suffix required)
-- `definition#en` - Single English definition designation (order suffix skipped)
-- `definition#en##1`, `definition#en##2` - Multiple English definition designations (order suffix required)
-- `definition#ru` - Single Russian definition designation (order suffix skipped)
+- `display:en` - Single English display designation (order suffix skipped)
+- `display:en::1`, `display:en::2` - Multiple English display designations (order suffix required)
+- `definition:en` - Single English definition designation (order suffix skipped)
+- `definition:en::1`, `definition:en::2` - Multiple English definition designations (order suffix required)
+- `definition:ru` - Single Russian definition designation (order suffix skipped)
 
 ### Property Columns
 
 #### Simple Property Types
-Format: `{propertyName}##{order}` (when multiple) or `{propertyName}` (when single)
+Format: `{propertyName}::{order}` (when multiple) or `{propertyName}` (when single)
 
 - `{propertyName}` - The property name
 - `{order}` - **Optional** sequential number starting from 1 for multiple values of the same property. Skipped when there's only one value for that property (when maxCount == 1).
@@ -47,10 +49,10 @@ Format: `{propertyName}##{order}` (when multiple) or `{propertyName}` (when sing
 **Examples:**
 - `itemWeight` - Single itemWeight value (order suffix skipped)
 - `synonym` - Single synonym value (order suffix skipped)
-- `synonym##1`, `synonym##2` - Multiple synonym values (order suffix required)
+- `synonym::1`, `synonym::2` - Multiple synonym values (order suffix required)
 
 #### Coding Property Types
-Format: `{propertyName}#code##{order}` and `{propertyName}#system##{order}` (when multiple) or `{propertyName}#code` and `{propertyName}#system` (when single)
+Format: `{propertyName}#code::{order}` and `{propertyName}#system::{order}` (when multiple) or `{propertyName}#code` and `{propertyName}#system` (when single)
 
 - `{propertyName}` - The property name
 - `code` or `system` - Indicates whether this column contains the code or system
@@ -58,7 +60,7 @@ Format: `{propertyName}#code##{order}` and `{propertyName}#system##{order}` (whe
 
 **Examples:**
 - `type#code`, `type#system` - Single type coding value (order suffix skipped)
-- `type#code##1`, `type#system##1`, `type#code##2`, `type#system##2` - Multiple type coding values (order suffix required)
+- `type#code::1`, `type#system::1`, `type#code::2`, `type#system::2` - Multiple type coding values (order suffix required)
 
 ### Special Columns
 - `status` - Concept status (active, draft, retired, etc.)
@@ -74,15 +76,15 @@ Format: `{propertyName}#code##{order}` and `{propertyName}#system##{order}` (whe
 Columns appear in the following order:
 
 1. **Base column**: `code` (always first)
-2. **Display designation columns**: All `display#{language}` columns, sorted alphabetically by `{language}` (with or without order suffix)
-3. **Other designation columns**: All non-display designation columns (e.g., `definition`, `alias`), sorted alphabetically by `{type}#{language}` (with or without order suffix)
+2. **Display designation columns**: All `display:{language}` columns, sorted alphabetically by `{language}` (with or without order suffix)
+3. **Other designation columns**: All non-display designation columns (e.g., `definition`, `alias`), sorted alphabetically by `{type}:{language}` (with or without order suffix)
 4. **Property columns**: 
    - Ordered by their position in the CodeSystem properties definition (`codeSystem.getProperties()`)
    - Properties not in the definition are sorted alphabetically after defined properties
    - For coding properties: `code` column comes before `system` column for the same order
    - Within the same property: order 1 comes before order 2, etc.
-   - Example: `itemWeight`, `synonym`, `synonym##2`, `type#code`, `type#system`, `type#code##2`, `type#system##2` (when single values skip suffix)
-   - Example: `itemWeight##1`, `synonym##1`, `synonym##2`, `type#code##1`, `type#system##1`, `type#code##2`, `type#system##2` (when multiple values use suffix)
+   - Example: `itemWeight`, `synonym`, `synonym::2`, `type#code`, `type#system`, `type#code::2`, `type#system::2` (when single values skip suffix)
+   - Example: `itemWeight::1`, `synonym::1`, `synonym::2`, `type#code::1`, `type#system::1`, `type#code::2`, `type#system::2` (when multiple values use suffix)
 5. **Special columns**: `status`, `is-a`, `parent`, `child`, `partOf`, `groupedBy`, `classifiedWith`
 
 ## Data Formatting
@@ -135,9 +137,9 @@ Columns appear in the following order:
 ## Header Generation Logic
 
 ### Designation Headers
-1. Scan up to 1000 concepts to find all designation type#language combinations
-2. Count maximum occurrences per `{type}#{language}` combination
-3. Generate columns: `{type}#{language}##1`, `{type}#{language}##2`, ..., `{type}#{language}##{maxCount}` (or `{type}#{language}` when maxCount == 1)
+1. Scan up to 1000 concepts to find all designation type:language combinations
+2. Count maximum occurrences per `{type}:{language}` combination
+3. Generate columns: `{type}:{language}::1`, `{type}:{language}::2`, ..., `{type}:{language}::{maxCount}` (or `{type}:{language}` when maxCount == 1)
 4. Separate display designations from other designations
 5. Sort display designation columns alphabetically
 6. Sort other designation columns alphabetically
@@ -148,8 +150,8 @@ Columns appear in the following order:
 2. Determine property type from first occurrence
 3. Count maximum occurrences per property name
 4. Generate columns based on property type:
-   - **Simple types**: `{propertyName}##1`, `{propertyName}##2`, ... (or `{propertyName}` when maxCount == 1)
-   - **Coding types**: `{propertyName}#code##1`, `{propertyName}#system##1`, `{propertyName}#code##2`, `{propertyName}#system##2`, ... (or `{propertyName}#code` and `{propertyName}#system` when maxCount == 1)
+   - **Simple types**: `{propertyName}::1`, `{propertyName}::2`, ... (or `{propertyName}` when maxCount == 1)
+   - **Coding types**: `{propertyName}#code::1`, `{propertyName}#system::1`, `{propertyName}#code::2`, `{propertyName}#system::2`, ... (or `{propertyName}#code` and `{propertyName}#system` when maxCount == 1)
 5. Sort property columns:
    - By their order in CodeSystem properties definition (`codeSystem.getProperties()`)
    - Properties not in definition sorted alphabetically after defined properties
@@ -159,9 +161,9 @@ Columns appear in the following order:
 ## Row Generation Logic
 
 ### Designation Values
-1. Group designations by `{type}#{language}` key
-2. For each designation column `{type}#{language}##{order}`:
-   - Find the designation group matching `{type}#{language}`
+1. Group designations by `{type}:{language}` key
+2. For each designation column `{type}:{language}::{order}`:
+   - Find the designation group matching `{type}:{language}`
    - Get the designation at index `{order} - 1` (0-based)
    - Extract the name/value
    - If no designation at that order, use empty string
@@ -169,7 +171,7 @@ Columns appear in the following order:
 ### Property Values
 1. Group property values by property name
 2. For each property column:
-   - **Column Type Detection**: Headers containing `#code` or `#system` are identified as property columns (coding properties) and processed first, before designation columns. This prevents false matches (e.g., `type#code##1` would match designation pattern but is actually a coding property).
+   - **Column Type Detection**: Headers containing `#code` or `#system` are identified as property columns (coding properties) and processed first, before designation columns. This prevents false matches (e.g., `type#code::1` would match designation pattern but is actually a coding property).
    - Parse column header to extract property name, type, and order
    - Find the property value group matching the property name
    - Get the property value at index `{order} - 1` (0-based)
@@ -207,7 +209,7 @@ Columns appear in the following order:
 
 **Export:**
 ```csv
-code,display#en,itemWeight,synonym,synonym##2
+code,display:en,itemWeight,synonym,synonym::2
 a1,A1,10,x,Y
 ```
 
@@ -222,11 +224,11 @@ a1,A1,10,x,Y
 
 **Export:**
 ```csv
-code,display#en,type#code##1,type#system##1,type#code##2,type#system##2
+code,display:en,type#code::1,type#system::1,type#code::2,type#system::2
 a1,A1,AdverseEvent,http://hl7.org/fhir/fhir-types,Age,http://hl7.org/fhir/fhir-types
 ```
 
-**Note**: Since there are multiple coding values (maxCount == 2), the order suffix is required for all columns (`##1`, `##2`).
+**Note**: Since there are multiple coding values (maxCount == 2), the order suffix is required for all columns (`::1`, `::2`).
 
 ### Example 3: Concept with Multiple Designations
 
@@ -238,7 +240,7 @@ a1,A1,AdverseEvent,http://hl7.org/fhir/fhir-types,Age,http://hl7.org/fhir/fhir-t
 
 **Export:**
 ```csv
-code,display#en,definition#en,definition#en##2,definition#ru,synonym,synonym##2
+code,display:en,definition:en,definition:en::2,definition:ru,synonym,synonym::2
 b1,B1,bar-bar,bar,бар,g1,g2
 ```
 
@@ -250,26 +252,26 @@ b1,B1,bar-bar,bar,бар,g1,g2
 
 **Export:**
 ```csv
-code,display#en,definition#en,definition#en##2,definition#ru,itemWeight,synonym##1,synonym##2,type#code##1,type#system##1,type#code##2,type#system##2
+code,display:en,definition:en,definition:en::2,definition:ru,itemWeight,synonym::1,synonym::2,type#code::1,type#system::1,type#code::2,type#system::2
 a1,A1,,,,10,x,Y,AdverseEvent,http://hl7.org/fhir/fhir-types,Age,http://hl7.org/fhir/fhir-types
 b1,B1,bar-bar,bar,бар,,g1,g2,Account,http://hl7.org/fhir/fhir-types,ActivityDefinition,http://hl7.org/fhir/fhir-types
 ```
 
 **Note**: 
-- Since there are multiple `synonym` values (maxCount == 2), the order suffix is required (`synonym##1`, `synonym##2`)
-- Since there are multiple `type` coding values (maxCount == 2), the order suffix is required for all columns (`type#code##1`, `type#system##1`, `type#code##2`, `type#system##2`)
+- Since there are multiple `synonym` values (maxCount == 2), the order suffix is required (`synonym::1`, `synonym::2`)
+- Since there are multiple `type` coding values (maxCount == 2), the order suffix is required for all columns (`type#code::1`, `type#system::1`, `type#code::2`, `type#system::2`)
 
 ## Import Compatibility
 
 The export format is designed to be compatible with the import functionality. The import processor recognizes:
 
-1. **Designation columns**: `{type}#{language}##{order}` format (with suffix) or `{type}#{language}` format (without suffix for single values)
-2. **Simple property columns**: `{propertyName}##{order}` format (with suffix) or `{propertyName}` format (without suffix for single values)
-3. **Coding property columns**: `{propertyName}#code##{order}` and `{propertyName}#system##{order}` format (with suffix) or `{propertyName}#code` and `{propertyName}#system` format (without suffix for single values)
+1. **Designation columns**: `{type}:{language}::{order}` format (with suffix) or `{type}:{language}` format (without suffix for single values)
+2. **Simple property columns**: `{propertyName}::{order}` format (with suffix) or `{propertyName}` format (without suffix for single values)
+3. **Coding property columns**: `{propertyName}#code::{order}` and `{propertyName}#system::{order}` format (with suffix) or `{propertyName}#code` and `{propertyName}#system` format (without suffix for single values)
 
 The import processor:
 - Parses column headers to extract type, language, property name, and order
-- Supports both formats: with `##{order}` suffix and without (defaults to order 1 when suffix is skipped)
+- Supports both formats: with `::{order}` suffix and without (defaults to order 1 when suffix is skipped)
 - Reconstructs designations and property values in the correct order
 - Combines code and system columns for coding properties
 
@@ -282,7 +284,7 @@ The import processor:
 - **Exception Details**: The exception includes comprehensive diagnostic information:
   - **Code system ID**: The identifier of the CodeSystem being exported
   - **Code system description**: The title (English) or name, falling back to ID if neither is available
-  - **Missing designations**: Comma-separated list of missing designations in format `conceptCode:type#language`
+  - **Missing designations**: Comma-separated list of missing designations in format `conceptCode:type:language`
   - **Diagnostic information**: Structured log message containing:
     - CodeSystem ID
     - CodeSystem description
@@ -293,16 +295,16 @@ The import processor:
   1. Collect all active and draft designations from all concepts in the export
   2. For each designation, check if a corresponding column exists in headers
   3. A designation matches a header if:
-     - The header exactly matches `{type}#{language}` (for single values without suffix)
-     - The header starts with `{type}#{language}##` (for multiple values with order suffix)
+     - The header exactly matches `{type}:{language}` (for single values without suffix)
+     - The header starts with `{type}:{language}::` (for multiple values with order suffix; legacy `##` also accepted)
   4. If any designation has no matching header, collect it as missing
   5. If any missing designations are found, throw exception with diagnostic information
   6. Additionally, if there are any designations (active or draft) in the database but no designation columns in the export headers, throw exception
-- **Example**: If concept "a1" has a designation `display#en` in the database but the export headers don't include a `display#en` or `display#en##1` column, an exception is thrown with:
+- **Example**: If concept "a1" has a designation `display:en` in the database but the export headers don't include a `display:en` or `display:en::1` column, an exception is thrown with:
   - CodeSystem ID: "test1"
   - Description: "Test1" (from title or name)
-  - Missing designations: "a1:display#en"
-  - Diagnostic info: "CodeSystem Structure - ID: test1, Description: Test1, Total concepts: 2, Concepts with designations: 2, Missing designations: a1:display#en"
+  - Missing designations: "a1:display:en"
+  - Diagnostic info: "CodeSystem Structure - ID: test1, Description: Test1, Total concepts: 2, Concepts with designations: 2, Missing designations: a1:display:en"
 
 ## Error Handling
 
@@ -350,14 +352,14 @@ This specification represents a **breaking change** from previous export formats
 2. **Coding properties**: Split into separate code and system columns
 3. **Designations**: Now included with order-based format
 4. **Column ordering**: Changed to group code/system together for coding properties
-5. **Optional order suffix**: Order suffix (`##{order}`) is skipped when there's only one value, making the format cleaner for common single-value cases
+5. **Optional order suffix**: Order suffix (`::{order}`) is skipped when there's only one value, making the format cleaner for common single-value cases
 
 ## Migration Notes
 
 - Old export files will not be compatible with the new import format
 - Users must re-export CodeSystems to get the new format
 - The import processor supports both old and new formats for backward compatibility during transition
-- The import processor supports both formats: with `##{order}` suffix (for backward compatibility) and without suffix (new cleaner format for single values)
+- The import processor supports both formats: with `::{order}` suffix (for backward compatibility) and without suffix (new cleaner format for single values)
 
 ## Implementation Details
 
@@ -372,8 +374,8 @@ This specification represents a **breaking change** from previous export formats
   - **Column Processing Order**: Property columns (with `#code` or `#system`) are processed before designation columns to prevent false matches
   - Headers containing `#code` or `#system` are identified as property columns first
   - Only headers without `#code` or `#system` are checked as designation columns
-- `parseColumnHeader()`: Parses property column headers (supports both with and without `##{order}` suffix)
-- `parseDesignationColumn()`: Parses designation column headers (supports both with and without `##{order}` suffix)
+- `parseColumnHeader()`: Parses property column headers (supports both with and without `::{order}` suffix)
+- `parseDesignationColumn()`: Parses designation column headers (supports both with and without `::{order}` suffix)
 - `validateDesignationsPresent()`: Validates that all designations from database are present in export output structure
   - Collects all active and draft designations from all concepts
   - Checks each designation against generated headers

--- a/docs/features/codesystem-concept-import-specification.md
+++ b/docs/features/codesystem-concept-import-specification.md
@@ -1,11 +1,13 @@
 # CodeSystem Concept Import Specification
 
 ## Version
-**1.0.3** (Compatible with Export Format 1.0.2)
+**1.1.0** (Compatible with Export Format 1.1.0)
 
 ## Overview
 
 The CodeSystem Concept Import functionality imports concepts from CSV, TSV, or XLSX files into a CodeSystem version. The import processor supports both the new export format (with optional order suffixes) and legacy formats for backward compatibility.
+
+Designation columns encode the value's language with a `type:language` header (e.g. `definition:et`), matching the FHIR language-tagged shorthand. Exported files use `:`; the older `#` separator (e.g. `definition#et`) is still accepted on import for backward compatibility.
 
 ## Supported File Formats
 
@@ -25,18 +27,23 @@ The import processor recognizes columns in the following formats:
 ### Designation Columns
 
 #### New Format (Recommended)
-Format: `{designationType}#{language}##{order}` (when multiple) or `{designationType}#{language}` (when single)
+Format: `{designationType}:{language}::{order}` (when multiple) or `{designationType}:{language}` (when single)
+
+The `:` separator mirrors the FHIR language-tagged shorthand (e.g. `definition:et` in a FHIR CodeSystem/ValueSet JSON), so the same `type:language` notation is used across FHIR resources and CSV/Excel files. Exported CSV/TSV/XLSX files use `:` as well.
 
 - `{designationType}` - The designation type (e.g., "display", "definition")
 - `{language}` - The language code (e.g., "en", "ru", "ru-RU"). Can be empty string
 - `{order}` - **Optional** sequential number starting from 1. Defaults to 1 when suffix is omitted
 
 **Examples:**
-- `display#en` - Single English display designation (order defaults to 1)
-- `display#en##1`, `display#en##2` - Multiple English display designations
-- `definition#en` - Single English definition designation (order defaults to 1)
-- `definition#en##1`, `definition#en##2` - Multiple English definition designations
-- `definition#ru` - Single Russian definition designation (order defaults to 1)
+- `display:en` - Single English display designation (order defaults to 1)
+- `display:en::1`, `display:en::2` - Multiple English display designations
+- `definition:en` - Single English definition designation (order defaults to 1)
+- `definition:en::1`, `definition:en::2` - Multiple English definition designations
+- `definition:ru` - Single Russian definition designation (order defaults to 1)
+
+#### `#` / `##` Separators (Backward Compatibility)
+The `#` character is still accepted on import as the value/language separator, so files produced by earlier TermX versions (e.g. `display#en`, `definition#ru##2`) continue to import unchanged. New exports always emit `:` for the value/language separator and `::` for the order suffix. The legacy `##` order suffix is still accepted on import (and can be freely mixed with `:`, e.g. `definition:ru##2`). Note that `#` is also used for coding sub-columns (`#code`/`#system`) — see below.
 
 #### Legacy Format (Backward Compatibility)
 - Simple column names that are mapped to designation properties via import configuration
@@ -46,7 +53,7 @@ Format: `{designationType}#{language}##{order}` (when multiple) or `{designation
 #### Simple Property Types
 
 ##### New Format (Recommended)
-Format: `{propertyName}##{order}` (when multiple) or `{propertyName}` (when single)
+Format: `{propertyName}::{order}` (when multiple) or `{propertyName}` (when single)
 
 - `{propertyName}` - The property name
 - `{order}` - **Optional** sequential number starting from 1. Defaults to 1 when suffix is omitted
@@ -54,7 +61,7 @@ Format: `{propertyName}##{order}` (when multiple) or `{propertyName}` (when sing
 **Examples:**
 - `itemWeight` - Single itemWeight value (order defaults to 1)
 - `synonym` - Single synonym value (order defaults to 1)
-- `synonym##1`, `synonym##2` - Multiple synonym values
+- `synonym::1`, `synonym::2` - Multiple synonym values
 
 ##### Legacy Format (Backward Compatibility)
 - Simple column names that are mapped to properties via import configuration
@@ -63,7 +70,7 @@ Format: `{propertyName}##{order}` (when multiple) or `{propertyName}` (when sing
 #### Coding Property Types
 
 ##### New Format (Recommended)
-Format: `{csvPrefix}#code##{order}` and `{csvPrefix}#system##{order}` (when multiple) or `{csvPrefix}#code` and `{csvPrefix}#system` (when single)
+Format: `{csvPrefix}#code::{order}` and `{csvPrefix}#system::{order}` (when multiple) or `{csvPrefix}#code` and `{csvPrefix}#system` (when single)
 
 - `{csvPrefix}` - A **file-local label** used only to pair code and system columns that belong together (same prefix, same order). It **does not** have to match the TermX **entity property** name chosen in the import mapping UI/API.
 - `code` or `system` - Indicates whether this column contains the code or system
@@ -71,13 +78,13 @@ Format: `{csvPrefix}#code##{order}` and `{csvPrefix}#system##{order}` (when mult
 
 **Important**: Code and system columns must be paired. The import processor:
 - Identifies columns with `#code` or `#system` suffix as coding property columns
-- Groups them by **CSV prefix** and order (so `type#code##1` pairs with `type#system##1`)
+- Groups them by **CSV prefix** and order (so `type#code::1` pairs with `type#system::1`)
 - Emits each combined coding value under the **mapped** property name from import configuration (e.g. CSV `type#…` columns may map to entity property `flag`)
 - Creates a single coding value from each code/system pair
 
 **Examples:**
 - `type#code`, `type#system` - Single type coding value (order defaults to 1 for both)
-- `type#code##1`, `type#system##1`, `type#code##2`, `type#system##2` - Multiple type coding values
+- `type#code::1`, `type#system::1`, `type#code::2`, `type#system::2` - Multiple type coding values
 
 **Processing Logic:**
 1. Columns with `#code` or `#system` are identified as coding property columns
@@ -94,9 +101,9 @@ Format: `{csvPrefix}#code##{order}` and `{csvPrefix}#system##{order}` (when mult
 
 The import processor uses the following logic to parse designation columns:
 
-1. **Check for order suffix**: If column contains `##`, extract the order number
+1. **Check for order suffix**: If column contains `::` (or legacy `##`), extract the order number
 2. **Default order**: If no suffix, order defaults to 1
-3. **Split type and language**: Split by `#` to extract designation type and language
+3. **Split type and language**: Split by `:` to extract designation type and language; if no `:` is present, fall back to `#` (backward compatibility)
 4. **Create designation property**: Create a property value with:
    - Property name: designation type
    - Property type: "designation"
@@ -109,9 +116,9 @@ The import processor uses the following logic to parse designation columns:
 The import processor uses the following logic to parse property columns:
 
 1. **Check for coding suffix**: If column contains `#code` or `#system`, treat as coding property
-2. **Check for order suffix**: If column contains `##`, extract the order number
+2. **Check for order suffix**: If column contains `::` (or legacy `##`), extract the order number
 3. **Default order**: If no suffix, order defaults to 1
-4. **Extract CSV prefix for pairing**: Remove `#code`, `#system`, and `##{order}` suffixes to obtain the file-local prefix used to group pairs
+4. **Extract CSV prefix for pairing**: Remove `#code`, `#system`, and `::{order}` suffixes to obtain the file-local prefix used to group pairs
 5. **Group coding pairs**: For coding properties, group code and system columns by that CSV prefix and order; **output** property values use the configured mapped entity property name
 6. **Create property values**: 
    - For coding: Create single value from code/system pair
@@ -122,10 +129,10 @@ The import processor uses the following logic to parse property columns:
 The import processor processes columns in the following order to prevent false matches:
 
 1. **Coding property columns first**: Columns containing `#code` or `#system` are identified and processed as property columns
-2. **Designation columns second**: Columns matching designation pattern (`{type}#{language}`) are processed as designations
+2. **Designation columns second**: Columns matching the designation pattern (`{type}:{language}`, or legacy `{type}#{language}`) are processed as designations
 3. **Simple property columns last**: Remaining columns are processed as simple properties
 
-This order ensures that `type#code##1` is correctly identified as a coding property column, not a designation column.
+This order ensures that `type#code::1` is correctly identified as a coding property column, not a designation column. Because coding sub-columns keep using `#code`/`#system`, the new `:` value/language separator and `::` order suffix never collide with them.
 
 ## Data Transformation
 
@@ -318,16 +325,16 @@ The `import` flag (whether to import a column) is automatically set based on col
 
 **File (CSV):**
 ```csv
-code,display#en,itemWeight,synonym##1,synonym##2
+code,display:en,itemWeight,synonym::1,synonym::2
 a1,A1,10,x,Y
 b1,B1,,g1,g2
 ```
 
 **Configuration:**
 - `code` → `concept-code` (identifier, preferred)
-- `display#en` → `display` (designation, language: "en")
+- `display:en` → `display` (designation, language: "en")
 - `itemWeight` → `itemWeight` (property, type: `decimal`)
-- `synonym##1`, `synonym##2` → `synonym` (property, type: `string`)
+- `synonym::1`, `synonym::2` → `synonym` (property, type: `string`)
 
 **Result:**
 - Concept `a1`: display "A1" (en), itemWeight=10, synonyms=["x", "Y"]
@@ -337,16 +344,16 @@ b1,B1,,g1,g2
 
 **File (CSV):**
 ```csv
-code,display#en,type#code##1,type#system##1,type#code##2,type#system##2
+code,display:en,type#code::1,type#system::1,type#code::2,type#system::2
 a1,A1,AdverseEvent,http://hl7.org/fhir/fhir-types,Age,http://hl7.org/fhir/fhir-types
 b1,B1,Account,http://hl7.org/fhir/fhir-types,,
 ```
 
 **Configuration:**
 - `code` → `concept-code` (identifier, preferred)
-- `display#en` → `display` (designation, language: "en")
-- `type#code##1`, `type#system##1` → `type` (property, type: `coding`)
-- `type#code##2`, `type#system##2` → `type` (property, type: `coding`)
+- `display:en` → `display` (designation, language: "en")
+- `type#code::1`, `type#system::1` → `type` (property, type: `coding`)
+- `type#code::2`, `type#system::2` → `type` (property, type: `coding`)
 
 The same CSV headers can be mapped to a different entity property name (e.g. all four columns → `flag`); the `type` segment in the file is only used to pair columns, not as the TermX property id.
 
@@ -362,15 +369,15 @@ The same CSV headers can be mapped to a different entity property name (e.g. all
 
 **File (CSV):**
 ```csv
-code,display#en,definition#en,definition#en##2,definition#ru
+code,display:en,definition:en,definition:en::2,definition:ru
 b1,B1,bar-bar,bar,бар
 ```
 
 **Configuration:**
 - `code` → `concept-code` (identifier, preferred)
-- `display#en` → `display` (designation, language: "en")
-- `definition#en`, `definition#en##2` → `definition` (designation, language: "en")
-- `definition#ru` → `definition` (designation, language: "ru")
+- `display:en` → `display` (designation, language: "en")
+- `definition:en`, `definition:en::2` → `definition` (designation, language: "en")
+- `definition:ru` → `definition` (designation, language: "ru")
 
 **Result:**
 - Concept `b1`:
@@ -381,13 +388,13 @@ b1,B1,bar-bar,bar,бар
 
 **File (CSV):**
 ```csv
-code,display#en,itemWeight,synonym,type#code,type#system
+code,display:en,itemWeight,synonym,type#code,type#system
 a1,A1,10,x,AdverseEvent,http://hl7.org/fhir/fhir-types
 ```
 
 **Configuration:**
 - `code` → `concept-code` (identifier, preferred)
-- `display#en` → `display` (designation, language: "en")
+- `display:en` → `display` (designation, language: "en")
 - `itemWeight` → `itemWeight` (property, type: `decimal`)
 - `synonym` → `synonym` (property, type: `string`)
 - `type#code`, `type#system` → `type` (property, type: `coding`)
@@ -401,6 +408,31 @@ a1,A1,10,x,AdverseEvent,http://hl7.org/fhir/fhir-types
 
 **Note**: Since there's only one value for each property, the order suffix is omitted. The import processor defaults to order 1.
 
+### Example 5: FHIR-aligned `:` Separator (with a Legacy `#` Column)
+
+A file may freely mix the new `:` separator with legacy `#` designation columns; both are parsed into designations with the correct language.
+
+**File (CSV):**
+```csv
+code,display:en,definition:en,definition:ru,synonym#et
+a1,A1,First,Первый,sünonüüm
+```
+
+**Configuration:**
+- `code` → `concept-code` (identifier, preferred)
+- `display:en` → `display` (designation, language: "en")
+- `definition:en` → `definition` (designation, language: "en")
+- `definition:ru` → `definition` (designation, language: "ru")
+- `synonym#et` → `synonym` (designation, language: "et") — legacy `#` separator, still accepted
+
+**Result:**
+- Concept `a1`:
+  - display "A1" (en)
+  - definitions=["First" (en), "Первый" (ru)]
+  - synonym "sünonüüm" (et)
+
+**Note**: A round-trip export of this concept produces `:`-separated headers (`display:en`, `definition:en`, `definition:ru`, `synonym:et`).
+
 ## Backward Compatibility
 
 The import processor maintains backward compatibility with legacy formats:
@@ -410,7 +442,7 @@ The import processor maintains backward compatibility with legacy formats:
 3. **Legacy coding columns**: Single column with code value, system from configuration
 
 The processor automatically detects the format based on column names:
-- New format: Contains `#` or `##` patterns
+- New format: Contains `:`, `::`, `#`, or `##` patterns
 - Legacy format: Simple column names
 
 ## Implementation Details
@@ -441,7 +473,7 @@ The processor automatically detects the format based on column names:
 4. **Row Processing**: For each row:
    - Create entity map
    - Process coding property columns (identify and pair code/system)
-   - Process designation columns (parse type#language format)
+   - Process designation columns (parse type:language format, or legacy type#language)
    - Process simple property columns
    - Extract identifier (concept code)
    - Add auto concept order (if enabled)
@@ -460,9 +492,9 @@ The processor automatically detects the format based on column names:
 
 When migrating from legacy format to new format:
 
-1. **Update column names**: Rename columns to new format (e.g., `synonym` → `synonym##1`, `synonym##2`)
+1. **Update column names**: Rename columns to new format (e.g., `synonym` → `synonym::1`, `synonym::2`)
 2. **Update coding columns**: Split single coding column into `property#code` and `property#system` columns
-3. **Update designation columns**: Use `type#language` format instead of simple column names
+3. **Update designation columns**: Use `type:language` format (FHIR-aligned, e.g. `definition:et`) instead of simple column names; legacy `type#language` columns still import
 4. **Update import configuration**: Map new column names to properties
 5. **Test import**: Verify that all data is imported correctly
 

--- a/docs/features/codesystem-import.md
+++ b/docs/features/codesystem-import.md
@@ -137,13 +137,13 @@ This document validates that the current implementation matches the specificatio
 - ✅ `code` is always first column (line 110)
 
 **Designation Columns:**
-- ✅ Format: `{designationType}#{language}##{order}` when multiple, `{designationType}#{language}` when single
+- ✅ Format: `{designationType}:{language}::{order}` when multiple, `{designationType}:{language}` when single (export emits `:`; legacy `#` separator still accepted on import)
 - ✅ Order suffix skipped when maxCount == 1 (lines 202-208)
 - ✅ Language can be empty string (line 162: `d.getLanguage() != null ? d.getLanguage().trim() : ""`)
 
 **Property Columns:**
-- ✅ Simple properties: `{propertyName}##{order}` when multiple, `{propertyName}` when single (lines 255-261)
-- ✅ Coding properties: `{propertyName}#code##{order}` and `{propertyName}#system##{order}` when multiple, `{propertyName}#code` and `{propertyName}#system` when single (lines 242-250)
+- ✅ Simple properties: `{propertyName}::{order}` when multiple, `{propertyName}` when single (lines 255-261)
+- ✅ Coding properties: `{propertyName}#code::{order}` and `{propertyName}#system::{order}` when multiple, `{propertyName}#code` and `{propertyName}#system` when single (lines 242-250)
 - ✅ Order suffix skipped when maxCount == 1 (lines 256-260, 243-249)
 
 ##### ✅ Column Ordering
@@ -186,7 +186,7 @@ This document validates that the current implementation matches the specificatio
 
 **Designation Headers:**
 - ✅ Scans up to 1000 concepts (line 119)
-- ✅ Counts maximum occurrences per `{type}#{language}` (lines 160-176)
+- ✅ Counts maximum occurrences per `{type}:{language}` (or legacy `{type}#{language}`) (lines 160-176)
 - ✅ Generates columns with optional order suffix (lines 201-215)
 - ✅ Separates display from other designations (lines 195-196)
 - ✅ Sorts display designations alphabetically (line 218)
@@ -207,7 +207,7 @@ This document validates that the current implementation matches the specificatio
 - ✅ Only headers without `#code` or `#system` checked as designation columns (lines 462-544)
 
 **Designation Values:**
-- ✅ Grouped by `{type}#{language}` key (lines 325-329)
+- ✅ Grouped by `{type}:{language}` (or legacy `{type}#{language}`) key (lines 325-329)
 - ✅ Designation at index `{order} - 1` extracted (line 475)
 - ✅ Empty string if no designation at that order (line 481)
 
@@ -266,13 +266,13 @@ This document validates that the current implementation matches the specificatio
 - ✅ `code` recognized as identifier (via `concept-code` property mapping)
 
 **Designation Columns:**
-- ✅ New format: `{designationType}#{language}##{order}` or `{designationType}#{language}` (method `parseDesignationColumn()`, line 315)
+- ✅ New format: `{designationType}:{language}::{order}` or `{designationType}:{language}`; legacy `#` separator still accepted (method `parseDesignationColumn()`)
 - ✅ Order defaults to 1 when suffix omitted (line 320-330 in parseDesignationColumn)
 - ✅ Legacy format supported via configuration mapping
 
 **Property Columns:**
-- ✅ Simple properties: `{propertyName}##{order}` or `{propertyName}` (method `parseNewFormatColumn()`, line 252)
-- ✅ Coding properties: `{propertyName}#code##{order}` and `{propertyName}#system##{order}` or `{propertyName}#code` and `{propertyName}#system` (lines 252-314)
+- ✅ Simple properties: `{propertyName}::{order}` or `{propertyName}` (method `parseNewFormatColumn()`, line 252)
+- ✅ Coding properties: `{propertyName}#code::{order}` and `{propertyName}#system::{order}` or `{propertyName}#code` and `{propertyName}#system` (lines 252-314)
 - ✅ Order defaults to 1 when suffix omitted (line 252-314)
 
 ##### ✅ Column Parsing Logic
@@ -281,17 +281,17 @@ This document validates that the current implementation matches the specificatio
 - ✅ Coding property columns processed first (lines 89-100)
 - ✅ Designation columns processed second (lines 101-118)
 - ✅ Simple property columns processed last (lines 125-131)
-- ✅ Prevents false matches (e.g., `type#code##1` identified as property, not designation)
+- ✅ Prevents false matches (e.g., `type#code::1` identified as property, not designation)
 
 **Designation Column Parsing:**
-- ✅ Checks for order suffix (`##`) (line 315-330)
+- ✅ Checks for order suffix (`::`, legacy `##`) (line 315-330)
 - ✅ Defaults to order 1 if no suffix (line 320-330)
-- ✅ Splits type and language by `#` (line 315-330)
+- ✅ Splits type and language by `:` (preferred), falling back to `#` for backward compatibility
 - ✅ Creates designation property value with type, language, order (lines 109-117)
 
 **Property Column Parsing:**
 - ✅ Checks for coding suffix (`#code` or `#system`) (line 252-314)
-- ✅ Checks for order suffix (`##`) (line 252-314)
+- ✅ Checks for order suffix (`::`, legacy `##`) (line 252-314)
 - ✅ Defaults to order 1 if no suffix (line 252-314)
 - ✅ Groups coding pairs by property name and order (lines 94-100, 135-151)
 
@@ -429,9 +429,9 @@ This document validates that the current implementation matches the specificatio
 - ✅ CSV, TSV, XLSX
 
 **Column Formats:**
-- ✅ Designations: `type#language` and `type#language##order`
-- ✅ Simple properties: `property` and `property##order`
-- ✅ Coding properties: `property#code`/`property#system` and `property#code##order`/`property#system##order`
+- ✅ Designations: `type:language` and `type:language::order` (legacy `#` still accepted)
+- ✅ Simple properties: `property` and `property::order`
+- ✅ Coding properties: `property#code`/`property#system` and `property#code::order`/`property#system::order`
 
 **Property Types:**
 - ✅ String, Integer, Decimal, Boolean, DateTime, Coding
@@ -529,13 +529,13 @@ Validates that CSV files can be imported with the new column format when there's
 **Key Validations:**
 - CSV file parsing works correctly
 - Columns without order suffix default to order 1
-- Designations are correctly parsed using `type#language` format
+- Designations are correctly parsed using `type:language` format (legacy `type#language` still accepted)
 - Simple properties (string, decimal) are correctly parsed
 - Coding properties are correctly paired (code and system columns)
 - Empty cells are properly skipped
 
 **Business Scenario:**
-A user exports a CodeSystem with single values for each property. The export omits the order suffix (e.g., `itemWeight` instead of `itemWeight##1`). When importing this file back, the system must correctly recognize these columns and import the data.
+A user exports a CodeSystem with single values for each property. The export omits the order suffix (e.g., `itemWeight` instead of `itemWeight::1`). When importing this file back, the system must correctly recognize these columns and import the data.
 
 **Expected Behavior:**
 - All properties are imported with correct values
@@ -551,7 +551,7 @@ Validates that CSV files can be imported with multiple values per property using
 
 **Key Validations:**
 - Multiple values for the same property are correctly ordered
-- Order suffixes (`##1`, `##2`) are correctly parsed
+- Order suffixes (`::1`, `::2`) are correctly parsed
 - Multiple designations of the same type/language are correctly ordered
 - Multiple coding values are correctly paired by order
 - Incomplete coding pairs (missing code or system) are handled correctly
@@ -562,8 +562,8 @@ A user exports a CodeSystem with multiple values for properties (e.g., multiple 
 **Expected Behavior:**
 - Multiple property values are imported in correct order
 - Multiple designations are imported with correct order
-- Coding properties are paired correctly (code##1 with system##1, code##2 with system##2)
-- Incomplete pairs (e.g., code##2 present but system##2 empty) are handled gracefully
+- Coding properties are paired correctly (code::1 with system::1, code::2 with system::2)
+- Incomplete pairs (e.g., code::2 present but system::2 empty) are handled gracefully
 
 ---
 
@@ -615,12 +615,12 @@ A user exports a CodeSystem to Excel format or receives an Excel file from anoth
 Validates that code and system columns are correctly paired by order, ensuring coding properties are created correctly.
 
 **Key Validations:**
-- Code and system columns are paired by order (##1 with ##1, ##2 with ##2)
+- Code and system columns are paired by order (::1 with ::1, ::2 with ::2)
 - Multiple coding values are correctly ordered
 - Missing code or system values are handled correctly (incomplete pairs are skipped)
 
 **Business Scenario:**
-A user imports a file with coding properties. The system must correctly pair code and system columns that have the same property name and order, creating proper coding values. If a pair is incomplete (e.g., code##2 exists but system##2 is empty), the system should handle this gracefully.
+A user imports a file with coding properties. The system must correctly pair code and system columns that have the same property name and order, creating proper coding values. If a pair is incomplete (e.g., code::2 exists but system::2 is empty), the system should handle this gracefully.
 
 **Expected Behavior:**
 - Coding properties are correctly paired by order
@@ -723,7 +723,7 @@ Validates that columns with `#code` or `#system` are correctly identified as pro
 - Both property and designation columns can coexist with similar names
 
 **Business Scenario:**
-A user has both a coding property named "type" and a designation with type "type" and language "code". The column `type#code##1` should be treated as a coding property column, while `type#code` (without order suffix) could be a designation. The system must correctly distinguish between these.
+A user has both a coding property named "type" and a designation with type "type" and language "code". The column `type#code::1` should be treated as a coding property column, while `type#code` (without order suffix) could be a designation. The system must correctly distinguish between these.
 
 **Expected Behavior:**
 - Coding property columns (with `#code` or `#system`) are processed as properties
@@ -784,9 +784,9 @@ Validation fails inside the isolated dry-run transaction; the user sees a struct
 - ✅ XLSX (Excel format - structure tested)
 
 #### Column Formats Covered
-- ✅ Designations: `type#language` and `type#language##order`
-- ✅ Simple properties: `property` and `property##order`
-- ✅ Coding properties: `property#code`/`property#system` and `property#code##order`/`property#system##order`
+- ✅ Designations: `type:language` and `type:language::order` (legacy `#` still accepted)
+- ✅ Simple properties: `property` and `property::order`
+- ✅ Coding properties: `property#code`/`property#system` and `property#code::order`/`property#system::order`
 
 #### Property Types Covered
 - ✅ String
@@ -1148,9 +1148,9 @@ A user imports a CodeSystem with multiple date properties, each using a differen
 - ✅ XLSX (Excel format - structure tested)
 
 #### Column Formats Covered
-- ✅ Designations: `type#language` and `type#language##order`
-- ✅ Simple properties: `property` and `property##order`
-- ✅ Coding properties: `property#code`/`property#system` and `property#code##order`/`property#system##order`
+- ✅ Designations: `type:language` and `type:language::order` (legacy `#` still accepted)
+- ✅ Simple properties: `property` and `property::order`
+- ✅ Coding properties: `property#code`/`property#system` and `property#code::order`/`property#system::order`
 
 #### Property Types Covered
 - ✅ String

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
@@ -142,8 +142,9 @@ public class CodeSystemFileImportProcessor {
             log.debug("IMPORT DEBUG: Row {} - Stored code value for csvPrefix '{}', order {}: '{}'",
                 rowIndex + 1, csvPrefix, order, cellValue);
           }
-        } else if (parsed != null && !parsed.isCoding && prop.getColumnName().contains("#")) {
-          // This might be a designation column in new format (type#language##order or type#language)
+        } else if (parsed != null && !parsed.isCoding
+            && (prop.getColumnName().contains("#") || prop.getColumnName().contains(":"))) {
+          // This might be a designation column (type:language##order or type:language; "#" kept for backward compatibility)
           DesignationParseResult designationParsed = parseDesignationColumn(prop.getColumnName());
           if (designationParsed != null) {
             // This is a designation column in new format
@@ -377,7 +378,26 @@ public class CodeSystemFileImportProcessor {
   }
   
   /**
-   * Parses column names in the new format: {property}##{order} or {property}#code##{order} or {property}#system##{order}
+   * Returns the order-suffix separator present in the column name: "##" (legacy) or "::" (new,
+   * colon-consistent with the ":" designation separator), preferring "##" when both happen to appear.
+   * Returns null when no order suffix is present.
+   */
+  private static String orderSeparator(String columnName) {
+    if (columnName == null) {
+      return null;
+    }
+    if (columnName.contains("##")) {
+      return "##";
+    }
+    if (columnName.contains("::")) {
+      return "::";
+    }
+    return null;
+  }
+
+  /**
+   * Parses column names in the new format: {property}::{order} or {property}#code::{order} or {property}#system::{order}.
+   * The "::" order separator mirrors the ":" designation separator; "##" is still accepted for backward compatibility.
    * Returns null if the column doesn't match the new format.
    */
   private static ColumnParseResult parseNewFormatColumn(String columnName) {
@@ -390,12 +410,13 @@ public class CodeSystemFileImportProcessor {
       return null;
     }
     
-    boolean hasOrderSuffix = columnName.contains("##");
+    String orderSep = orderSeparator(columnName);
+    boolean hasOrderSuffix = orderSep != null;
     int order = 1; // Default order when suffix is omitted
     String prefix = columnName;
-    
+
     if (hasOrderSuffix) {
-      String[] parts = columnName.split("##", 2);
+      String[] parts = columnName.split(orderSep, 2);
       if (parts.length != 2) {
         log.debug("IMPORT DEBUG: parseNewFormatColumn - Failed to split order suffix from '{}'", columnName);
         return null;
@@ -456,18 +477,20 @@ public class CodeSystemFileImportProcessor {
    */
   private static DesignationParseResult parseDesignationColumn(String columnName) {
     log.debug("IMPORT DEBUG: parseDesignationColumn - Parsing column name: '{}'", columnName);
-    // Pattern: {type}#{language}##{order} or {type}#{language} when order is 1
+    // Pattern: {type}:{language}##{order} or {type}:{language} when order is 1.
+    // The ":" separator mirrors FHIR shorthand (e.g. "definition:et"); "#" is still accepted for backward compatibility.
     if (columnName == null) {
       log.debug("IMPORT DEBUG: parseDesignationColumn - Column name is null");
       return null;
     }
     
-    boolean hasOrderSuffix = columnName.contains("##");
+    String orderSep = orderSeparator(columnName);
+    boolean hasOrderSuffix = orderSep != null;
     int order = 1; // Default order when suffix is omitted
     String typeLang = columnName;
-    
+
     if (hasOrderSuffix) {
-      String[] parts = columnName.split("##", 2);
+      String[] parts = columnName.split(orderSep, 2);
       if (parts.length != 2) {
         log.debug("IMPORT DEBUG: parseDesignationColumn - Failed to split order suffix from '{}'", columnName);
         return null;
@@ -482,11 +505,13 @@ public class CodeSystemFileImportProcessor {
       }
     }
     
-    if (typeLang.contains("#")) {
-      String[] typeLangParts = typeLang.split("#", 2);
+    // Prefer the ":" separator; fall back to "#" for backward compatibility.
+    String separator = typeLang.contains(":") ? ":" : (typeLang.contains("#") ? "#" : null);
+    if (separator != null) {
+      String[] typeLangParts = typeLang.split(separator, 2);
       if (typeLangParts.length == 2) {
         DesignationParseResult result = new DesignationParseResult(typeLangParts[0], typeLangParts[1], order);
-        log.debug("IMPORT DEBUG: parseDesignationColumn - Result: type='{}', language='{}', order={}", 
+        log.debug("IMPORT DEBUG: parseDesignationColumn - Result: type='{}', language='{}', order={}",
             result.type, result.language, result.order);
         return result;
       }

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptExportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptExportService.java
@@ -160,7 +160,7 @@ public class ConceptExportService {
             .collect(Collectors.groupingBy(d -> {
               String type = d.getDesignationType() != null ? d.getDesignationType().trim() : "";
               String lang = d.getLanguage() != null ? d.getLanguage().trim() : "";
-              return type + "#" + lang;
+              return type + ":" + lang;
             }));
         
         log.debug("EXPORT DEBUG: composeHeaders - Concept: {}, Version: {}, Designation groups after filtering: {}", 
@@ -197,14 +197,14 @@ public class ConceptExportService {
     log.debug("EXPORT DEBUG: designationMaxCounts size: {}", designationMaxCounts.size());
     designationMaxCounts.forEach((typeLang, maxCount) -> {
       log.debug("EXPORT DEBUG: Processing designation typeLang: {}, maxCount: {}", typeLang, maxCount);
-      boolean isDisplay = typeLang.startsWith("display#");
+      boolean isDisplay = typeLang.startsWith("display:");
       for (int order = 1; order <= maxCount; order++) {
-        // Omit ##1 suffix when there's only one designation of this type#language
+        // Omit ##1 suffix when there's only one designation of this type:language
         String columnName;
         if (maxCount == 1) {
           columnName = typeLang;
         } else {
-          columnName = typeLang + "##" + order;
+          columnName = typeLang + "::" + order;
         }
         if (isDisplay) {
           displayDesignationColumns.add(columnName);
@@ -244,8 +244,8 @@ public class ConceptExportService {
             columns.add(propertyName + "#code");
             columns.add(propertyName + "#system");
           } else {
-            columns.add(propertyName + "#code##" + order);
-            columns.add(propertyName + "#system##" + order);
+            columns.add(propertyName + "#code::" + order);
+            columns.add(propertyName + "#system::" + order);
           }
         }
       } else {
@@ -256,7 +256,7 @@ public class ConceptExportService {
           if (maxCount == 1) {
             columns.add(propertyName);
           } else {
-            columns.add(propertyName + "##" + order);
+            columns.add(propertyName + "::" + order);
           }
         }
       }
@@ -338,7 +338,7 @@ public class ConceptExportService {
         .collect(Collectors.groupingBy(d -> {
           String type = d.getDesignationType() != null ? d.getDesignationType().trim() : "";
           String lang = d.getLanguage() != null ? d.getLanguage().trim() : "";
-          return type + "#" + lang;
+          return type + ":" + lang;
         }, Collectors.toList()));
     
     // Group property values by property name, preserving order
@@ -460,13 +460,13 @@ public class ConceptExportService {
             row.add(""); // Could not parse column header or property name is null
           }
         } else {
-          // Check if this is a designation column (format: type#language##order)
+          // Check if this is a designation column (format: type:language##order)
           DesignationColumnInfo designationInfo = parseDesignationColumn(h);
           log.debug("EXPORT DEBUG: composeRow - Concept: {}, Header: {}, DesignationInfo: {}", 
               c.getCode(), h, designationInfo != null ? ("type=" + designationInfo.type + ", lang=" + designationInfo.language + ", order=" + designationInfo.order) : "null");
           
           if (designationInfo != null && designationInfo.type != null && !designationInfo.type.isEmpty()) {
-            String typeLang = designationInfo.type + "#" + (designationInfo.language != null ? designationInfo.language : "");
+            String typeLang = designationInfo.type + ":" + (designationInfo.language != null ? designationInfo.language : "");
             if (designationsByTypeLang.containsKey(typeLang)) {
               List<Designation> designations = designationsByTypeLang.get(typeLang);
               if (designationInfo.order > 0 && designationInfo.order <= designations.size()) {
@@ -548,23 +548,43 @@ public class ConceptExportService {
     return row.toArray();
   }
   
+  /**
+   * Returns the order-suffix separator present in the column name: "::" (the format produced by
+   * export, colon-consistent with the ":" designation separator) or "##" (legacy), preferring "##"
+   * when both happen to appear. Returns null when no order suffix is present.
+   */
+  private static String orderSeparator(String columnName) {
+    if (columnName == null) {
+      return null;
+    }
+    if (columnName.contains("##")) {
+      return "##";
+    }
+    if (columnName.contains("::")) {
+      return "::";
+    }
+    return null;
+  }
+
   private ColumnInfo parseColumnHeader(String header) {
-    // Pattern: {property-name}##{order} for simple types (or {property-name} when order is 1)
-    // Pattern: {property-name}#code##{order} or {property-name}#system##{order} for coding types
+    // Pattern: {property-name}::{order} for simple types (or {property-name} when order is 1)
+    // Pattern: {property-name}#code::{order} or {property-name}#system::{order} for coding types
     // Pattern: {property-name}#code or {property-name}#system when order is 1
+    // "##" is also accepted as the order separator for backward compatibility.
     log.debug("EXPORT DEBUG: parseColumnHeader - Parsing header: {}", header);
-    
+
     if (header == null) {
       log.debug("EXPORT DEBUG: parseColumnHeader - Header is null");
       return null;
     }
-    
-    boolean hasOrderSuffix = header.contains("##");
+
+    String orderSep = orderSeparator(header);
+    boolean hasOrderSuffix = orderSep != null;
     int order = 1; // Default order when suffix is omitted
     String prefix = header;
-    
+
     if (hasOrderSuffix) {
-      String[] parts = header.split("##", 2);
+      String[] parts = header.split(orderSep, 2);
       if (parts.length != 2) {
         log.debug("EXPORT DEBUG: parseColumnHeader - Header '{}' has ## but split failed", header);
         return null;
@@ -616,11 +636,12 @@ public class ConceptExportService {
   }
   
   private static String extractPropertyName(String columnName) {
-    // Remove #code, #system, and ##order suffixes to get the base property name
-    // Handle both formats: with ## suffix and without (for single values)
+    // Remove #code, #system, and order suffixes to get the base property name
+    // Handle both formats: with order suffix ("::" or legacy "##") and without (for single values)
     String beforeOrder = columnName;
-    if (columnName.contains("##")) {
-      beforeOrder = columnName.split("##")[0];
+    String orderSep = orderSeparator(columnName);
+    if (orderSep != null) {
+      beforeOrder = columnName.split(orderSep)[0];
     }
     if (beforeOrder.endsWith("#code")) {
       return beforeOrder.substring(0, beforeOrder.length() - 5);
@@ -631,10 +652,11 @@ public class ConceptExportService {
   }
   
   private static int extractOrder(String columnName) {
-    // Extract order from column name, defaulting to 1 when no ## suffix is present
-    if (columnName != null && columnName.contains("##")) {
+    // Extract order from column name, defaulting to 1 when no order suffix ("::" or legacy "##") is present
+    String orderSep = orderSeparator(columnName);
+    if (orderSep != null) {
       try {
-        String[] parts = columnName.split("##", 2);
+        String[] parts = columnName.split(orderSep, 2);
         return Integer.parseInt(parts[1]);
       } catch (NumberFormatException e) {
         return 1; // Default to order 1 on parse error
@@ -644,17 +666,21 @@ public class ConceptExportService {
   }
   
   private DesignationColumnInfo parseDesignationColumn(String header) {
-    // Pattern: {type}#{language}##{order} or {type}#{language} when order is 1
+    // Pattern: {type}:{language}::{order} or {type}:{language} when order is 1.
+    // Export emits ":" for the value/language separator and "::" for the order suffix; coding
+    // sub-columns use "#code"/"#system", so matching the designation ":" cleanly tells them apart.
+    // "##" is still accepted as the order separator for backward compatibility.
     if (header == null) {
       return null;
     }
-    
-    boolean hasOrderSuffix = header.contains("##");
+
+    String orderSep = orderSeparator(header);
+    boolean hasOrderSuffix = orderSep != null;
     int order = 1; // Default order when suffix is omitted
     String typeLang = header;
-    
+
     if (hasOrderSuffix) {
-      String[] parts = header.split("##", 2);
+      String[] parts = header.split(orderSep, 2);
       if (parts.length != 2) {
         return null;
       }
@@ -666,8 +692,8 @@ public class ConceptExportService {
       }
     }
     
-    if (typeLang != null && typeLang.contains("#")) {
-      String[] typeLangParts = typeLang.split("#", 2);
+    if (typeLang != null && typeLang.contains(":")) {
+      String[] typeLangParts = typeLang.split(":", 2);
       if (typeLangParts.length == 2) {
         String type = typeLangParts[0] != null ? typeLangParts[0] : "";
         String lang = typeLangParts[1] != null ? typeLangParts[1] : "";
@@ -758,7 +784,7 @@ public class ConceptExportService {
             
             if (type != null && !type.trim().isEmpty()) {
               String lang = d.getLanguage() != null ? d.getLanguage().trim() : "";
-              String typeLang = type.trim() + "#" + lang;
+              String typeLang = type.trim() + ":" + lang;
               designationsByConcept.computeIfAbsent(c.getCode(), k -> new java.util.ArrayList<>()).add(typeLang);
               totalDesignationsFound++;
               log.debug("EXPORT DEBUG: Added designation to collection - Concept: {}, TypeLang: '{}'", c.getCode(), typeLang);
@@ -808,11 +834,11 @@ public class ConceptExportService {
       String conceptCode = entry.getKey();
       for (String typeLang : entry.getValue()) {
         // Check if this typeLang has a corresponding column in headers
-        // It could be without suffix (single value) or with ##1, ##2, etc.
+        // It could be without suffix (single value) or with an order suffix (::1, ::2, or legacy ##1, ##2)
         boolean found = false;
         String matchingHeader = null;
         for (String header : headers) {
-          if (header.equals(typeLang) || header.startsWith(typeLang + "##")) {
+          if (header.equals(typeLang) || header.startsWith(typeLang + "::") || header.startsWith(typeLang + "##")) {
             found = true;
             matchingHeader = header;
             break;

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportProcessorTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportProcessorTest.groovy
@@ -105,6 +105,112 @@ b1,B1,,g1,,"""
   }
 
   /**
+   * BUSINESS: Test CSV import using the ":" designation separator (FHIR-style, e.g. "definition:et").
+   *
+   * Validates that:
+   * - "type:language" designation columns are parsed (value + language)
+   * - The ":" separator works together with "##" order suffixes
+   * - "#" designation columns keep working in the same file (backward compatibility)
+   * - Coding columns ("#code"/"#system") are unaffected by the new separator
+   */
+  def "should import CSV file using ':' designation separator (and keep '#' for backward compatibility)"() {
+    given: "CSV file mixing ':' designations, a legacy '#' designation, ordered designations and a coding property"
+    String csvContent = """code,display:en,definition:en,definition:en##2,definition:ru,synonym#et,type#code,type#system
+a1,A1,First,Second,Первый,sünonüüm,AdverseEvent,http://hl7.org/fhir/fhir-types
+b1,B1,,,,,,"""
+
+    byte[] file = csvContent.getBytes("UTF-8")
+
+    CodeSystemFileImportRequest request = new CodeSystemFileImportRequest(
+      type: "csv",
+      properties: [
+        new FileProcessingProperty(columnName: "code", propertyName: "concept-code", propertyType: "string", preferred: true),
+        new FileProcessingProperty(columnName: "display:en", propertyName: "display", propertyType: "designation", language: "en"),
+        new FileProcessingProperty(columnName: "definition:en", propertyName: "definition", propertyType: "designation", language: "en"),
+        new FileProcessingProperty(columnName: "definition:en##2", propertyName: "definition", propertyType: "designation", language: "en"),
+        new FileProcessingProperty(columnName: "definition:ru", propertyName: "definition", propertyType: "designation", language: "ru"),
+        new FileProcessingProperty(columnName: "synonym#et", propertyName: "synonym", propertyType: "designation", language: "et"),
+        new FileProcessingProperty(columnName: "type#code", propertyName: "type", propertyType: "coding"),
+        new FileProcessingProperty(columnName: "type#system", propertyName: "type", propertyType: "coding")
+      ]
+    )
+
+    when: "processing the import"
+    CodeSystemFileImportResult result = CodeSystemFileImportProcessor.process(request, file)
+
+    then: "':' and '#' designation columns are both parsed with the correct value and language"
+    result.entities.size() == 2
+
+    def a1Entity = result.entities.find { it.get("concept-code")?.get(0)?.getValue() == "a1" }
+    a1Entity != null
+    a1Entity.get("display")?.size() == 1
+    a1Entity.get("display")?.get(0)?.getValue() == "A1"
+    a1Entity.get("display")?.get(0)?.getLang() == "en"
+    a1Entity.get("definition")?.size() == 3
+    a1Entity.get("definition")?.collect { it.getValue() }?.containsAll(["First", "Second", "Первый"])
+    a1Entity.get("definition")?.find { it.getValue() == "Первый" }?.getLang() == "ru"
+    // legacy "#" designation column still works
+    a1Entity.get("synonym")?.size() == 1
+    a1Entity.get("synonym")?.get(0)?.getValue() == "sünonüüm"
+    a1Entity.get("synonym")?.get(0)?.getLang() == "et"
+    // coding columns unaffected
+    def typeValue = a1Entity.get("type")?.get(0)?.getValue()
+    typeValue instanceof Map
+    typeValue.get("code") == "AdverseEvent"
+    typeValue.get("codeSystem") == "http://hl7.org/fhir/fhir-types"
+  }
+
+  /**
+   * BUSINESS: Test CSV import using the "::" order separator (colon-consistent with ":").
+   *
+   * Validates that:
+   * - Fully colon-based designation columns ("type:language::order") are parsed
+   * - The "::" order separator works for designations, simple properties and coding columns
+   * - Legacy "##" order separator still works in the same file (backward compatibility)
+   */
+  def "should import CSV file using '::' order separator (and keep '##' for backward compatibility)"() {
+    given: "CSV mixing '::' order suffixes with a legacy '##' column and a coding property"
+    String csvContent = """code,display:en,definition:en::1,definition:en::2,synonym::1,synonym##2,type#code::1,type#system::1,type#code::2,type#system::2
+a1,A1,First,Second,x,Y,AdverseEvent,http://hl7.org/fhir/fhir-types,Age,http://hl7.org/fhir/fhir-types"""
+
+    byte[] file = csvContent.getBytes("UTF-8")
+
+    CodeSystemFileImportRequest request = new CodeSystemFileImportRequest(
+      type: "csv",
+      properties: [
+        new FileProcessingProperty(columnName: "code", propertyName: "concept-code", propertyType: "string", preferred: true),
+        new FileProcessingProperty(columnName: "display:en", propertyName: "display", propertyType: "designation", language: "en"),
+        new FileProcessingProperty(columnName: "definition:en::1", propertyName: "definition", propertyType: "designation", language: "en"),
+        new FileProcessingProperty(columnName: "definition:en::2", propertyName: "definition", propertyType: "designation", language: "en"),
+        new FileProcessingProperty(columnName: "synonym::1", propertyName: "synonym", propertyType: "string"),
+        new FileProcessingProperty(columnName: "synonym##2", propertyName: "synonym", propertyType: "string"),
+        new FileProcessingProperty(columnName: "type#code::1", propertyName: "type", propertyType: "coding"),
+        new FileProcessingProperty(columnName: "type#system::1", propertyName: "type", propertyType: "coding"),
+        new FileProcessingProperty(columnName: "type#code::2", propertyName: "type", propertyType: "coding"),
+        new FileProcessingProperty(columnName: "type#system::2", propertyName: "type", propertyType: "coding")
+      ]
+    )
+
+    when: "processing the import"
+    CodeSystemFileImportResult result = CodeSystemFileImportProcessor.process(request, file)
+
+    then: "'::' and '##' order suffixes are both honoured across designations, properties and codings"
+    result.entities.size() == 1
+
+    def a1Entity = result.entities.find { it.get("concept-code")?.get(0)?.getValue() == "a1" }
+    a1Entity != null
+    a1Entity.get("display")?.get(0)?.getValue() == "A1"
+    a1Entity.get("definition")?.size() == 2
+    a1Entity.get("definition")?.collect { it.getValue() }?.containsAll(["First", "Second"])
+    // "::1" + legacy "##2" both map to the same simple property
+    a1Entity.get("synonym")?.size() == 2
+    a1Entity.get("synonym")?.collect { it.getValue() }?.containsAll(["x", "Y"])
+    // two coding pairs ordered via "::"
+    a1Entity.get("type")?.size() == 2
+    a1Entity.get("type")?.collect { it.getValue().get("code") }?.containsAll(["AdverseEvent", "Age"])
+  }
+
+  /**
    * BUSINESS: Test CSV import with new format columns (multiple values with order suffix)
    * 
    * Validates that:

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/concept/ConceptExportServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/concept/ConceptExportServiceTest.groovy
@@ -194,17 +194,17 @@ class ConceptExportServiceTest extends Specification {
     codeIndex >= 0
     row[codeIndex] == "test1"
     
-    // Single display should not have ##1 suffix
-    def displayIndex = headers.findIndexOf { it == "display#en" || it == "display#en##1" }
+    // Single display should not have ::1 suffix
+    def displayIndex = headers.findIndexOf { it == "display:en" || it == "display:en::1" }
     displayIndex >= 0
     row[displayIndex] == "Test Display"
     
-    // Multiple definitions: first one may or may not have suffix, second one should have ##2
-    def def1Index = headers.findIndexOf { it == "definition#en" || it == "definition#en##1" }
+    // Multiple definitions: first one may or may not have suffix, second one should have ::2
+    def def1Index = headers.findIndexOf { it == "definition:en" || it == "definition:en::1" }
     def1Index >= 0
     row[def1Index] == "Definition 1"
     
-    def def2Index = headers.indexOf("definition#en##2")
+    def def2Index = headers.indexOf("definition:en::2")
     def2Index >= 0
     row[def2Index] == "Definition 2"
   }
@@ -525,7 +525,7 @@ class ConceptExportServiceTest extends Specification {
     (b1Type2.getCode() == "ActivityDefinition" && b1Type2.getCodeSystem() == "http://hl7.org/fhir/fhir-types")
   }
   
-  def "should use optional order suffix - omit ##1 for single values"() {
+  def "should use optional order suffix - omit ::1 for single values"() {
     given: "concepts with single and multiple values"
     CodeSystem codeSystem = new CodeSystem()
     codeSystem.setId("test-cs")
@@ -606,18 +606,18 @@ class ConceptExportServiceTest extends Specification {
     headers[0] == "code"
     
     // Display designations come first after code
-    def displayIndex = headers.indexOf("display#en##1")
+    def displayIndex = headers.indexOf("display:en::1")
     displayIndex > 0
-    headers.contains("display#en##1")
-    headers.contains("display#en##2")
+    headers.contains("display:en::1")
+    headers.contains("display:en::2")
     
     // Since concept1 has 1 itemWeight and concept2 has 0, maxCount is 1, so no suffix
     headers.contains("itemWeight")
-    !headers.contains("itemWeight##1")
+    !headers.contains("itemWeight::1")
     
-    // Since concept2 has 2 synonyms, maxCount is 2, so we get ##1 and ##2
-    headers.contains("synonym##1")
-    headers.contains("synonym##2")
+    // Since concept2 has 2 synonyms, maxCount is 2, so we get ::1 and ::2
+    headers.contains("synonym::1")
+    headers.contains("synonym::2")
     
     // Properties come after designations
     def itemWeightIndex = headers.indexOf("itemWeight")
@@ -676,17 +676,17 @@ class ConceptExportServiceTest extends Specification {
     
     then: "both active and draft designations should be included"
     // Since we have 2 displays (active + draft), maxCount is 2
-    headers.contains("display#en##1")
-    headers.contains("display#en##2")
+    headers.contains("display:en::1")
+    headers.contains("display:en::2")
     
     // Since we have 2 definitions (active + draft), maxCount is 2
-    headers.contains("definition#en##1")
-    headers.contains("definition#en##2")
+    headers.contains("definition:en::1")
+    headers.contains("definition:en::2")
     
     // Column order: code, display, other designations
     headers[0] == "code"
-    def displayIndex = headers.indexOf("display#en##1")
-    def definitionIndex = headers.indexOf("definition#en##1")
+    def displayIndex = headers.indexOf("display:en::1")
+    def definitionIndex = headers.indexOf("definition:en::1")
     displayIndex > 0
     definitionIndex > displayIndex
   }
@@ -745,11 +745,11 @@ class ConceptExportServiceTest extends Specification {
     
     // Display designations come after code
     def codeIndex = headers.indexOf("code")
-    def displayIndex = headers.indexOf("display#en")
+    def displayIndex = headers.indexOf("display:en")
     displayIndex > codeIndex
     
     // Other designations come after display
-    def definitionIndex = headers.indexOf("definition#en")
+    def definitionIndex = headers.indexOf("definition:en")
     definitionIndex > displayIndex
     
     // Properties come after designations


### PR DESCRIPTION
## Summary

Aligns CSV/TSV/XLSX designation columns with the FHIR language-tagged shorthand TermX already understands for FHIR JSON (`definition:et`).

- **Value/language separator** is now `:` (e.g. `definition:en`) instead of `#`.
- **Order suffix** is now `::` (e.g. `definition:en::2`) instead of `##`, so designation columns are fully colon-based.
- **Export** emits `:` and `::`.
- **Import** keeps accepting the legacy `#` separator and `##` order suffix for backward compatibility; old and new forms can be freely mixed within a single file.
- Coding sub-columns (`#code`/`#system`) and hierarchy joins are unchanged — `:`/`::` never collide with them.

A freshly exported file now looks like:
`code,display:en,definition:en::1,definition:en::2,type#code::1,type#system::1`

Files produced by earlier TermX versions (`display#en`, `definition#ru##2`) still import unchanged.

## Changes

- `CodeSystemFileImportProcessor` — parse `:`/`#` value-language separators and `::`/`##` order suffixes (shared `orderSeparator()` helper).
- `ConceptExportService` — emit `:`/`::`; parse both old and new forms.
- Updated import/export feature specifications under `docs/features/`.

## Tests

New unit tests cover the `:` separator and `::` order suffix mixed with legacy `#`/`##` columns and coding properties. Existing `#`/`##` import tests remain green (backward compatibility).

- import processor 13/0/0, export 8/0/0, mapper 15/0/0, dry-run 2/0/0.

## Note

No `termx-web` changes needed: the import wizard maps columns through structured form fields (property + language dropdown), so the separator is never surfaced in the UI.