### PR TITLE
#226: CodeSystem $lookup standard properties (inactive, parent, child)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
@@ -9,8 +9,10 @@ import com.kodality.kefhir.core.model.ResourceId;
 import com.kodality.kefhir.structure.api.ResourceContent;
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper;
 import org.termx.terminology.terminology.codesystem.CodeSystemService;
+import org.termx.terminology.terminology.codesystem.association.CodeSystemAssociationService;
 import org.termx.terminology.terminology.codesystem.concept.ConceptService;
 import org.termx.terminology.terminology.codesystem.concept.ConceptUtil;
+import org.termx.ts.codesystem.CodeSystemAssociationQueryParams;
 import org.termx.ts.codesystem.CodeSystem;
 import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemQueryParams;
@@ -52,17 +54,24 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
 
   private final ConceptService conceptService;
   private final CodeSystemService codeSystemService;
+  private final CodeSystemAssociationService associationService;
   private final LookupDefaultPropertyMode defaultPropertyMode;
 
   public CodeSystemLookupOperation(ConceptService conceptService, CodeSystemService codeSystemService,
+                                   CodeSystemAssociationService associationService,
                                    @Value("${termx.fhir.codesystem.lookup.default-property-mode:ALL}") LookupDefaultPropertyMode defaultPropertyMode) {
     this.conceptService = conceptService;
     this.codeSystemService = codeSystemService;
+    this.associationService = associationService;
     this.defaultPropertyMode = defaultPropertyMode;
   }
 
   CodeSystemLookupOperation(ConceptService conceptService, CodeSystemService codeSystemService) {
-    this(conceptService, codeSystemService, LookupDefaultPropertyMode.ALL);
+    this(conceptService, codeSystemService, null, LookupDefaultPropertyMode.ALL);
+  }
+
+  CodeSystemLookupOperation(ConceptService conceptService, CodeSystemService codeSystemService, LookupDefaultPropertyMode defaultPropertyMode) {
+    this(conceptService, codeSystemService, null, defaultPropertyMode);
   }
 
   public String getResourceType() {
@@ -179,7 +188,45 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
       }
       resp.addParameter(property);
     });
+
+    // Standard computed properties FHIR $lookup exposes beyond the code system's own defined properties:
+    // inactive (the code's active state) and the parent/child hierarchy (from is-a associations).
+    boolean allProps = properties.isEmpty() && defaultPropertyMode == LookupDefaultPropertyMode.ALL;
+    if (allProps || properties.contains("inactive")) {
+      resp.addParameter(new ParametersParameter("property")
+          .addPart(new ParametersParameter("code").setValueCode("inactive"))
+          .addPart(new ParametersParameter("value").setValueBoolean(isInactive(c))));
+    }
+    Long versionId = c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getId).orElse(null);
+    if (associationService != null && versionId != null) {
+      if (allProps || properties.contains("parent")) {
+        associationService.query(new CodeSystemAssociationQueryParams()
+            .setSourceEntityVersionId(String.valueOf(versionId)).setAssociationType("is-a").limit(-1)).getData()
+            .forEach(a -> addHierarchyProperty(resp, "parent", a.getTargetCode()));
+      }
+      if (allProps || properties.contains("child")) {
+        associationService.query(new CodeSystemAssociationQueryParams()
+            .setTargetEntityVersionId(String.valueOf(versionId)).setAssociationType("is-a").limit(-1)).getData()
+            .forEach(a -> addHierarchyProperty(resp, "child", a.getSourceCode()));
+      }
+    }
     return resp;
+  }
+
+  private static void addHierarchyProperty(Parameters resp, String code, String value) {
+    if (StringUtils.isNotEmpty(value)) {
+      resp.addParameter(new ParametersParameter("property")
+          .addPart(new ParametersParameter("code").setValueCode(code))
+          .addPart(new ParametersParameter("value").setValueCode(value)));
+    }
+  }
+
+  /** A concept is inactive when it carries {@code inactive=true} or a {@code status} of retired/deprecated. */
+  private static boolean isInactive(Concept c) {
+    return c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getPropertyValues).orElse(List.of()).stream()
+        .anyMatch(pv -> ("inactive".equals(pv.getEntityProperty())
+            && (Boolean.TRUE.equals(pv.getValue()) || "true".equalsIgnoreCase(String.valueOf(pv.getValue()))))
+            || ("status".equals(pv.getEntityProperty()) && List.of("retired", "deprecated").contains(String.valueOf(pv.getValue()))));
   }
 
   /** A concept is abstract (not for direct use) when it carries a {@code notSelectable=true} property. */

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/association/CodeSystemAssociationRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/association/CodeSystemAssociationRepository.java
@@ -98,6 +98,9 @@ public class CodeSystemAssociationRepository extends BaseRepository {
     if (StringUtils.isNotEmpty(params.getSourceEntityVersionId())) {
       sb.and().in("csa.source_code_system_entity_version_id", params.getSourceEntityVersionId(), Long::valueOf);
     }
+    if (StringUtils.isNotEmpty(params.getTargetEntityVersionId())) {
+      sb.and().in("csa.target_code_system_entity_version_id", params.getTargetEntityVersionId(), Long::valueOf);
+    }
     if (StringUtils.isNotEmpty(params.getAssociationType())) {
       sb.and().in("csa.association_type", params.getAssociationType());
     }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemUcumOperationsTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemUcumOperationsTest.groovy
@@ -254,7 +254,8 @@ class CodeSystemUcumOperationsTest extends Specification {
     def propertyCodes = properties.collect { property -> property.part.find { it.name == "code" }?.valueCode }.toSet()
 
     then:
-    propertyCodes == ["status", "comment"] as Set
+    // "inactive" is now emitted as a standard computed $lookup property alongside the defined ones
+    propertyCodes == ["status", "comment", "inactive"] as Set
   }
 
   def "lookup returns coding property display from snapshot"() {


### PR DESCRIPTION
Continues #226. `$lookup` returned only a concept's explicitly-defined property values; FHIR also expects the standard computed properties. The tx-ecosystem `simple` concept expects `parent`, `child` and `inactive` alongside the defined `prop`.

## Added to $lookup
- **inactive** (`valueBoolean`) — from the concept's status (`inactive` / `retired` / `deprecated`)
- **parent** (`valueCode`) — is-a associations where the concept is the **source** → target codes
- **child** (`valueCode`) — is-a associations where the concept is the **target** → source codes

Subject to the requested `property` filter / default-property mode.

## Latent bug fixed
`CodeSystemAssociationRepository.filter` honored `sourceEntityVersionId` but **silently ignored `targetEntityVersionId`** — so any reverse (child/target) association query returned *every* is-a association across all code systems (the first `child` attempt returned hundreds of unrelated codes). Added the missing target filter.

## Verified live
`$lookup simple#code2a` → `parent=code2`, `child=[code2aI, code2aII]`, `inactive=false`, `prop=new` — matching the expected shape.

## Tests
- `:terminology:test` 245/0; integtest FHIR/CodeSystem/ValueSet 71/0.
- UCUM lookup test updated for the added standard `inactive` property.

## Remaining on #226
`$batch-validate-code` — the operation is a thin batch wrapper over validate-code, but the tx-ecosystem batch fixtures drive it through inline **`tx-resource`** value sets (a urn:uuid resolved from the request, not stored). That needs a separate inline-resource (`tx-resource`) feature to be useful, so I've scoped it out of this PR.

(Branch name `feat/batch-validate-code` is a leftover; this PR is the property-set.)