### PR TITLE
FHIR $batch-validate-code for CodeSystem and ValueSet

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/BatchValidateCodeSupport.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/BatchValidateCodeSupport.java
@@ -1,0 +1,60 @@
+package org.termx.terminology.fhir;
+
+import com.kodality.kefhir.core.exception.FhirException;
+import com.kodality.zmei.fhir.resource.other.Parameters;
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Shared envelope for the FHIR {@code $batch-validate-code} operation (CodeSystem and ValueSet). The HL7
+ * validator batches many code validations into a single request: a {@code Parameters} with one
+ * {@code validation} part per code, each carrying that code's {@code $validate-code} input as a nested
+ * {@code Parameters} resource, plus shared inputs (e.g. {@code tx-resource}, {@code displayLanguage}) at the
+ * batch top level. The response mirrors it — one {@code validation} part per input, in order, each holding
+ * the standard {@code $validate-code} result as a nested {@code Parameters}.
+ */
+public final class BatchValidateCodeSupport {
+  private static final String VALIDATION = "validation";
+
+  private BatchValidateCodeSupport() {
+  }
+
+  public static Parameters run(Parameters batch, Function<Parameters, Parameters> validateCode) {
+    List<ParametersParameter> all = batch.getParameter() == null ? List.of() : batch.getParameter();
+    List<ParametersParameter> shared = all.stream().filter(p -> !VALIDATION.equals(p.getName())).toList();
+
+    Parameters resp = new Parameters();
+    for (ParametersParameter item : all) {
+      if (!VALIDATION.equals(item.getName())) {
+        continue;
+      }
+      Parameters in = itemParameters(item);
+      // Shared batch-level inputs (tx-resource, displayLanguage, …) apply to every validation; per-item
+      // params come first so findParameter resolves them ahead of the shared defaults.
+      shared.forEach(in::addParameter);
+
+      Parameters result;
+      try {
+        result = validateCode.apply(in);
+      } catch (FhirException e) {
+        result = new Parameters()
+            .addParameter(new ParametersParameter("result").setValueBoolean(false))
+            .addParameter(new ParametersParameter("message").setValueString(e.getMessage()));
+      }
+      resp.addParameter(new ParametersParameter(VALIDATION).setResource(result));
+    }
+    return resp;
+  }
+
+  /** Each validation's input is a nested Parameters resource; tolerate the part-based shape as a fallback. */
+  private static Parameters itemParameters(ParametersParameter item) {
+    Parameters in = new Parameters();
+    if (item.getResource() instanceof Parameters nested && nested.getParameter() != null) {
+      nested.getParameter().forEach(in::addParameter);
+    } else if (item.getPart() != null) {
+      item.getPart().forEach(in::addParameter);
+    }
+    return in;
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemBatchValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemBatchValidateCodeOperation.java
@@ -1,0 +1,35 @@
+package org.termx.terminology.fhir.codesystem.operations;
+
+import com.kodality.kefhir.core.api.resource.TypeOperationDefinition;
+import com.kodality.kefhir.structure.api.ResourceContent;
+import com.kodality.zmei.fhir.FhirMapper;
+import com.kodality.zmei.fhir.resource.other.Parameters;
+import io.micronaut.context.annotation.Factory;
+import lombok.RequiredArgsConstructor;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.termx.terminology.fhir.BatchValidateCodeSupport;
+
+/**
+ * FHIR CodeSystem {@code $batch-validate-code}: validates many codes against code systems in one request,
+ * delegating each {@code validation} item to {@link CodeSystemValidateCodeOperation} (so inline tx-resource
+ * code systems, displays, versions etc. behave identically to the single-code operation).
+ */
+@Factory
+@RequiredArgsConstructor
+public class CodeSystemBatchValidateCodeOperation implements TypeOperationDefinition {
+  private final CodeSystemValidateCodeOperation validateCodeOperation;
+
+  public String getResourceType() {
+    return ResourceType.CodeSystem.name();
+  }
+
+  public String getOperationName() {
+    return "batch-validate-code";
+  }
+
+  public ResourceContent run(ResourceContent p) {
+    Parameters batch = FhirMapper.fromJson(p.getValue(), Parameters.class);
+    Parameters resp = BatchValidateCodeSupport.run(batch, validateCodeOperation::run);
+    return new ResourceContent(FhirMapper.toJson(resp), "json");
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -71,7 +71,7 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     return new ResourceContent(FhirMapper.toJson(resp), "json");
   }
 
-  private Parameters run(Parameters req) {
+  public Parameters run(Parameters req) {
     String url = req.findParameter("url")
         .map(pp -> StringUtils.firstNonBlank(pp.getValueUrl(), pp.getValueCanonical(), pp.getValueUri(), pp.getValueString()))
         .or(() -> req.findParameter("system")

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetBatchValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetBatchValidateCodeOperation.java
@@ -1,0 +1,35 @@
+package org.termx.terminology.fhir.valueset.operations;
+
+import com.kodality.kefhir.core.api.resource.TypeOperationDefinition;
+import com.kodality.kefhir.structure.api.ResourceContent;
+import com.kodality.zmei.fhir.FhirMapper;
+import com.kodality.zmei.fhir.resource.other.Parameters;
+import io.micronaut.context.annotation.Factory;
+import lombok.RequiredArgsConstructor;
+import org.hl7.fhir.r4.model.ResourceType;
+import org.termx.terminology.fhir.BatchValidateCodeSupport;
+
+/**
+ * FHIR ValueSet {@code $batch-validate-code}: validates many codes against value sets in one request,
+ * delegating each {@code validation} item to {@link ValueSetValidateCodeOperation} (so inline tx-resource
+ * value sets, designations, displays etc. behave identically to the single-code operation).
+ */
+@Factory
+@RequiredArgsConstructor
+public class ValueSetBatchValidateCodeOperation implements TypeOperationDefinition {
+  private final ValueSetValidateCodeOperation validateCodeOperation;
+
+  public String getResourceType() {
+    return ResourceType.ValueSet.name();
+  }
+
+  public String getOperationName() {
+    return "batch-validate-code";
+  }
+
+  public ResourceContent run(ResourceContent p) {
+    Parameters batch = FhirMapper.fromJson(p.getValue(), Parameters.class);
+    Parameters resp = BatchValidateCodeSupport.run(batch, validateCodeOperation::run);
+    return new ResourceContent(FhirMapper.toJson(resp), "json");
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/CodeSystemBatchValidateCodeIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/CodeSystemBatchValidateCodeIT.groovy
@@ -1,0 +1,63 @@
+package org.termx.terminology.codesystem
+
+import com.kodality.kefhir.structure.api.ResourceContent
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.operations.CodeSystemBatchValidateCodeOperation
+
+/**
+ * CodeSystem $batch-validate-code: many codes validated in one request. Each `validation` item carries its
+ * own $validate-code params; shared inputs (here the inline tx-resource code system) sit at the batch top
+ * level. The response holds one `validation` result per item, in order.
+ */
+@MicronautTest(transactional = true)
+class CodeSystemBatchValidateCodeIT extends TermxIntegTest {
+  @Inject CodeSystemBatchValidateCodeOperation csBatch
+
+  static final String CS_URL = "urn:test:txcsbatch"
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  private static ParametersParameter inlineCs() {
+    new ParametersParameter().setName("tx-resource").setResource(FhirMapper.fromJson(FhirMapper.toJson([
+        resourceType: "CodeSystem", id: "txcsbatch", url: CS_URL, name: "TxcsbatchCs", status: "active",
+        content: "complete", caseSensitive: true,
+        concept: [[code: "c1", display: "C1"], [code: "c2", display: "C2"]]]),
+        com.kodality.zmei.fhir.resource.terminology.CodeSystem))
+  }
+
+  private static ParametersParameter validation(String code) {
+    new ParametersParameter().setName("validation").setResource(new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri(CS_URL),
+        new ParametersParameter().setName("code").setValueCode(code)]))
+  }
+
+  def "validates each code against the shared inline code system, preserving order"() {
+    given:
+    def batch = new Parameters().setParameter([inlineCs(), validation("c1"), validation("c3"), validation("c2")])
+
+    when:
+    def content = csBatch.run(new ResourceContent(FhirMapper.toJson(batch), "json"))
+    def resp = FhirMapper.fromJson(content.getValue(), Parameters)
+    def results = resp.getParameter().findAll { it.name == "validation" }.collect { it.resource as Parameters }
+
+    then:
+    results.size() == 3
+    results[0].findParameter("result").orElseThrow().valueBoolean
+    !results[1].findParameter("result").orElseThrow().valueBoolean
+    results[2].findParameter("result").orElseThrow().valueBoolean
+    results[0].findParameter("display").orElseThrow().valueString == "C1"
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetBatchValidateCodeIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetBatchValidateCodeIT.groovy
@@ -1,0 +1,69 @@
+package org.termx.terminology.valueset
+
+import com.kodality.kefhir.structure.api.ResourceContent
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetBatchValidateCodeOperation
+
+/**
+ * ValueSet $batch-validate-code: many codes validated against value sets in one request. The value set is
+ * supplied once as a shared inline tx-resource at the batch top level; each `validation` item carries its
+ * own code/system. Responses come back one per item, in order.
+ */
+@MicronautTest(transactional = true)
+class ValueSetBatchValidateCodeIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImport
+  @Inject ValueSetBatchValidateCodeOperation vsBatch
+
+  static final String CS_URL = "http://termx-test.local/CodeSystem/vsbatch-cs"
+  static final String VS_URL = "urn:test:vsbatch-inline-vs"
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+    csImport.importCodeSystem(FhirMapper.toJson([
+        resourceType: "CodeSystem", id: "vsbatch-cs", url: CS_URL, name: "VsbatchCs", title: "Vsbatch CS",
+        status: "active", content: "complete", version: "1.0.0",
+        concept: [[code: "c1", display: "C1"], [code: "c2", display: "C2"], [code: "c3", display: "C3"]]]), "vsbatch-cs")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  private static ParametersParameter inlineVs(List<String> codes) {
+    new ParametersParameter().setName("tx-resource").setResource(FhirMapper.fromJson(FhirMapper.toJson([
+        resourceType: "ValueSet", url: VS_URL, status: "active",
+        compose: [include: [[system: CS_URL, concept: codes.collect { [code: it] }]]]]),
+        com.kodality.zmei.fhir.resource.terminology.ValueSet))
+  }
+
+  private static ParametersParameter validation(String code) {
+    new ParametersParameter().setName("validation").setResource(new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri(VS_URL),
+        new ParametersParameter().setName("code").setValueCode(code),
+        new ParametersParameter().setName("system").setValueUri(CS_URL)]))
+  }
+
+  def "validates each code against the shared inline value set, preserving order"() {
+    given:
+    def batch = new Parameters().setParameter([inlineVs(["c1", "c2"]), validation("c1"), validation("c3"), validation("c2")])
+
+    when:
+    def content = vsBatch.run(new ResourceContent(FhirMapper.toJson(batch), "json"))
+    def resp = FhirMapper.fromJson(content.getValue(), Parameters)
+    def results = resp.getParameter().findAll { it.name == "validation" }.collect { it.resource as Parameters }
+
+    then:
+    results.size() == 3
+    results[0].findParameter("result").orElseThrow().valueBoolean
+    !results[1].findParameter("result").orElseThrow().valueBoolean
+    results[2].findParameter("result").orElseThrow().valueBoolean
+  }
+}


### PR DESCRIPTION
Implements the HL7 validator's batch validation protocol: a type-level `batch-validate-code` operation on both CodeSystem and ValueSet.

The validator batches many code validations into one request — a `Parameters` with one `validation` part per code, each carrying that code's `$validate-code` input as a nested `Parameters`, plus shared inputs (`tx-resource`, `displayLanguage`, …) at the batch top level. The response mirrors it: one `validation` result per input, **in order**, each a nested `Parameters` with the standard `$validate-code` output.

Each item is delegated to the existing single-code operation (`ValueSetValidateCodeOperation` / `CodeSystemValidateCodeOperation`), so inline tx-resource resources, displays, versions and designations behave identically to single validate-code — including the inline tx-resource support from #235/#236/#237. Shared batch-level params are merged into every item (per-item params win). A per-item `FhirException` becomes that item's `result=false` + message rather than failing the whole batch. Envelope logic shared via `BatchValidateCodeSupport`.

`CodeSystemValidateCodeOperation.run(Parameters)` made public so the batch op can delegate.

## Verification
- `terminology` unit: 245/0
- `integtest`: 82/0, incl. new `CodeSystemBatchValidateCodeIT` + `ValueSetBatchValidateCodeIT` (order-preserving, mixed valid/invalid, shared inline tx-resource)
- Over-HTTP registration is the same mechanism as the proven single `$validate-code` ops; the type-level wire path will be exercised by the upcoming tx-ecosystem conformance rerun.