### PR TITLE
Point shared dev Snowstorm at dev.termx.org SNOMEDCT-EE branch

### DIFF
--- a/termx-app/src/main/resources/application-dev.yml
+++ b/termx-app/src/main/resources/application-dev.yml
@@ -10,6 +10,15 @@ termx:
   web-url: http://localhost:4200
   api-url: https://localhost:8200
 
+# ─── Snowstorm (SNOMED backend) — shared dev instance ────────────────────────────
+# Shared across developers: the dev.termx.org Snowstorm, Estonian edition branch.
+# Overridable per-env via SNOWSTORM_URL / SNOWSTORM_BRANCH. user/password inherit
+# from application.yml (blank → client sends no auth → read-only), which is enough
+# for expand/validate-code/lookup against the shared instance.
+snowstorm:
+  url: ${SNOWSTORM_URL:`https://snomed.termx.org/snowstorm/snomed-ct/`}
+  branch: ${SNOWSTORM_BRANCH:`MAIN/SNOMEDCT-EE`}
+
 github:
   client:
     id: 'Iv23lipQQ7hPChW6Hv2P'


### PR DESCRIPTION
`application-dev.yml` is the shared dev profile; default `snowstorm.url`/`branch` to the dev.termx.org instance and the Estonian edition branch (`MAIN/SNOMEDCT-EE`) so all developers hit the same SNOMED backend out of the box.

- Overridable via `SNOWSTORM_URL` / `SNOWSTORM_BRANCH`.
- Credentials inherit from `application.yml` (blank → client sends no auth → read-only), which covers expand/validate-code/lookup against the shared instance.
- Verified the branch is reachable: `GET .../branches/MAIN/SNOMEDCT-EE` → 200.