### PR TITLE
FHIR $expand: apply supplements + enrich external (SNOMED) members in expansion

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -24,6 +24,7 @@ import org.termx.ts.codesystem.CodeSystemQueryParams;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
 import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.ConceptQueryParams;
+import io.micronaut.core.util.StringUtils;
 import org.termx.ts.codesystem.Designation;
 import com.kodality.commons.model.QueryResult;
 import org.termx.ts.valueset.*;
@@ -53,6 +54,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   private final List<ValueSetExternalExpandProvider> externalExpandProviders;
   private final CodeSystemService codeSystemService;
   private final ConceptService conceptService;
+  private final org.termx.terminology.terminology.codesystem.concept.ConceptSupplementService conceptSupplementService;
 
   // SNOMED CT implicit-ValueSet URL family
   // https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html
@@ -177,6 +179,15 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
 
     ValueSetSnapshot snapshot = valueSetVersionConceptService.expand(vs.getId(), version.getVersion(), displayLanguage, includeDesignations);
     List<ValueSetVersionConcept> expandedConcepts = snapshot.getExpansion();
+
+    // Layer supplements (e.g. a SNOMED-based supplement's localized designations) onto the expanded
+    // members. The external SNOMED expand provider fetches base concepts from Snowstorm but never applies
+    // supplements, so they were absent from $expand. Only run on the freshly-computed (non-cached) view —
+    // a displayLanguage or includeDesignations request bypasses the request-agnostic default snapshot, so
+    // the members here are safe to enrich in place.
+    if (StringUtils.isNotEmpty(displayLanguage) || includeDesignations) {
+      conceptSupplementService.mergeSupplementsIntoExpansion(expandedConcepts, supplementParams(displayLanguage, req));
+    }
     List<Provenance> provenances = provenanceService.find("ValueSetVersion|" + version.getId());
 
     // FHIR R5 ValueSet/$expand `filter`: free-text typeahead filter applied to the
@@ -228,6 +239,93 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     return mapper.toFhir(vs, version, provenances, snapshot, req);
   }
 
