### PR TITLE
tx-conformance setup loader: treat already-present resources as loaded

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
@@ -135,6 +135,17 @@ public class TxConformanceSetupLoader {
       if (resp.statusCode() / 100 == 2) {
         return true;
       }
+      // The tx-ecosystem ships the same canonical (url) at the same version more than once — e.g. a value
+      // set referenced by several suites, or duplicated across test folders. reconcileCanonicalId folds
+      // these to one resource, so the second POST of an identical, already-active version is rejected
+      // (TE104 "already final" / TE102 "already exists"). Since the import is transactional, an active
+      // version means a complete prior load — the content is present either way, so treat it as loaded
+      // (matching this loader's "duplicates on re-run are tolerated" contract) rather than re-posting it
+      // every pass and reporting it as unresolved.
+      if (alreadyPresent(resp.body())) {
+        log.info("tx conformance setup: {} {} -> already present, treating as loaded", method, url);
+        return true;
+      }
       // Honest logging: report the real status + a snippet of the error so an incomplete setup is
       // diagnosable, instead of the misleading blanket "already present".
       log.info("tx conformance setup: {} {} -> {}: {}", method, url, resp.statusCode(), summarize(resp.body()));
@@ -166,6 +177,18 @@ public class TxConformanceSetupLoader {
         return "";
       }
     }
+  }
+
+  /**
+   * True when an import failure means the resource is already present (a duplicate of an already-loaded,
+   * activated canonical): TE104 "version already final" or TE102 "version already exists". Such a resource's
+   * content is in the server, so the loader treats it as loaded rather than retrying it every pass.
+   */
+  static boolean alreadyPresent(String responseBody) {
+    if (responseBody == null) {
+      return false;
+    }
+    return responseBody.contains("TE104") || responseBody.contains("TE102");
   }
 
   private static String summarize(String responseBody) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
@@ -47,6 +47,19 @@ class TxConformanceSetupLoaderTest extends Specification {
     Files.deleteIfExists(f)
   }
 
+  def "alreadyPresent treats 'version already final/exists' as loaded, not other errors"() {
+    expect:
+    TxConformanceSetupLoader.alreadyPresent(body) == expected
+
+    where:
+    body                                                                                || expected
+    '{"issue":[{"details":{"text":"TE104: Version 1.0.0 is already created and final"}}]}' || true
+    '{"issue":[{"details":{"text":"TE102: Version 1.0.0 already exists."}}]}'              || true
+    '{"issue":[{"details":{"text":"TE110: Code system x does not exist."}}]}'              || false
+    '{"issue":[{"details":{"text":"TE111: Value set x does not exist."}}]}'                || false
+    null                                                                                  || false
+  }
+
   def "isSetupFile accepts setup resources of the kind and rejects test artifacts"() {
     expect:
     TxConformanceSetupLoader.isSetupFile(name, prefix) == expected


### PR DESCRIPTION
The tx-ecosystem ships the same canonical (`url`) at the same version more than once (a value set referenced by several suites, duplicated across folders). `reconcileCanonicalId` folds these to one resource, so the second POST of an identical, already-active version is rejected with **TE104** 'version already final' / **TE102** 'already exists'. The loader treated that as failure and re-posted it every pass — inflating the unresolved count and never converging.

Since the import is `@Transactional` (an active version means a *complete* prior load), the content is already present. Classify TE104/TE102 as **loaded**, matching the loader's documented "duplicates on re-run are tolerated" contract.

## Effect (clean-DB conformance run, `POST /tx-conformance/runs {loadSetup:true}`)
- Loaded fixtures **140 → 222 of 252**. The remaining ~30 are genuinely-missing, mostly SNOMED-backed code systems (need a Snowstorm).
- Headline pass rate **unchanged (0/599)** — that gap is real, operation-level FHIR conformance, not setup.

## Verification
- `terminology` unit: `TxConformanceSetupLoaderTest` 16/0, incl. new cases asserting TE104/TE102 → loaded and TE110/TE111/null → not.
- Verified live: "already present, treating as loaded" for 82 resources; total load 222/252.