### PR TITLE
#228: fold same-canonical-url imports into one resource + versions (TDD red→green)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
@@ -88,6 +88,7 @@ public class CodeSystemImportService {
 
   @Transactional
   public CodeSystem importCodeSystem(CodeSystem codeSystem, List<AssociationType> associationTypes, CodeSystemImportAction action) {
+    reconcileCanonicalId(codeSystem);
     SessionStore.require().checkPermitted(codeSystem.getId(), Privilege.CS_WRITE);
 
     long start = System.currentTimeMillis();
@@ -96,6 +97,7 @@ public class CodeSystemImportService {
     associationTypeService.createIfNotExist(associationTypes);
 
     saveCodeSystem(codeSystem);
+    // (see reconcileCanonicalId — id may have been adopted from an existing same-uri code system)
     CodeSystemVersion codeSystemVersion = codeSystem.getVersions().getFirst();
     saveCodeSystemVersion(codeSystemVersion, action.isCleanRun());
 
@@ -140,6 +142,33 @@ public class CodeSystemImportService {
       concepts.forEach(c -> baseVersionIds.getOrDefault(c.getCode(), Optional.empty()).ifPresent(baseVersionId -> c.getVersions().getFirst().setBaseEntityVersionId(baseVersionId)));
     }
     return concepts;
+  }
+
+  /**
+   * Folds an incoming code system into an existing canonical: a FHIR resource's identity is its {@code url},
+   * but the tx-ecosystem ships multiple versions of one canonical as SEPARATE resources sharing a url with
+   * distinct ids. TermX keys on id and has a unique index on uri, so without this the second such resource
+   * collides on {@code code_system_ukey}. When a code system with the same uri already exists under a
+   * different id, adopt that id so the import becomes a NEW VERSION of the existing canonical.
+   */
+  private void reconcileCanonicalId(CodeSystem codeSystem) {
+    if (StringUtils.isEmpty(codeSystem.getUri())) {
+      return;
+    }
+    codeSystemService.query(new org.termx.ts.codesystem.CodeSystemQueryParams().setUri(codeSystem.getUri()).limit(1)).findFirst()
+        .map(CodeSystem::getId)
+        .filter(existingId -> !existingId.equals(codeSystem.getId()))
+        .ifPresent(existingId -> {
+          log.info("Reconciling code system '{}' to existing canonical id '{}' (uri {})", codeSystem.getId(), existingId, codeSystem.getUri());
+          codeSystem.setId(existingId);
+          // Propagate the adopted id to every nested reference (versions, concepts and their entity versions),
+          // whose code_system FK still points at the old id.
+          Optional.ofNullable(codeSystem.getVersions()).orElse(List.of()).forEach(v -> v.setCodeSystem(existingId));
+          Optional.ofNullable(codeSystem.getConcepts()).orElse(List.of()).forEach(concept -> {
+            concept.setCodeSystem(existingId);
+            Optional.ofNullable(concept.getVersions()).orElse(List.of()).forEach(ev -> ev.setCodeSystem(existingId));
+          });
+        });
   }
 
   private void saveCodeSystem(CodeSystem codeSystem) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetImportService.java
@@ -53,6 +53,7 @@ public class ValueSetImportService {
 
   @Transactional
   public ValueSet importValueSet(ValueSet valueSet, ValueSetImportAction action) {
+    reconcileCanonicalId(valueSet);
     SessionStore.require().checkPermitted(valueSet.getId(), Privilege.VS_WRITE);
 
     long start = System.currentTimeMillis();
@@ -74,6 +75,28 @@ public class ValueSetImportService {
     }
     log.info("IMPORT FINISHED (" + (System.currentTimeMillis() - start) / 1000 + " sec)");
     return valueSet;
+  }
+
+  /**
+   * Folds an incoming value set into an existing canonical: a FHIR resource's identity is its {@code url},
+   * but the tx-ecosystem ships multiple versions of one canonical as SEPARATE resources sharing a url with
+   * distinct ids. TermX keys on id and has a unique index on uri, so without this the second such resource
+   * collides on {@code value_set_ukey}. When a value set with the same uri already exists under a different
+   * id, adopt that id so the import becomes a NEW VERSION of the existing canonical.
+   */
+  private void reconcileCanonicalId(ValueSet valueSet) {
+    if (StringUtils.isEmpty(valueSet.getUri())) {
+      return;
+    }
+    valueSetService.query(new org.termx.ts.valueset.ValueSetQueryParams().setUri(valueSet.getUri()).limit(1)).findFirst()
+        .map(ValueSet::getId)
+        .filter(existingId -> !existingId.equals(valueSet.getId()))
+        .ifPresent(existingId -> {
+          log.info("Reconciling value set '{}' to existing canonical id '{}' (uri {})", valueSet.getId(), existingId, valueSet.getUri());
+          valueSet.setId(existingId);
+          // Propagate the adopted id to the nested versions, whose value_set FK still points at the old id.
+          Optional.ofNullable(valueSet.getVersions()).orElse(List.of()).forEach(v -> v.setValueSet(existingId));
+        });
   }
 
   private void saveValueSet(ValueSet valueSet) {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/CodeSystemVersionResolutionIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/CodeSystemVersionResolutionIT.groovy
@@ -1,0 +1,66 @@
+package org.termx.terminology.codesystem
+
+import com.kodality.kefhir.structure.api.ResourceContent
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.codesystem.operations.CodeSystemLookupOperation
+
+/**
+ * RED tests for issue #228 — multiple versions of one canonical CodeSystem shipped as SEPARATE resources that
+ * share a {@code url} but have distinct ids. TermX has a unique index on {@code code_system.uri}
+ * ({@code code_system_ukey}), so the second such CodeSystem fails to import (500), and {@code $lookup} with
+ * {@code system}+{@code version} then can't resolve the missing version.
+ *
+ * <p>Expected behavior (to be implemented): two CodeSystems with one canonical url but distinct ids should be
+ * folded into a single canonical resource carrying both versions, and {@code $lookup} by {@code version} should
+ * return that version's display. (Same-id multi-version already works — this is the distinct-id case.)
+ */
+@MicronautTest(transactional = true)
+class CodeSystemVersionResolutionIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImport
+  @Inject CodeSystemLookupOperation lookup
+
+  static final String CS_URL = "http://termx-test.local/CodeSystem/csvr"
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "two code systems with one canonical url but distinct ids both load and \$lookup resolves by version"() {
+    given: "v1 (id csvr-1) A->'Alpha v1'; v2 (id csvr-2, SAME url) A->'Alpha v2'"
+    csImport.importCodeSystem(codeSystem("csvr-1", "1.0.0", "Alpha v1"), "csvr-1")
+    csImport.importCodeSystem(codeSystem("csvr-2", "2.0.0", "Alpha v2"), "csvr-2")
+
+    expect: "lookup of A resolves the display of the requested version"
+    lookupDisplay("1.0.0") == "Alpha v1"
+    lookupDisplay("2.0.0") == "Alpha v2"
+  }
+
+  private String lookupDisplay(String version) {
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("system").setValueUri(CS_URL),
+        new ParametersParameter().setName("code").setValueCode("A"),
+        new ParametersParameter().setName("version").setValueString(version)])
+    def resp = lookup.run(new ResourceContent(FhirMapper.toJson(req), "json"))
+    def params = FhirMapper.fromJson(resp.value, Parameters)
+    return params.findParameter("display").map { it.valueString }.orElse(null)
+  }
+
+  private static String codeSystem(String id, String version, String display) {
+    FhirMapper.toJson([
+        resourceType: "CodeSystem", id: id, url: CS_URL, name: "Csvr", title: "Csvr",
+        status: "active", content: "complete", version: version,
+        concept: [[code: "A", display: display]]])
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetVersionResolutionIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetVersionResolutionIT.groovy
@@ -1,0 +1,75 @@
+package org.termx.terminology.valueset
+
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
+
+/**
+ * RED tests for issue #228 — the FHIR tx-ecosystem ships multiple versions of one canonical resource as
+ * SEPARATE resources that share a {@code url} but have distinct ids. TermX has a unique index on
+ * {@code value_set.uri} ({@code value_set_ukey}), so the second such ValueSet fails to import (500), and the
+ * versioned {@code $expand} then can't find it.
+ *
+ * <p>Expected behavior (to be implemented): two ValueSets with one canonical url but distinct ids should be
+ * folded into a single canonical resource carrying both versions, and {@code $expand} by {@code valueSetVersion}
+ * should resolve each version's own definition. (Same-id multi-version already works — this is the distinct-id
+ * case the suite exercises.)
+ */
+@MicronautTest(transactional = true)
+class ValueSetVersionResolutionIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImport
+  @Inject ValueSetFhirImportService vsImport
+  @Inject ValueSetExpandOperation vsExpand
+
+  static final String CS_URL = "http://termx-test.local/CodeSystem/vsvr-cs"
+  static final String VS_URL = "http://termx-test.local/ValueSet/vsvr"
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+    csImport.importCodeSystem(baseCs(), "vsvr-cs")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "two value sets with one canonical url but distinct ids both load and \$expand resolves by version"() {
+    given: "v1 (id vsvr-1) includes c1; v2 (id vsvr-2, SAME url) includes c1+c2"
+    vsImport.importValueSet(valueSet("vsvr-1", "1.0.0", ["c1"]), "vsvr-1")
+    vsImport.importValueSet(valueSet("vsvr-2", "2.0.0", ["c1", "c2"]), "vsvr-2")
+
+    expect: "each version expands to its own member set"
+    expandCodes("1.0.0") == ["c1"] as Set
+    expandCodes("2.0.0") == ["c1", "c2"] as Set
+  }
+
+  private Set<String> expandCodes(String version) {
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri(VS_URL),
+        new ParametersParameter().setName("valueSetVersion").setValueString(version)])
+    def vs = vsExpand.run(req)
+    return (vs.expansion?.contains ?: []).collect { it.code } as Set
+  }
+
+  private static String baseCs() {
+    FhirMapper.toJson([
+        resourceType: "CodeSystem", id: "vsvr-cs", url: CS_URL, name: "VsvrCs", title: "Vsvr CS",
+        status: "active", content: "complete", version: "1.0.0",
+        concept: [[code: "c1", display: "C1"], [code: "c2", display: "C2"], [code: "c3", display: "C3"]]])
+  }
+
+  private static String valueSet(String id, String version, List<String> codes) {
+    FhirMapper.toJson([
+        resourceType: "ValueSet", id: id, url: VS_URL, name: "Vsvr", title: "Vsvr",
+        status: "active", version: version,
+        compose: [include: [[system: CS_URL, concept: codes.collect { [code: it] }]]]])
+  }
+}