+  /**
+   * Enriches members the SQL expand couldn't resolve — those from an external (provider-backed, e.g.
+   * SNOMED via Snowstorm) code system come back with no display/designations because the in-DB expand
+   * has no access to the provider. Fetches them through the concept providers by code system + code and
+   * grafts the display + designations. Only members missing a display are fetched, so a pure-local
+   * expansion makes no provider calls.
+   */
+  private void enrichExternalMembers(List<ValueSetVersionConcept> members, String displayLanguage) {
+    java.util.Map<String, List<ValueSetVersionConcept>> byCodeSystem = new java.util.LinkedHashMap<>();
+    for (ValueSetVersionConcept m : members) {
+      if (m.getConcept() == null || StringUtils.isEmpty(m.getConcept().getCode())) {
+        continue;
+      }
+      if (m.getDisplay() != null && StringUtils.isNotEmpty(m.getDisplay().getName())) {
+        continue;
+      }
+      String csId = resolveCodeSystemId(m.getConcept());
+      if (StringUtils.isEmpty(csId)) {
+        continue;
+      }
+      byCodeSystem.computeIfAbsent(csId, key -> new java.util.ArrayList<>()).add(m);
+    }
+    byCodeSystem.forEach((csId, csMembers) -> {
+      List<String> codes = csMembers.stream().map(m -> m.getConcept().getCode()).distinct().toList();
+      java.util.Map<String, Concept> byCode = conceptService.query(new ConceptQueryParams()
+              .setCodeSystem(csId).setCodes(codes).setDisplayLanguage(displayLanguage).limit(codes.size()))
+          .getData().stream().collect(java.util.stream.Collectors.toMap(Concept::getCode, c -> c, (a, b) -> a));
+      csMembers.forEach(m -> {
+        Concept src = byCode.get(m.getConcept().getCode());
+        if (src == null || src.getVersions() == null || src.getVersions().isEmpty()) {
+          return;
+        }
+        List<Designation> designations = java.util.Optional.ofNullable(src.getVersions().get(0).getDesignations()).orElse(List.of());
+        Designation display = ConceptUtil.getDisplay(designations, displayLanguage, List.of());
+        if (display != null) {
+          m.setDisplay(display);
+        }
+        if (m.getAdditionalDesignations() == null || m.getAdditionalDesignations().isEmpty()) {
+          m.setAdditionalDesignations(designations);
+        }
+      });
+    });
+  }
+
+  /** Resolves the internal code system id for an expansion member, mapping a canonical url to the stored id when the id is absent (inline/external members); null when it resolves to no stored code system (nothing to enrich from). */
+  private String resolveCodeSystemId(ValueSetVersionConcept.ValueSetVersionConceptValue c) {
+    if (StringUtils.isNotEmpty(c.getCodeSystem())) {
+      java.util.Optional<CodeSystem> loaded = codeSystemService.load(c.getCodeSystem());
+      if (loaded != null && loaded.isPresent()) {
+        return c.getCodeSystem();
+      }
+    }
+    String uri = StringUtils.isNotEmpty(c.getCodeSystemUri()) ? c.getCodeSystemUri() : c.getCodeSystem();
+    if (StringUtils.isEmpty(uri)) {
+      return null;
+    }
+    // Unresolvable code system → no provider to enrich from; skip rather than query with a bogus id.
+    var byUri = codeSystemService.query(new CodeSystemQueryParams().setUri(uri).limit(1));
+    return byUri == null ? null : byUri.findFirst().map(CodeSystem::getId).orElse(null);
+  }
+
+  /** Builds the supplement context for an expansion: auto-load supplements for the requested displayLanguage, plus any explicit {@code useSupplement}. */
+  private static ConceptQueryParams supplementParams(String displayLanguage, Parameters req) {
+    return new ConceptQueryParams()
+        .setIncludeSupplement(true)
+        .setDisplayLanguage(displayLanguage)
+        .setUseSupplement(extractUseSupplement(req));
+  }
+
+  private static String extractUseSupplement(Parameters req) {
+    if (req == null || req.getParameter() == null) {
+      return null;
+    }
+    String joined = req.getParameter().stream()
+        .filter(p -> "useSupplement".equals(p.getName()))
+        .map(p -> {
+          String v = p.getValueCanonical() != null ? p.getValueCanonical()
+              : p.getValueUri() != null ? p.getValueUri()
+              : p.getValueUrl() != null ? p.getValueUrl() : p.getValueString();
+          return v;
+        })
+        .filter(StringUtils::isNotEmpty)
+        .distinct()
+        .collect(java.util.stream.Collectors.joining(","));
+    return StringUtils.isEmpty(joined) ? null : joined;
+  }
+
   /** Finds a ValueSet supplied inline via a tx-resource parameter whose url matches the requested url. */
   private static com.kodality.zmei.fhir.resource.terminology.ValueSet findTxResourceValueSet(Parameters req, String url) {
     if (req.getParameter() == null || url == null) {
@@ -258,6 +356,12 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     boolean includeDesignations = req != null && req.findParameter("includeDesignations")
         .map(pr -> pr.getValueBoolean() != null && pr.getValueBoolean() || "true".equals(pr.getValueString()))
         .orElse(false);
+
+    // The SQL expand can't reach external providers (e.g. SNOMED via Snowstorm), so those members arrive
+    // bare. Enrich them with display/designations from the providers, then layer supplements onto the
+    // whole expansion — so a SNOMED-based supplement surfaces in an inline/tx-resource $expand too.
+    enrichExternalMembers(expandedConcepts, displayLanguage);
+    conceptSupplementService.mergeSupplementsIntoExpansion(expandedConcepts, supplementParams(displayLanguage, req));
 
     // Apply FHIR R5 `filter` (free-text typeahead) before pagination, matching
     // the stored-VS path semantics. Filters affect `expansion.total`;

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
@@ -15,6 +15,7 @@ import org.termx.ts.codesystem.CodeSystemQueryParams;
 import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.ConceptQueryParams;
 import org.termx.ts.codesystem.Designation;
+import org.termx.ts.valueset.ValueSetVersionConcept;
 import io.micronaut.core.util.CollectionUtils;
 import jakarta.inject.Singleton;
 import java.util.ArrayList;
@@ -60,6 +61,81 @@ public class ConceptSupplementService {
     }
     mergeRuntimeSupplements(List.of(concept), params);
     return concept;
+  }
+
+  /**
+   * Layers supplement designations onto an already-expanded ValueSet member list (display + additional
+   * designations), by base code system and code — the expansion counterpart of {@link #mergeRuntimeSupplements}.
+   * The $lookup/$validate-code path merges supplements inside {@link ConceptService#query}; $expand builds its
+   * members through other routes (the SQL expand and the external SNOMED expand provider) that never touch that
+   * merge, so a supplement on e.g. SNOMED never surfaced in an expansion. This closes that gap for both the
+   * stored and inline expand paths. Triggered by {@code useSupplement} or {@code includeSupplement}+displayLanguage.
+   */
+  public void mergeSupplementsIntoExpansion(List<ValueSetVersionConcept> members, ConceptQueryParams params) {
+    if (CollectionUtils.isEmpty(members) || !shouldLoadSupplements(params)) {
+      return;
+    }
+    List<Concept> conceptView = members.stream()
+        .map(ValueSetVersionConcept::getConcept).filter(Objects::nonNull)
+        .filter(c -> StringUtils.isNotBlank(c.getCode()) && StringUtils.isNotBlank(c.getCodeSystem()))
+        .map(c -> {
+          Concept view = new Concept();
+          view.setCode(c.getCode());
+          view.setCodeSystem(c.getCodeSystem());
+          return view;
+        })
+        .toList();
+    Map<String, List<ResolvedSupplement>> supplementsByBaseCodeSystem = resolveSupplements(conceptView, params);
+    if (supplementsByBaseCodeSystem.isEmpty()) {
+      return;
+    }
+
+    members.stream()
+        .filter(m -> m.getConcept() != null && StringUtils.isNotBlank(m.getConcept().getCodeSystem()))
+        .collect(Collectors.groupingBy(m -> m.getConcept().getCodeSystem()))
+        .forEach((baseCodeSystem, csMembers) -> {
+          List<ResolvedSupplement> supplements = supplementsByBaseCodeSystem.get(baseCodeSystem);
+          if (CollectionUtils.isEmpty(supplements)) {
+            return;
+          }
+          List<String> codes = csMembers.stream().map(m -> m.getConcept().getCode()).filter(StringUtils::isNotBlank).distinct().toList();
+          Map<String, List<Designation>> byCode = new LinkedHashMap<>();
+          supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), codes, supplement.version(), params).forEach(concept -> {
+            List<Designation> designations = concept.getVersions() == null ? List.of() : concept.getVersions().stream()
+                .flatMap(v -> Optional.ofNullable(v.getDesignations()).orElse(List.of()).stream())
+                .filter(d -> languageMatches(d.getLanguage(), params.getDisplayLanguage()))
+                .map(d -> d.setSupplement(true))
+                .toList();
+            if (CollectionUtils.isNotEmpty(designations)) {
+              byCode.computeIfAbsent(concept.getCode(), key -> new ArrayList<>()).addAll(designations);
+            }
+          }));
+          csMembers.forEach(member -> applySupplementDesignations(member, byCode.getOrDefault(member.getConcept().getCode(), List.of()), params.getDisplayLanguage()));
+        });
+  }
+
+  /** Appends supplement designations to a member (deduped) and, when a displayLanguage is requested, surfaces a matching supplement designation as the member's display. */
+  private static void applySupplementDesignations(ValueSetVersionConcept member, List<Designation> supplementDesignations, String displayLanguage) {
+    if (CollectionUtils.isEmpty(supplementDesignations)) {
+      return;
+    }
+    List<Designation> additional = new ArrayList<>(Optional.ofNullable(member.getAdditionalDesignations()).orElse(List.of()));
+    supplementDesignations.forEach(d -> {
+      if (additional.stream().noneMatch(a -> designationKey(a).equals(designationKey(d)))) {
+        additional.add(d);
+      }
+    });
+    member.setAdditionalDesignations(additional);
+    if (StringUtils.isNotBlank(displayLanguage)) {
+      supplementDesignations.stream()
+          .filter(d -> languageMatches(d.getLanguage(), displayLanguage) && d.getName() != null)
+          .findFirst()
+          .ifPresent(member::setDisplay);
+    }
+  }
+
+  private static String designationKey(Designation d) {
+    return d.getLanguage() + "|" + d.getDesignationType() + "|" + d.getName();
   }
 
   private void applySupplements(String baseCodeSystem, List<Concept> concepts, List<ResolvedSupplement> supplements, ConceptQueryParams params) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -49,6 +49,7 @@ class ValueSetExpandOperationTest extends Specification {
   def mapper = Mock(ValueSetFhirMapper)
   def codeSystemService = Mock(CodeSystemService)
   def conceptService = Mock(ConceptService)
+  def conceptSupplementService = Mock(org.termx.terminology.terminology.codesystem.concept.ConceptSupplementService)
   // SNOMED provider — recognised via getCodeSystemId() == "snomed-ct". Delegated
   // to by the operation for `?fhir_vs[=...]` URLs. The mock captures the
   // synthesised rule so tests can assert on the filter (operator + value) the
@@ -66,7 +67,8 @@ class ValueSetExpandOperationTest extends Specification {
       mapper,
       [snomedProvider],
       codeSystemService,
-      conceptService)
+      conceptService,
+      conceptSupplementService)
 
   /**
    * Snapshot the operation hands off to {@link ValueSetFhirMapper#toFhir}.


### PR DESCRIPTION
Supplement designations only surfaced in `$lookup`/`$validate-code` (which merge them inside `ConceptService.query`). `$expand` builds members through other routes — the SQL expand and the external SNOMED expand provider — that never touched that merge. So a **SNOMED-based supplement's** localized designations never appeared in an expansion, and inline/tx-resource expansion of SNOMED members returned no `display` at all (the SQL function can't reach Snowstorm).

## Fixes (both expand paths)
- **`ConceptSupplementService.mergeSupplementsIntoExpansion`** — layers supplement designations onto an expanded `ValueSetVersionConcept` list by base code system + code (the expansion counterpart of `mergeRuntimeSupplements`), surfacing a matching supplement designation as the member display when a `displayLanguage` is requested. Applied in the stored expand (after the external providers run) and the inline/tx-resource expand.
- **`ValueSetExpandOperation.enrichExternalMembers`** — members the SQL expand left bare (external, provider-backed, e.g. SNOMED via Snowstorm) are fetched through the concept providers and given their display/designations, so inline/tx-resource `$expand` over SNOMED is no longer display-less. Only members missing a display are fetched, so pure-local expansions make no provider calls.

## Verification
Verified live against the shared Snowstorm (`MAIN/SNOMEDCT-EE`): a CodeSystem supplement on `http://snomed.info/sct` surfaces its localized designation in **both stored and inline** `$expand` (display + designations), alongside the Snowstorm-sourced base displays (e.g. `404684003` → "Kliininen löydös (SUPP)" + et "Kliiniline leid").

- `terminology` unit: **253/0** (incl. `ValueSetExpandOperationTest`, updated for the new dependency).
- `integtest`: **59/0** — existing `ValueSetSupplementExpandIT` (local, extension-bound supplement) and the tx-resource / expand ITs all still pass.
- SNOMED paths need a live Snowstorm, so they can't run in CI (same constraint as the conformance SNOMED fixtures).