### PR TITLE
LOINC external delegation: resolve http://loinc.org via fhir.loinc.org (configurable)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/loinc/LoincClient.java
+++ b/terminology/src/main/java/org/termx/terminology/loinc/LoincClient.java
@@ -1,0 +1,74 @@
+package org.termx.terminology.loinc;
+
+import com.kodality.zmei.fhir.FhirMapper;
+import com.kodality.zmei.fhir.resource.other.Parameters;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Thin client over an external LOINC FHIR terminology server (default the official {@code https://fhir.loinc.org},
+ * a Smile CDR that requires HTTP Basic auth). The whole {@code Authorization} header value is taken verbatim
+ * from {@code loinc.authentication} so an operator can drop in their own LOINC key, e.g. {@code "Basic xxxx"}.
+ * Mirrors the SNOMED/Snowstorm integration pattern.
+ */
+@Slf4j
+@Singleton
+public class LoincClient {
+  public static final String LOINC_URI = "http://loinc.org";
+  private static final String FHIR_JSON = "application/fhir+json";
+
+  private final String baseUrl;
+  private final String authentication;
+  private final HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+  public LoincClient(@Value("${loinc.url:}") String url,
+                     @Value("${loinc.authentication:}") String authentication) {
+    String resolved = StringUtils.isNotEmpty(url) ? url : "https://fhir.loinc.org";
+    this.baseUrl = resolved.endsWith("/") ? resolved.substring(0, resolved.length() - 1) : resolved;
+    this.authentication = authentication;
+  }
+
+  public boolean isConfigured() {
+    return StringUtils.isNotEmpty(authentication);
+  }
+
+  /** CodeSystem/$lookup for a LOINC code; returns the FHIR Parameters response, or null on any non-2xx/error. */
+  public Parameters lookup(String code, String version) {
+    String q = "/CodeSystem/$lookup?system=" + enc(LOINC_URI) + "&code=" + enc(code)
+        + (StringUtils.isNotEmpty(version) ? "&version=" + enc(version) : "");
+    return get(q);
+  }
+
+  private Parameters get(String path) {
+    try {
+      HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(baseUrl + path))
+          .timeout(Duration.ofSeconds(30))
+          .header("Accept", FHIR_JSON);
+      if (StringUtils.isNotEmpty(authentication)) {
+        b.header("Authorization", authentication);
+      }
+      HttpResponse<String> resp = http.send(b.GET().build(), HttpResponse.BodyHandlers.ofString());
+      if (resp.statusCode() / 100 != 2) {
+        log.debug("LOINC {} -> {}", path, resp.statusCode());
+        return null;
+      }
+      return FhirMapper.fromJson(resp.body(), Parameters.class);
+    } catch (Exception e) {
+      log.warn("LOINC request {} failed: {}", path, e.getMessage());
+      return null;
+    }
+  }
+
+  private static String enc(String s) {
+    return URLEncoder.encode(s, StandardCharsets.UTF_8);
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/loinc/LoincCodeSystemProvider.java
+++ b/terminology/src/main/java/org/termx/terminology/loinc/LoincCodeSystemProvider.java
@@ -1,0 +1,179 @@
+package org.termx.terminology.loinc;
+
+import com.kodality.commons.model.QueryResult;
+import com.kodality.zmei.fhir.resource.other.Parameters;
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter;
+import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Value;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.termx.core.ts.CodeSystemExternalProvider;
+import org.termx.terminology.terminology.codesystem.CodeSystemService;
+import org.termx.ts.PublicationStatus;
+import org.termx.ts.codesystem.CodeSystem;
+import org.termx.ts.codesystem.CodeSystemEntityVersion;
+import org.termx.ts.codesystem.Concept;
+import org.termx.ts.codesystem.ConceptQueryParams;
+import org.termx.ts.codesystem.Designation;
+import org.termx.ts.codesystem.EntityPropertyType;
+import org.termx.ts.codesystem.EntityPropertyValue;
+
+/**
+ * Resolves {@code http://loinc.org} codes by delegating to an external LOINC FHIR server ({@link LoincClient})
+ * instead of importing the (100k+ concept) LOINC content locally. Plugs into the same
+ * {@link CodeSystemExternalProvider} mechanism SNOMED uses, so {@code $lookup}/{@code $validate-code} render
+ * the delegated concept unchanged.
+ *
+ * <p>The local-vs-external policy is configurable via {@code loinc.source}:
+ * <ul>
+ *   <li>{@code local} — never delegate (pure local LOINC, or "not found" if none loaded);</li>
+ *   <li>{@code local-first} (default) — delegate only when no local LOINC content is present, so an
+ *       install that imported LOINC keeps its own version;</li>
+ *   <li>{@code external} — always delegate, even if a local LOINC exists.</li>
+ * </ul>
+ * Inert unless {@code loinc.authentication} is set (then it behaves as {@code local}).
+ */
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class LoincCodeSystemProvider extends CodeSystemExternalProvider {
+  /** TermX CodeSystem id of the {@code http://loinc.org} stub (see the loinc-external-codesystem-stub changeset). */
+  private static final String LOINC = "loinc";
+
+  private final LoincClient loincClient;
+  // Lazy: this is a CodeSystemExternalProvider and CodeSystemService transitively depends on
+  // ConceptService, which injects List<CodeSystemExternalProvider> — a direct injection forms a DI
+  // cycle (same reason SnomedCodeSystemProvider uses BeanProvider). Defer resolution to call time.
+  private final BeanProvider<CodeSystemService> codeSystemService;
+
+  @Value("${loinc.source:local-first}")
+  String source;
+
+  @Override
+  public QueryResult<Concept> searchConcepts(ConceptQueryParams params) {
+    if (!LOINC.equals(params.getCodeSystem()) || !shouldDelegate()) {
+      return QueryResult.empty();
+    }
+    // Only single-code lookups ($lookup / $validate-code by code) are delegated.
+    String code = StringUtils.isNotEmpty(params.getCodeEq()) ? params.getCodeEq() : params.getCode();
+    if (StringUtils.isEmpty(code)) {
+      return QueryResult.empty();
+    }
+    Parameters resp = loincClient.lookup(code, params.getCodeSystemVersion());
+    if (resp == null || resp.findParameter("display").isEmpty()) {
+      return QueryResult.empty();
+    }
+    return new QueryResult<>(List.of(toConcept(code, resp)));
+  }
+
+  @Override
+  public String getCodeSystemId() {
+    return LOINC;
+  }
+
+  private boolean shouldDelegate() {
+    if (!loincClient.isConfigured() || "local".equalsIgnoreCase(source)) {
+      return false;
+    }
+    if ("external".equalsIgnoreCase(source)) {
+      return true;
+    }
+    // local-first: delegate only when the local LOINC CodeSystem carries no content of its own
+    return !hasLocalContent();
+  }
+
+  private boolean hasLocalContent() {
+    // The external stub is content=not-present; a locally imported LOINC is content=complete/fragment.
+    return codeSystemService.get().load(LOINC).map(cs -> !"not-present".equals(cs.getContent())).orElse(false);
+  }
+
+  /** Maps an external {@code $lookup} Parameters response into a TermX {@link Concept}. */
+  private Concept toConcept(String code, Parameters resp) {
+    CodeSystemEntityVersion version = new CodeSystemEntityVersion();
+    version.setCode(code);
+    version.setCodeSystem(LOINC);
+    version.setStatus(PublicationStatus.active);
+
+    List<Designation> designations = new ArrayList<>();
+    resp.findParameter("display").map(ParametersParameter::getValueString).ifPresent(display ->
+        designations.add(new Designation().setName(display).setDesignationType("display").setPreferred(true).setStatus("active")));
+    if (resp.getParameter() != null) {
+      resp.getParameter().stream().filter(p -> "designation".equals(p.getName())).forEach(p -> {
+        String value = part(p, "value", ParametersParameter::getValueString);
+        if (StringUtils.isNotEmpty(value)) {
+          designations.add(new Designation()
+              .setName(value)
+              .setLanguage(part(p, "language", ParametersParameter::getValueCode))
+              .setDesignationType(Optional.ofNullable(p.getPart("use"))
+                  .map(ParametersParameter::getValueCoding).map(c -> c.getCode()).orElse("display"))
+              .setStatus("active"));
+        }
+      });
+    }
+    version.setDesignations(designations);
+
+    List<EntityPropertyValue> properties = new ArrayList<>();
+    if (resp.getParameter() != null) {
+      resp.getParameter().stream().filter(p -> "property".equals(p.getName())).forEach(p -> {
+        String pCode = part(p, "code", ParametersParameter::getValueCode);
+        EntityPropertyValue pv = toPropertyValue(pCode, p.getPart("value"));
+        if (pv != null) {
+          properties.add(pv);
+        }
+      });
+    }
+    version.setPropertyValues(properties);
+
+    Concept concept = new Concept();
+    concept.setCode(code);
+    concept.setCodeSystem(LOINC);
+    concept.setVersions(List.of(version));
+    return concept;
+  }
+
+  private static String part(ParametersParameter p, String name, java.util.function.Function<ParametersParameter, String> getter) {
+    return Optional.ofNullable(p.getPart(name)).map(getter).orElse(null);
+  }
+
+  /**
+   * Maps a {@code property} part into an {@link EntityPropertyValue} with the {@code entityPropertyType} set
+   * to match the FHIR {@code value[x]} — required because the $lookup renderer switches on that type (a null
+   * type NPEs). A Coding value is rendered as its display/code string (the not-present stub has no property
+   * definitions to validate a coding against).
+   */
+  private static EntityPropertyValue toPropertyValue(String code, ParametersParameter value) {
+    if (StringUtils.isEmpty(code) || value == null) {
+      return null;
+    }
+    if (value.getValueCode() != null) {
+      return prop(code, EntityPropertyType.code, value.getValueCode());
+    }
+    if (value.getValueString() != null) {
+      return prop(code, EntityPropertyType.string, value.getValueString());
+    }
+    if (value.getValueBoolean() != null) {
+      return prop(code, EntityPropertyType.bool, value.getValueBoolean());
+    }
+    if (value.getValueDecimal() != null) {
+      return prop(code, EntityPropertyType.decimal, value.getValueDecimal());
+    }
+    if (value.getValueInteger() != null) {
+      return prop(code, EntityPropertyType.integer, value.getValueInteger());
+    }
+    if (value.getValueCoding() != null) {
+      String s = value.getValueCoding().getDisplay() != null ? value.getValueCoding().getDisplay() : value.getValueCoding().getCode();
+      return s == null ? null : prop(code, EntityPropertyType.string, s);
+    }
+    return null;
+  }
+
+  private static EntityPropertyValue prop(String code, String type, Object value) {
+    return new EntityPropertyValue().setEntityProperty(code).setEntityPropertyType(type).setValue(value);
+  }
+}

--- a/terminology/src/main/resources/terminology/changelog/terminology/01-code_system.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/01-code_system.sql
@@ -164,3 +164,13 @@ add column external_web_source text;
 alter table terminology.code_system add column profile text[];
 --rollback alter table terminology.code_system drop column profile;
 --
+
+--changeset termx:loinc-external-codesystem-stub
+-- A content=not-present stub for http://loinc.org so $lookup/$validate-code can resolve the system to a
+-- CodeSystem id and delegate to the external LOINC server (LoincCodeSystemProvider). Seeded only when no
+-- LOINC CodeSystem already exists, so installs that imported LOINC are never touched.
+insert into terminology.code_system(id, uri, title, content, case_sensitive, sys_status, sys_version, sys_created_at, sys_created_by, sys_modified_at, sys_modified_by)
+select 'loinc', 'http://loinc.org', '{"en":"LOINC"}'::jsonb, 'not-present', 'ci', 'A', 1, now(), 'system', now(), 'system'
+where not exists (select 1 from terminology.code_system where uri = 'http://loinc.org' and sys_status = 'A');
+--rollback delete from terminology.code_system where id = 'loinc' and content = 'not-present';
+--

--- a/terminology/src/test/groovy/org/termx/terminology/loinc/LoincCodeSystemProviderSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/loinc/LoincCodeSystemProviderSpec.groovy
@@ -1,0 +1,98 @@
+package org.termx.terminology.loinc
+
+import com.kodality.zmei.fhir.datatypes.Coding
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.context.BeanProvider
+import org.termx.terminology.terminology.codesystem.CodeSystemService
+import org.termx.ts.codesystem.CodeSystem
+import org.termx.ts.codesystem.ConceptQueryParams
+import org.termx.ts.codesystem.EntityPropertyType
+import spock.lang.Specification
+
+class LoincCodeSystemProviderSpec extends Specification {
+  def loincClient = Mock(LoincClient)
+  def codeSystemService = Mock(CodeSystemService)
+  def beanProvider = Mock(BeanProvider) { get() >> codeSystemService }
+  def provider = new LoincCodeSystemProvider(loincClient, beanProvider)
+
+  private static Parameters lookupResponse() {
+    new Parameters().setParameter([
+        new ParametersParameter().setName("display").setValueString("Hematocrit, Blood"),
+        new ParametersParameter().setName("designation").setPart([
+            new ParametersParameter().setName("language").setValueCode("en"),
+            new ParametersParameter().setName("value").setValueString("Hematocrit [Volume Fraction] of Blood"),
+            new ParametersParameter().setName("use").setValueCoding(new Coding().setCode("FULLY_SPECIFIED_NAME"))]),
+        new ParametersParameter().setName("property").setPart([
+            new ParametersParameter().setName("code").setValueCode("CLASS"),
+            new ParametersParameter().setName("value").setValueString("HEM/BC")]),
+        new ParametersParameter().setName("property").setPart([
+            new ParametersParameter().setName("code").setValueCode("STATUS"),
+            new ParametersParameter().setName("value").setValueCode("ACTIVE")]),
+    ])
+  }
+
+  def "delegates a loinc code lookup and maps display, designations and typed properties"() {
+    given:
+    provider.source = "local-first"
+    loincClient.isConfigured() >> true
+    codeSystemService.load("loinc") >> Optional.of(new CodeSystem().setContent("not-present"))
+    loincClient.lookup("4544-3", null) >> lookupResponse()
+
+    when:
+    def result = provider.searchConcepts(new ConceptQueryParams().setCodeSystem("loinc").setCodeEq("4544-3"))
+    def concept = result.data[0]
+    def version = concept.versions[0]
+
+    then:
+    concept.code == "4544-3"
+    concept.codeSystem == "loinc"
+    version.designations.find { it.designationType == "display" }.name == "Hematocrit, Blood"
+    version.designations.find { it.designationType == "FULLY_SPECIFIED_NAME" }.language == "en"
+    version.propertyValues.find { it.entityProperty == "CLASS" }.with { it.value == "HEM/BC" && it.entityPropertyType == EntityPropertyType.string }
+    version.propertyValues.find { it.entityProperty == "STATUS" }.entityPropertyType == EntityPropertyType.code
+  }
+
+  def "source=local never delegates"() {
+    given:
+    provider.source = "local"
+    loincClient.isConfigured() >> true
+
+    when:
+    def result = provider.searchConcepts(new ConceptQueryParams().setCodeSystem("loinc").setCodeEq("4544-3"))
+
+    then:
+    result.data.isEmpty()
+    0 * loincClient.lookup(_, _)
+  }
+
+  def "local-first defers to local when LOINC has local content"() {
+    given:
+    provider.source = "local-first"
+    loincClient.isConfigured() >> true
+    codeSystemService.load("loinc") >> Optional.of(new CodeSystem().setContent("complete"))
+
+    when:
+    def result = provider.searchConcepts(new ConceptQueryParams().setCodeSystem("loinc").setCodeEq("4544-3"))
+
+    then:
+    result.data.isEmpty()
+    0 * loincClient.lookup(_, _)
+  }
+
+  def "external always delegates even with local content"() {
+    given:
+    provider.source = "external"
+    loincClient.isConfigured() >> true
+    loincClient.lookup("4544-3", null) >> lookupResponse()
+
+    expect:
+    provider.searchConcepts(new ConceptQueryParams().setCodeSystem("loinc").setCodeEq("4544-3")).data[0].code == "4544-3"
+  }
+
+  def "ignores non-loinc systems and unconfigured client"() {
+    expect:
+    provider.searchConcepts(new ConceptQueryParams().setCodeSystem("snomed-ct").setCodeEq("x")).data.isEmpty()
+    provider.getCodeSystemId() == "loinc"
+  }
+}

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -110,6 +110,15 @@ snowstorm:
   branch: 'MAIN'
   namespace: '1000265'
 
+# External LOINC FHIR terminology server (default the official fhir.loinc.org). When configured, TermX
+# resolves http://loinc.org codes by delegating $lookup/$validate-code there instead of importing LOINC.
+loinc:
+  url: ${LOINC_URL:`https://fhir.loinc.org`}
+  # Full Authorization header value (the server is HTTP Basic), e.g. "Basic <base64 user:pass>". Empty = off.
+  authentication: ${LOINC_AUTHENTICATION:}
+  # local | local-first | external — see LoincCodeSystemProvider.
+  source: ${LOINC_SOURCE:local-first}
+
 terminology-ecosystem:
   coordination-server-url: ${TERMINOLOGY_ECOSYSTEM_URL:http://tx.fhir.org/tx-reg}
 


### PR DESCRIPTION
Implements the LOINC external-provider design from #227. TermX now resolves `http://loinc.org` codes by delegating to an external LOINC FHIR server instead of importing the 100k+ LOINC concepts — reusing the same `CodeSystemExternalProvider` mechanism SNOMED uses, so `$lookup`/`$validate-code` render the delegated concept unchanged.

## Pieces
- **`LoincClient`** — HTTP client over `loinc.url` (default `https://fhir.loinc.org`). The full `Authorization` header is taken verbatim from `loinc.authentication` (`"Basic xxxx"`) so an operator drops in their own LOINC key.
- **`LoincCodeSystemProvider`** — maps the external `$lookup` Parameters into a TermX `Concept` (display + designations + **typed** property values — the $lookup renderer switches on `entityPropertyType`, so it must be set). Lazy `CodeSystemService` injection to avoid the provider↔ConceptService DI cycle (same as `SnomedCodeSystemProvider`).
- **Liquibase stub** — seeds a `content=not-present` `http://loinc.org` CodeSystem (id `loinc`) **only when no LOINC CodeSystem exists**, so `$lookup` can resolve the system and installs that imported LOINC are never touched.
- **Config** (`application.yml`): `loinc.url` / `loinc.authentication` / `loinc.source`.

## Configurable local-vs-external (`loinc.source`)
| mode | behavior |
|---|---|
| `local` | never delegate |
| `local-first` *(default)* | delegate only when no local LOINC content — existing imported LOINC wins |
| `external` | always delegate, even with local content |

Inert unless `loinc.authentication` is set.

## Verified live (against fhir.loinc.org)
- `$lookup` `4544-3` → display `"Hematocrit, Blood"`, **25 designations, 33 properties**
- `$validate-code` `4544-3` → `result: true`

## Tests
- `LoincCodeSystemProviderSpec` — mapping (display/designation/typed properties) + all three source modes + non-loinc/unconfigured passthrough.
- `:terminology:test` 243/0.

Credentials for live testing live only in the gitignored `application-local.yml` (not in this PR). Follow-up: $expand of implicit LOINC value sets (`?fhir_vs=`) on the same provider.