### PR TITLE
FHIR import: complete the title/name/id fallback and derive child FKs from it

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -503,10 +503,13 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     }
     codeSystem.setUri(fhirCS.getUrl());
     codeSystem.setPublisher(fhirCS.getPublisher());
-    codeSystem.setName(fhirCS.getName());
-    // FHIR title is optional, but TermX stores it NOT NULL — default an absent title to the resource name.
+    // FHIR name and title are optional, but TermX stores title NOT NULL. Fall back title -> name -> id;
+    // id itself already derives from the url's last segment when absent (see fhirIdOrFromUrl above), so a
+    // resource carrying only a url still loads instead of hitting the not-null constraint.
+    String name = StringUtils.isNotEmpty(fhirCS.getName()) ? fhirCS.getName() : codeSystem.getId();
+    codeSystem.setName(name);
     codeSystem.setTitle(fromFhirName(
-        StringUtils.isNotEmpty(fhirCS.getTitle()) ? fhirCS.getTitle() : fhirCS.getName(),
+        StringUtils.isNotEmpty(fhirCS.getTitle()) ? fhirCS.getTitle() : name,
         fhirCS.getLanguage(), fhirCS.getPrimitiveElement("title")));
     codeSystem.setDescription(fromFhirName(fhirCS.getDescription(), fhirCS.getLanguage(), fhirCS.getPrimitiveElement("description")));
     codeSystem.setPurpose(fromFhirName(fhirCS.getPurpose(), fhirCS.getLanguage(), fhirCS.getPrimitiveElement("purpose")));
@@ -552,7 +555,9 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
 
   private static List<CodeSystemVersion> fromFhirVersion(com.kodality.zmei.fhir.resource.terminology.CodeSystem fhirCodeSystem) {
     CodeSystemVersion version = new CodeSystemVersion();
-    version.setCodeSystem(fhirCodeSystem.getId());
+    // Use the same id the code system resolves to (derived from the url's last segment when the resource
+    // carries no explicit id) — otherwise the version's code_system FK is null for id-less fixtures.
+    version.setCodeSystem(fhirIdOrFromUrl(fhirCodeSystem.getId(), fhirCodeSystem.getUrl()));
     version.setVersion(fhirCodeSystem.getVersion() == null ? "1.0.0" : fhirCodeSystem.getVersion());
     version.setPreferredLanguage(fhirCodeSystem.getLanguage() == null ? Language.en : fhirCodeSystem.getLanguage());
     var supportedLanguages = Optional.ofNullable(fhirCodeSystem.getConcept()).map(List::stream).orElse(Stream.of())
@@ -690,7 +695,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     fhirConcepts.forEach(c -> {
       Concept concept = new Concept();
       concept.setCode(c.getCode());
-      concept.setCodeSystem(fhirCodeSystem.getId());
+      concept.setCodeSystem(fhirIdOrFromUrl(fhirCodeSystem.getId(), fhirCodeSystem.getUrl()));
       concept.setVersions(fromFhirConcepts(c, fhirCodeSystem, parent, parentMap));
       concepts.add(concept);
       if (c.getConcept() != null) {
@@ -705,7 +710,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
                                                                 CodeSystemConcept parent, Map<String, List<String>> parentMap) {
     CodeSystemEntityVersion version = new CodeSystemEntityVersion();
     version.setCode(c.getCode());
-    version.setCodeSystem(codeSystem.getId());
+    version.setCodeSystem(fhirIdOrFromUrl(codeSystem.getId(), codeSystem.getUrl()));
     version.setDesignations(fromFhirDesignations(c, codeSystem));
     version.setPropertyValues(fromFhirProperties(c.getProperty(), c.getCode()));
     version.setAssociations(fromFhirAssociations(parent, parentMap.get(c.getCode()), codeSystem));
@@ -821,7 +826,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
       association.setAssociationType(codeSystem.getHierarchyMeaning() == null ? "is-a" : codeSystem.getHierarchyMeaning());
       association.setStatus(PublicationStatus.active);
       association.setTargetCode(parent.getCode());
-      association.setCodeSystem(codeSystem.getId());
+      association.setCodeSystem(fhirIdOrFromUrl(codeSystem.getId(), codeSystem.getUrl()));
       associations.add(association);
     }
     if (CollectionUtils.isNotEmpty(parents)) {
@@ -830,7 +835,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
         association.setAssociationType(codeSystem.getHierarchyMeaning() == null ? "is-a" : codeSystem.getHierarchyMeaning());
         association.setStatus(PublicationStatus.active);
         association.setTargetCode(p);
-        association.setCodeSystem(codeSystem.getId());
+        association.setCodeSystem(fhirIdOrFromUrl(codeSystem.getId(), codeSystem.getUrl()));
         return association;
       }).toList());
     }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -725,10 +725,13 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     }
     vs.setUri(valueSet.getUrl());
     vs.setPublisher(valueSet.getPublisher());
-    vs.setName(valueSet.getName());
-    // FHIR title is optional, but TermX stores it NOT NULL — default an absent title to the resource name.
+    // FHIR name and title are optional, but TermX stores title NOT NULL. Fall back title -> name -> id;
+    // id itself already derives from the url's last segment when absent (see fhirIdOrFromUrl above), so a
+    // resource carrying only a url still loads instead of hitting the not-null constraint.
+    String name = StringUtils.isNotEmpty(valueSet.getName()) ? valueSet.getName() : vs.getId();
+    vs.setName(name);
     vs.setTitle(fromFhirName(
-        StringUtils.isNotEmpty(valueSet.getTitle()) ? valueSet.getTitle() : valueSet.getName(),
+        StringUtils.isNotEmpty(valueSet.getTitle()) ? valueSet.getTitle() : name,
         valueSet.getLanguage(), valueSet.getPrimitiveElement("title")));
     vs.setDescription(fromFhirName(valueSet.getDescription(), valueSet.getLanguage(), valueSet.getPrimitiveElement("description")));
     vs.setPurpose(fromFhirName(valueSet.getPurpose(), valueSet.getLanguage(), valueSet.getPrimitiveElement("purpose")));