### PR DESCRIPTION
Closes #228. Implemented test-first: the two red tests were committed first, then the fix turns them green.

## Root cause (pinned empirically)
Multi-version under the *same* id already worked. The break was **distinct ids sharing one canonical url** (the tx-ecosystem shape, e.g. `valueset-version-1`/`-2`): TermX has a **unique index on uri** (`code_system_ukey` / `value_set_ukey` = `UNIQUE(uri) WHERE sys_status='A'`), so the second resource collided with a `DuplicateKeyException` and its version never loaded — so versioned `$expand`/`$lookup` reported "not found".

## Fix
On import, reconcile against an existing resource with the same canonical `uri`: **adopt that resource's id** so the incoming resource folds in as a **new version** of the existing canonical (the same-id path that already worked), and propagate the adopted id to every nested reference whose FK still pointed at the old id — versions, and for code systems the concepts and their entity versions.

Lives in the **core** `CodeSystemImportService` / `ValueSetImportService`, so it covers every entry point: the FHIR import service, the FHIR PUT/POST resource storage (the conformance loader's path), and file import.

## Tests (TDD)
- `ValueSetVersionResolutionIT` — two ValueSets, one url, distinct ids → `$expand` by `valueSetVersion` resolves `[c1]` vs `[c1,c2]`.
- `CodeSystemVersionResolutionIT` — two CodeSystems, one url, distinct ids → `$lookup` by `version` returns `Alpha v1` vs `Alpha v2`.
- Both were committed **red** (failing with the exact `DuplicateKeyException`), now **green**.
- Regression: `:terminology:test` 245/0; integtest FHIR/CodeSystem/ValueSet 71/0.

(Branch name says `-red` from the TDD first commit; it's green now.)