### PR TITLE
FHIR CodeSystem $lookup / $validate-code response completeness

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
@@ -19,6 +19,7 @@ import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.ConceptSnapshot;
 import org.termx.ts.codesystem.ConceptQueryParams;
 import org.termx.ts.codesystem.Designation;
+import org.termx.ts.codesystem.EntityProperty;
 import org.termx.ts.codesystem.EntityPropertyType;
 import org.termx.ts.codesystem.EntityPropertyValue;
 import com.kodality.zmei.fhir.FhirMapper;
@@ -33,9 +34,11 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
@@ -44,6 +47,8 @@ import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
 public class CodeSystemLookupOperation implements InstanceOperationDefinition, TypeOperationDefinition {
   private static final String UCUM = "ucum";
   private static final String UCUM_URI = "http://unitsofmeasure.org";
+  private static final String DEFINITION = "definition";
+  private static final String NOT_SELECTABLE = "notSelectable";
 
   private final ConceptService conceptService;
   private final CodeSystemService codeSystemService;
@@ -121,32 +126,43 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
     Concept c = conceptService.query(cQueryParams).findFirst()
         .orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "Concept not found"));
 
+    CodeSystem cs = codeSystemService.load(csId, true).orElse(null);
     List<Designation> designations = new ArrayList<>(c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getDesignations).orElse(List.of()));
 
-    Parameters resp = new Parameters();
-    resp.addParameter(new ParametersParameter().setName("name").setValueString(c.getCodeSystem()));
-
-
     Optional<CodeSystemVersionReference> csVersion = c.getVersions().stream().findFirst().flatMap(v -> Optional.ofNullable(v.getVersions()).orElse(List.of()).stream().findFirst());
-    if (csVersion.isPresent()) {
-      resp.addParameter(new ParametersParameter().setName("version").setValueString(csVersion.map(CodeSystemVersionReference::getVersion).orElse(null)));
-    }
-
     // displayLanguage may be a comma-separated list — prefer the FIRST requested language for the display.
     String firstDisplayLanguage = StringUtils.isBlank(displayLanguage) ? null : displayLanguage.split(",")[0].trim();
     String preferredLanguage = StringUtils.firstNonBlank(firstDisplayLanguage, csVersion.map(CodeSystemVersionReference::getPreferredLanguage).orElse(null));
     Designation display = ConceptUtil.getDisplay(designations, preferredLanguage, List.of());
-    List<Designation> responseDesignations = designations.stream()
-        .filter(d -> languageMatches(d.getLanguage(), displayLanguage))
-        .toList();
+    Designation definition = designations.stream()
+        .filter(d -> DEFINITION.equals(d.getDesignationType()) && (preferredLanguage == null || preferredLanguage.equals(d.getLanguage())))
+        .findFirst().or(() -> designations.stream().filter(d -> DEFINITION.equals(d.getDesignationType())).findFirst()).orElse(null);
+
+    Parameters resp = new Parameters();
+    // name is a display name for the code system (the resource name), not its id.
+    resp.addParameter(new ParametersParameter().setName("name").setValueString(cs != null ? cs.getName() : c.getCodeSystem()));
+    resp.addParameter(new ParametersParameter().setName("code").setValueCode(code));
+    if (cs != null && StringUtils.isNotEmpty(cs.getUri())) {
+      resp.addParameter(new ParametersParameter().setName("system").setValueUri(cs.getUri()));
+    }
+    csVersion.ifPresent(v -> resp.addParameter(new ParametersParameter().setName("version").setValueString(v.getVersion())));
     resp.addParameter(new ParametersParameter().setName("display").setValueString(display != null ? display.getName() : null));