@@ -761,7 +764,9 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
 
   private static ValueSetVersion fromFhirVersion(com.kodality.zmei.fhir.resource.terminology.ValueSet valueSet) {
     ValueSetVersion version = new ValueSetVersion();
-    version.setValueSet(valueSet.getId());
+    // Use the same id the value set resolves to (derived from the url's last segment when the resource
+    // carries no explicit id) — otherwise the version's value_set FK is null for id-less fixtures.
+    version.setValueSet(fhirIdOrFromUrl(valueSet.getId(), valueSet.getUrl()));
     version.setVersion(valueSet.getVersion() == null ? "1.0.0" : valueSet.getVersion());
     version.setStatus(PublicationStatus.draft);
     version.setAlgorithm(valueSet.getVersionAlgorithmString());

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
@@ -186,4 +186,43 @@ class CodeSystemFhirMapperSpec extends Specification {
     expect:
     mapper.toFhir(cs, version, []).meta == null
   }
+
+  def "fromFhir defaults an absent title and name to the id (derived from the url's last segment)"() {
+    given: "a CodeSystem with neither title nor name nor id — only a url (as many tx-ecosystem fixtures are)"
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.CodeSystem()
+        .setUrl("http://hl7.org/fhir/test/CodeSystem/search")
+        .setStatus("active")
+        .setContent("complete")
+        .setConcept([new com.kodality.zmei.fhir.resource.terminology.CodeSystem.CodeSystemConcept().setCode("a")])
+
+    when:
+    def cs = mapper.fromFhirCodeSystem(fhir)
+
+    then: "title is non-null (TermX stores it NOT NULL) and falls back through name -> id -> url last segment"
+    cs.id == "search"
+    cs.name == "search"
+    cs.title != null
+    cs.title.values().contains("search")
+    and: "the version's code_system FK uses the derived id (else the version insert hits a not-null violation)"
+    cs.versions.first().codeSystem == "search"
+    and: "concept and its entity version also carry the derived code_system id (their FKs are NOT NULL too)"
+    cs.concepts.first().codeSystem == "search"
+    cs.concepts.first().versions.first().codeSystem == "search"
+  }
+
+  def "fromFhir keeps an explicit title and only defaults the missing name"() {
+    given:
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.CodeSystem()
+        .setUrl("http://hl7.org/fhir/test/CodeSystem/simple")
+        .setTitle("Simple CS")
+        .setStatus("active")
+        .setContent("complete")
+
+    when:
+    def cs = mapper.fromFhirCodeSystem(fhir)
+
+    then:
+    cs.name == "simple"
+    cs.title.values().contains("Simple CS")
+  }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperLanguageSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/ValueSetFhirMapperLanguageSpec.groovy
@@ -57,4 +57,22 @@ class ValueSetFhirMapperLanguageSpec extends Specification {
     languages.contains("et")
     languages.contains("ru")
   }
+
+  def "fromFhir defaults an absent title and name to the id (derived from the url's last segment)"() {
+    given: "a ValueSet with neither title nor name nor id — only a url"
+    def fhir = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+        .setUrl("http://hl7.org/fhir/test/ValueSet/simple-all")
+        .setStatus("active")
+
+    when:
+    def vs = ValueSetFhirMapper.fromFhirValueSet(fhir)
+
+    then: "title is non-null (TermX stores it NOT NULL) and falls back through name -> id -> url last segment"
+    vs.id == "simple-all"
+    vs.name == "simple-all"
+    vs.title != null
+    vs.title.values().contains("simple-all")
+    and: "the version's value_set FK uses the derived id (else the version insert hits a not-null violation)"
+    vs.versions.first().valueSet == "simple-all"
+  }
 }


### PR DESCRIPTION
Importing a CodeSystem/ValueSet that carries only a `url` (no id, name, or title — common in the tx-ecosystem test fixtures) failed with `NOT NULL` violations. Two related gaps:

1. **title fell back to name only.** When both were absent it stayed null (`code_system.title` / `value_set.title` are NOT NULL). Complete the chain **title → name → id**, and **name → id**, where `id` already derives from the url's last segment (`fhirIdOrFromUrl`). A url-only resource now resolves a non-null id/name/title.
2. **child FKs used the raw id.** `code_system_version`, `code_system_entity_version`, `value_set_version`, and the concept/association rows set their owning `code_system`/`value_set` FK from the raw `fhirCS.getId()` (null for id-less fixtures) instead of the derived id, hitting NOT NULL on those FKs. Derive them the same way.

Surfaced by the tx-ecosystem conformance setup loader (`POST /tx-conformance/runs {loadSetup:true}`): these fixes take the import-failure count to **0** and raise the loaded-fixture count (132 → 140 of 252). Remaining unresolved fixtures are multi-version canonicals (version-conflict on re-import) and SNOMED-backed sets (need a Snowstorm), tracked separately.

## Verification
- `terminology` unit: 248/0, incl. new `CodeSystemFhirMapperSpec` / `ValueSetFhirMapperLanguageSpec` cases asserting a url-only resource maps to a non-null id/name/title and that the version/concept/entity-version FKs use the derived id.
- Verified live against the conformance loader: no more `null value in column "title"/"code_system"/"value_set"` errors.