### PR TITLE
FHIR $expand: resolve url against inline tx-resource ValueSets

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -122,6 +122,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       return snomedResp;
     }
 
+    // 3b. tx-resource: the FHIR validator passes referenced resources inline. When `url` names a ValueSet
+    //     supplied as a tx-resource, expand that inline definition instead of looking it up in storage.
+    com.kodality.zmei.fhir.resource.terminology.ValueSet txResourceVs = findTxResourceValueSet(req, url);
+    if (txResourceVs != null) {
+      return expandInline(txResourceVs, req);
+    }
+
     // 4. Stored ValueSet lookup.
     ValueSetQueryParams vsParams = new ValueSetQueryParams();
     vsParams.setUri(url);
@@ -219,6 +226,20 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     }
 
     return mapper.toFhir(vs, version, provenances, snapshot, req);
+  }
+
+  /** Finds a ValueSet supplied inline via a tx-resource parameter whose url matches the requested url. */
+  private static com.kodality.zmei.fhir.resource.terminology.ValueSet findTxResourceValueSet(Parameters req, String url) {
+    if (req.getParameter() == null || url == null) {
+      return null;
+    }
+    return req.getParameter().stream()
+        .filter(p -> "tx-resource".equals(p.getName()))
+        .map(ParametersParameter::getResource)
+        .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.ValueSet)
+        .map(r -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) r)
+        .filter(vs -> url.equals(vs.getUrl()))
+        .findFirst().orElse(null);
   }
 
   private com.kodality.zmei.fhir.resource.terminology.ValueSet expandInline(

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandTxResourceIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandTxResourceIT.groovy
@@ -1,0 +1,62 @@
+package org.termx.terminology.valueset
+
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
+
+/**
+ * tx-resource: the FHIR validator passes referenced resources inline so the server need not have them
+ * stored. A {@code $expand} whose {@code url} names a ValueSet supplied as a {@code tx-resource} parameter
+ * must expand that inline definition (resolving its included, stored CodeSystem) rather than 404.
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandTxResourceIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImport
+  @Inject ValueSetExpandOperation vsExpand
+
+  static final String CS_URL = "http://termx-test.local/CodeSystem/txr-cs"
+  static final String VS_URL = "http://termx-test.local/ValueSet/txr-vs"
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+    csImport.importCodeSystem(FhirMapper.toJson([
+        resourceType: "CodeSystem", id: "txr-cs", url: CS_URL, name: "TxrCs", title: "Txr CS",
+        status: "active", content: "complete", version: "1.0.0",
+        concept: [[code: "c1", display: "C1"], [code: "c2", display: "C2"]]]), "txr-cs")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "\$expand resolves a url against an inline tx-resource ValueSet (never stored)"() {
+    given: "an \$expand for a VS url that is NOT stored, with that VS supplied inline as a tx-resource"
+    def inlineVs = [resourceType: "ValueSet", url: VS_URL, status: "active",
+                    compose: [include: [[system: CS_URL, concept: [[code: "c1"]]]]]]
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri(VS_URL),
+        new ParametersParameter().setName("tx-resource").setResource(FhirMapper.fromJson(FhirMapper.toJson(inlineVs), com.kodality.zmei.fhir.resource.terminology.ValueSet)),
+    ])
+
+    when:
+    def expanded = vsExpand.run(req)
+
+    then: "it expands the inline definition rather than failing to find the (unstored) value set"
+    expanded.expansion.contains*.code as Set == ["c1"] as Set
+  }
+
+  def "without the tx-resource the same unstored url is not found"() {
+    when:
+    vsExpand.run(new Parameters().setParameter([new ParametersParameter().setName("url").setValueUri(VS_URL)]))
+
+    then:
+    thrown(Exception)
+  }
+}


### PR DESCRIPTION
Resumes the tx-resource work. The FHIR validator and tx-ecosystem suite pass referenced resources **inline** via `tx-resource` parameters so the server need not have them stored.

## Gap
`$expand` already handled an inline `valueSet` *parameter*, but when a request carries `url` + a `tx-resource` ValueSet **for that url**, the url path 404'd (`value set not found`).

## Fix
Resolve the requested `url` against any `tx-resource` ValueSet in the request and expand that inline definition (reusing the existing `expandInline`), inserted before the stored-VS lookup.

## Verified live
The tx-ecosystem `include-expand-combo` fixture (`url=…/include-combo` + an inline `tx-resource` ValueSet, with only the referenced `simple` CodeSystem stored) → expands to 3 codes (`female/male/other`) instead of 404.

## Tests
- `ValueSetExpandTxResourceIT`: expands a url against an inline tx-resource VS (never stored); and the same url without the tx-resource is not found.
- terminology + integtest ValueSet/FHIR suites: 143/0.

## Follow-up (scoped out)
`tx-resource` for `$validate-code` (CodeSystem + ValueSet) and `$batch-validate-code` — those operations have no inline path yet, so they need their own inline-resolution work (the iso3166 and batch fixtures drive validate, not expand).