-    responseDesignations.stream().filter(d -> display != d).forEach(d -> {
-      resp.addParameter(new ParametersParameter("designation")
-          .addPart(new ParametersParameter("use").setValueCoding(new Coding(d.getDesignationType())))
-          .addPart(new ParametersParameter("value").setValueString(d.getName()))
-          .addPart(new ParametersParameter("language").setValueString(d.getLanguage()))
-      );
-    });
+    if (definition != null && StringUtils.isNotEmpty(definition.getName())) {
+      resp.addParameter(new ParametersParameter().setName("definition").setValueString(definition.getName()));
+    }
+    resp.addParameter(new ParametersParameter().setName("abstract").setValueBoolean(isAbstract(c)));
+
+    designations.stream()
+        .filter(d -> d != display && d != definition)
+        .filter(d -> languageMatches(d.getLanguage(), displayLanguage))
+        .forEach(d -> resp.addParameter(new ParametersParameter("designation")
+            .addPart(new ParametersParameter("use").setValueCoding(new Coding(d.getDesignationType())))
+            .addPart(new ParametersParameter("value").setValueString(d.getName()))
+            .addPart(new ParametersParameter("language").setValueString(d.getLanguage()))));
+
+    Map<String, String> propertyDescriptions = cs == null || cs.getProperties() == null ? Map.of() :
+        cs.getProperties().stream().filter(p -> p.getName() != null && p.getDescription() != null && !p.getDescription().isEmpty())
+            .collect(Collectors.toMap(EntityProperty::getName, p -> p.getDescription().values().stream().findFirst().orElse(null), (a, b) -> a));
 
     List<String> properties = req.getParameter().stream()
         .filter(p -> "property".equals(p.getName()))
@@ -154,11 +170,23 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
         .toList();
     List<EntityPropertyValue> propertyValues = c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getPropertyValues).orElse(List.of());
     propertyValues.stream().filter(pv -> shouldReturnProperty(properties, pv)).forEach(pv -> {
-      resp.addParameter(new ParametersParameter("property")
-          .addPart(new ParametersParameter("code").setValueString(pv.getEntityProperty()))
-          .addPart(toParameter(pv.getEntityPropertyType(), pv.getValue(), c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getSnapshot).orElse(null), displayLanguage)));
+      ParametersParameter property = new ParametersParameter("property")
+          .addPart(new ParametersParameter("code").setValueCode(pv.getEntityProperty()))
+          .addPart(toParameter(pv.getEntityPropertyType(), pv.getValue(), c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getSnapshot).orElse(null), displayLanguage));
+      String description = propertyDescriptions.get(pv.getEntityProperty());
+      if (StringUtils.isNotEmpty(description)) {
+        property.addPart(new ParametersParameter("description").setValueString(description));
+      }
+      resp.addParameter(property);
     });
     return resp;
+  }
+
+  /** A concept is abstract (not for direct use) when it carries a {@code notSelectable=true} property. */
+  private static boolean isAbstract(Concept c) {
+    return c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getPropertyValues).orElse(List.of()).stream()
+        .filter(pv -> NOT_SELECTABLE.equals(pv.getEntityProperty()))
+        .anyMatch(pv -> Boolean.TRUE.equals(pv.getValue()) || "true".equalsIgnoreCase(String.valueOf(pv.getValue())));
   }
 
   private boolean shouldReturnProperty(List<String> requestedProperties, EntityPropertyValue propertyValue) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -143,8 +143,21 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
           .addParameter(new ParametersParameter("message").setValueString("The display '" + display + "' is incorrect"));
     }
 
-    return new Parameters()
-        .addParameter(new ParametersParameter("result").setValueBoolean(true));
+    // A successful validation echoes the resolved coding so the client can confirm what was validated.
+    CodeSystem cs = codeSystemService.load(csId).orElse(null);
+    Parameters result = new Parameters()
+        .addParameter(new ParametersParameter("result").setValueBoolean(true))
+        .addParameter(new ParametersParameter("code").setValueCode(code));
+    if (cs != null && StringUtils.isNotEmpty(cs.getUri())) {
+      result.addParameter(new ParametersParameter("system").setValueUri(cs.getUri()));
+    }
+    if (StringUtils.isNotEmpty(conceptDisplay)) {
+      result.addParameter(new ParametersParameter("display").setValueString(conceptDisplay));
+    }
+    if (StringUtils.isNotEmpty(versionUri)) {
+      result.addParameter(new ParametersParameter("version").setValueString(versionUri));
+    }
+    return result;
   }
 
   private static Parameters error(String message) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemUcumOperationsTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemUcumOperationsTest.groovy
