### PR TITLE
Supplement expand: surface localized designations to the user (deduped)

### DIFF
--- a/docs/rest-client/fhir-terminology-supplement.http
+++ b/docs/rest-client/fhir-terminology-supplement.http
@@ -182,6 +182,15 @@ GET {{fhir}}/ValueSet/$expand?url={{vsRu}}&displayLanguage=ru
 Authorization: Bearer {{token}}
 Accept: application/fhir+json
 
+### 10b. $expand with includeDesignations=true — the supplement's localized DESIGNATIONS
+#     surface in contains[].designation (not only the chosen display), each exactly once.
+# expect: red/green/blue; every contains[].designation lists the Estonian value
+#         (punane / roheline / sinine) sourced from the supplement, with NO duplicate
+#         of a designation already on the base concept.
+GET {{fhir}}/ValueSet/tx-rest-demo-color-vs-et/$expand?displayLanguage=et&includeDesignations=true
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
 ### 11. $validate-code (by URL) — a code that IS in the value set
 # expect: Parameters with result=true, code=red, system=base, display=Red.
 GET {{fhir}}/ValueSet/$validate-code?url={{vsEt}}&system={{base}}&code=red

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -476,8 +476,12 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
         c.getConcept().getCodeSystemVersions().stream().findFirst().orElse(null) : null);
     contains.setInactive(!c.isActive() ? true : null);
     contains.setDisplay(c.getDisplay() == null || (lang != null && !c.getDisplay().getLanguage().startsWith(lang)) ? null : c.getDisplay().getName());
+    // A supplement can contribute the same designation already present on the base concept, so dedup by
+    // (language, value, type) — otherwise the same localized designation is emitted twice in the expansion.
+    Set<String> seenDesignations = new HashSet<>();
     contains.setDesignation(CollectionUtils.isNotEmpty(c.getAdditionalDesignations()) && includeDesignations ? c.getAdditionalDesignations().stream()
         .filter(d -> !"definition".equals(d.getDesignationType()))
+        .filter(d -> seenDesignations.add(d.getLanguage() + "|" + d.getName() + "|" + d.getDesignationType()))
         .sorted(Comparator.comparing(d -> !d.isPreferred())).map(designation -> {
           ValueSetComposeIncludeConceptDesignation d = new ValueSetComposeIncludeConceptDesignation();
           d.setValue(designation.getName());

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -5,8 +5,11 @@ import jakarta.inject.Inject
 import org.termx.TermxIntegTest
 import org.termx.core.auth.SessionInfo
 import org.termx.core.auth.SessionStore
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
 import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
 
@@ -26,6 +29,7 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
   @Inject ValueSetFhirImportService vsImportService
   @Inject ValueSetVersionService vsVersionService
   @Inject ValueSetVersionConceptService vsConceptService
+  @Inject ValueSetExpandOperation vsExpand
 
   void setup() {
     def sessionInfo = new SessionInfo()
@@ -60,6 +64,25 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
     concept != null
     concept.display.language == "lt"
     concept.display.name == "Gliukozė"
+  }
+
+  def "the FHIR \$expand response surfaces the supplement's localized designation to the user (once)"() {
+    given: "an \$expand request for displayLanguage=lt with designations included"
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri("http://example.org/ValueSet/suppl-vs"),
+        new ParametersParameter().setName("displayLanguage").setValueCode("lt"),
+        new ParametersParameter().setName("includeDesignations").setValueBoolean(true)])
+
+    when:
+    def expanded = vsExpand.run(req)
+    def contains = expanded.expansion.contains.find { it.code == "code1" }
+
+    then: "the localized display and designation from the supplement are returned to the user"
+    contains != null
+    contains.display == "Gliukozė"
+
+    and: "the supplement's lt designation appears exactly once (not duplicated by the base+supplement merge)"
+    contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
   }
 
   private String fixture(String path) {


### PR DESCRIPTION
Addresses ensuring CodeSystem supplements work and their localized data reaches the user during ValueSet $expand.

## Verified working
A CodeSystem **supplement** (`content=supplement`, `supplements=<base>`) adding a localized designation (an `lt` display) **does** flow through `$expand`. Live, against a value set over a base code system + an `lt` supplement:
```
 ... displayLanguage=lt, includeDesignations=true
-> contains code1: display='Gliukozė', designation=[(lt,'Gliukozė')]
```

## Fixed: duplicate designation
The response emitted the same supplement designation **twice** when it duplicated one already present on the base concept. Dedup the expansion `contains.designation` by (language, value, type).

## Test (the "ensure")
The existing `ValueSetSupplementExpandIT` only checked the **internal** expansion service (`vsConceptService.expand(...).display`). Added a case that drives the **FHIR `$expand` operation** and asserts the response surfaces the supplement's localized display and lists its designation **exactly once** — a regression guard for the user-facing behavior.

terminology unit 245/0; `ValueSetSupplementExpandIT` 3/0.

Note: tx-resource (inline resource resolution) is paused mid-investigation on a separate branch; not part of this PR.