@@ -31,6 +31,8 @@ class CodeSystemUcumOperationsTest extends Specification {
 
   def setup() {
     SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+    codeSystemService.load(_) >> Optional.of(new CodeSystem().setId("ucum").setUri("http://unitsofmeasure.org").setName("UCUM"))
+    codeSystemService.load(_, _) >> Optional.of(new CodeSystem().setId("ucum").setUri("http://unitsofmeasure.org").setName("UCUM"))
   }
 
   def cleanup() {
@@ -125,7 +127,7 @@ class CodeSystemUcumOperationsTest extends Specification {
 
     then:
     valuesByUse["abbreviation"] == "ml"
-    valuesByUse["definition"] == "Milliliter"
+    parameters.findParameter("definition").orElseThrow().valueString == "Milliliter"
   }
 
   def "lookup auto-loads supplements by displayLanguage"() {
@@ -180,7 +182,7 @@ class CodeSystemUcumOperationsTest extends Specification {
     then:
     parameters.findParameter("display").orElseThrow().valueString == "milliliter"
     valuesByUse["abbreviation"] == "ml"
-    valuesByUse["definition"] == "Milliliter"
+    parameters.findParameter("definition").orElseThrow().valueString == "Milliliter"
     designationLanguages == ["lt"] as Set
   }
 
@@ -249,7 +251,7 @@ class CodeSystemUcumOperationsTest extends Specification {
     def response = lookupOperation.run(new ResourceContent(FhirMapper.toJson(request), "json"))
     def parameters = FhirMapper.fromJson(response.value, Parameters)
     def properties = parameters.parameter.findAll { it.name == "property" }
-    def propertyCodes = properties.collect { property -> property.part.find { it.name == "code" }?.valueString }.toSet()
+    def propertyCodes = properties.collect { property -> property.part.find { it.name == "code" }?.valueCode }.toSet()
 
     then:
     propertyCodes == ["status", "comment"] as Set
@@ -316,7 +318,7 @@ class CodeSystemUcumOperationsTest extends Specification {
     then:
     parametersWithoutProperty.parameter.findAll { it.name == "property" }.isEmpty()
     parametersWithProperty.parameter.findAll { it.name == "property" }.size() == 1
-    parametersWithProperty.parameter.find { it.name == "property" }.part.find { it.name == "code" }.valueString == "status"
+    parametersWithProperty.parameter.find { it.name == "property" }.part.find { it.name == "code" }.valueCode == "status"
   }
 
   def "lookup honours a comma-separated displayLanguage (designations for each language, display from the first)"() {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperationTest.groovy
@@ -31,6 +31,7 @@ class CodeSystemValidateCodeOperationTest extends Specification {
   def setup() {
     SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
     codeSystemService.query(_) >> new QueryResult([new CodeSystem().setId("snomed-ct")])
+    codeSystemService.load(_) >> Optional.of(new CodeSystem().setId("snomed-ct").setUri("http://snomed.info/sct").setName("SNOMED CT"))
   }
 
   def cleanup() {


### PR DESCRIPTION
Closes the CodeSystem-operation half of #226. These operations resolved codes correctly but their responses omitted parameters the tx-ecosystem suite (and the FHIR spec) expect — the reason loaded-content lookup/validate tests scored 0 on *shape*, not logic. Verified live against the loaded `simple` fixture.

## $lookup — now returns the full set
Before: `[name, version, display, designation…]`. After (live, `simple#code2a`):
```
[abstract, code, definition, designation, display, name, property, system, version]
name=SimpleTestCodeSystem  code=code2a  system=…/CodeSystem/simple
display=Display 2a  definition="My first second level code"  abstract=false
```
- **code** (echo), **system** (the code system uri), **abstract** (from a `notSelectable` property)
- **definition** — extracted from the concept's definition designation (and no longer also emitted as a plain `designation`)
- **name** — the code system's display *name* (was its id)
- **property.description** — from the code system's property definitions
- **property.code** as `valueCode` (was `valueString`) to match the FHIR `code` type

## $validate-code — success now echoes the resolved coding
Before: `[result]`. After: `[result, code, system, display, version]` (version when a version was resolved). ValueSet `$validate-code` already returned the full set — this is the CodeSystem side.

## Tests
- UCUM operation tests updated for the more-conformant shape (definition as a top-level param; `property.code` as `valueCode`).
- `:terminology:test` 245/0.

## Follow-ups (separate)
- `$batch-validate-code` (unimplemented operation).
- Full per-concept property set (this concept returned 1 property where the suite expects more — a concept-property-completeness question, distinct from response shape).