### PR TITLE
FHIR ValueSet $validate-code: graceful degradation for unknown systemVersion

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -220,6 +220,23 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         .filter(c -> finalVersion == null || (c.getConcept().getCodeSystemVersions() != null && c.getConcept().getCodeSystemVersions().contains(finalVersion)))
         .findFirst().orElse(null);
 
+    // Graceful degradation for an unknown systemVersion: the requested version names a code system
+    // version that does not exist (the code itself IS in the value set, just under a different version).
+    // Per the FHIR tx ecosystem this is a 200 with result=false plus an UNKNOWN_CODESYSTEM_VERSION issue
+    // listing the valid versions — not a 404/"not in value set".
+    if (concept == null && finalVersion != null && finalSystem != null) {
+      ValueSetVersionConcept anyVersion = vsConcepts.stream()
+          .filter(c -> finalCode.equals(c.getConcept().getCode()))
+          .filter(c -> finalSystem.equals(c.getConcept().getCodeSystemUri()))
+          .findFirst().orElse(null);
+      if (anyVersion != null) {
+        List<String> available = Optional.ofNullable(anyVersion.getConcept().getCodeSystemVersions()).orElse(List.of());
+        if (!available.contains(finalVersion)) {
+          return unknownSystemVersion(anyVersion, finalSystem, finalVersion, available, display, displayLanguage);
+        }
+      }
+    }
+
     if (concept == null) {
       return error(String.format("The provided code %s is not in the value set", (system != null ? system  + "#" : "") + code));
     }
@@ -243,6 +260,50 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       outcome.setIssue(List.of(new OperationOutcomeIssue().setCode("deleted").setSeverity("warning").setDetails(new CodeableConcept().setText("Concept is inactive"))));
       parameters.addParameter(new ParametersParameter("issues").setResource(outcome));
     }
+    return parameters;
+  }
+
+  /**
+   * Builds the response for a requested {@code systemVersion} that does not exist: result=false, the code's
+   * display/system/available version echoed, and an {@code issues} OperationOutcome carrying the
+   * UNKNOWN_CODESYSTEM_VERSION error (with the valid versions) plus the versionless-include mismatch warning.
+   * Mirrors the FHIR tx ecosystem's "graceful degradation" — a 200, not a 4xx.
+   */
+  private Parameters unknownSystemVersion(ValueSetVersionConcept concept, String system, String requestedVersion,
+                                          List<String> availableVersions, String display, String displayLanguage) {
+    String availableVersion = availableVersions.stream().findFirst().orElse(null);
+    String message = String.format(
+        "A definition for CodeSystem '%s' version '%s' could not be found, so the code cannot be validated. Valid versions: %s",
+        system, requestedVersion, String.join(", ", availableVersions));
+
+    OperationOutcomeIssue notFound = new OperationOutcomeIssue()
+        .setSeverity("error").setCode("not-found")
+        .setDetails(new CodeableConcept(new Coding("http://hl7.org/fhir/tools/CodeSystem/tx-issue-type", "not-found")).setText(message))
+        .setLocation(List.of("system")).setExpression(List.of("system"));
+    OperationOutcomeIssue mismatch = new OperationOutcomeIssue()
+        .setSeverity("warning").setCode("invalid")
+        .setDetails(new CodeableConcept(new Coding("http://hl7.org/fhir/tools/CodeSystem/tx-issue-type", "vs-invalid")).setText(String.format(
+            "The code system '%s' version '%s' for the versionless include in the ValueSet include is different to the one in the value ('%s')",
+            system, availableVersion, requestedVersion)))
+        .setLocation(List.of("version")).setExpression(List.of("version"));
+
+    OperationOutcome outcome = new OperationOutcome();
+    outcome.setIssue(List.of(notFound, mismatch));
+
+    Parameters parameters = new Parameters();
+    parameters.addParameter(new ParametersParameter("code").setValueCode(concept.getConcept().getCode()));
+    String conceptDisplay = findDisplay(concept, display, displayLanguage);
+    if (conceptDisplay != null) {
+      parameters.addParameter(new ParametersParameter("display").setValueString(conceptDisplay));
+    }
+    parameters.addParameter(new ParametersParameter("issues").setResource(outcome));
+    parameters.addParameter(new ParametersParameter("message").setValueString(message));
+    parameters.addParameter(new ParametersParameter("result").setValueBoolean(false));
+    parameters.addParameter(new ParametersParameter("system").setValueUri(system));
+    if (availableVersion != null) {
+      parameters.addParameter(new ParametersParameter("version").setValueString(availableVersion));
+    }
+    parameters.addParameter(new ParametersParameter("x-caused-by-unknown-system").setValueCanonical(system + "|" + requestedVersion));
     return parameters;
   }
 

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
@@ -125,6 +125,30 @@ class ValueSetValidateCodeOperationTest extends Specification {
     !resp.findParameter("message").isPresent()
   }
 
+  def "an unknown systemVersion degrades gracefully: result false + UNKNOWN_CODESYSTEM_VERSION issue + valid versions"() {
+    given: "the code is in the value set, but only under code system version 0.1.0"
+    def c = concept()
+    c.getConcept().setCodeSystemVersions(["0.1.0"])
+    valueSetVersionConceptService.expand(vsVersion, _) >> [c]
+
+    when: "validating with systemVersion 1.0.0, which does not exist"
+    def p = new Parameters()
+    p.addParameter(new ParametersParameter("code").setValueCode("allergy"))
+    p.addParameter(new ParametersParameter("system").setValueUri("https://helex.org/fhir/CodeSystem/ehr-feed-category"))
+    p.addParameter(new ParametersParameter("systemVersion").setValueString("1.0.0"))
+    def resp = operation.run(vsVersion, p)
+
+    then: "a 200-style graceful response: result false, available version echoed, message + issues + x-caused-by-unknown-system"
+    !bool(resp, "result")
+    resp.findParameter("version").get().getValueString() == "0.1.0"
+    resp.findParameter("message").get().getValueString().contains("version '1.0.0' could not be found")
+    resp.findParameter("message").get().getValueString().contains("Valid versions: 0.1.0")
+    resp.findParameter("x-caused-by-unknown-system").get().getValueCanonical() == "https://helex.org/fhir/CodeSystem/ehr-feed-category|1.0.0"
+    def oo = resp.findParameter("issues").get().getResource()
+    oo.getIssue().find { it.code == "not-found" && it.severity == "error" } != null
+    oo.getIssue().find { it.code == "invalid" && it.severity == "warning" } != null
+  }
+
   private static ValueSetVersionConcept concept() {
     return new ValueSetVersionConcept()
         .setActive(true)


### PR DESCRIPTION
When a `$validate-code` request pins a `systemVersion` that doesn't exist for the code system (the code itself **is** in the value set, just under another version), termx returned a plain *"The provided code … is not in the value set"* — masking the real cause. The FHIR tx ecosystem requires **graceful degradation**: HTTP 200 with `result=false` plus an `UNKNOWN_CODESYSTEM_VERSION` issue listing the valid versions, never a 4xx / generic miss.

This detects the case (code+system match the expansion but the requested version is absent from the member's `codeSystemVersions`) and builds the spec response: `result=false`, the code's display/system + available version echoed, an `issues` OperationOutcome with the not-found error (*"… Valid versions: 0.1.0"*) and the versionless-include mismatch warning, and `x-caused-by-unknown-system`.

## Verification
- Verified live against the tx-ecosystem `version` suite fixtures: the response is **structurally identical** to the expected output (code, display, two issues with exact texts/locations, message, result, system, version, x-caused-by-unknown-system).
- `terminology` unit: **253/0**, incl. a new unknown-`systemVersion` case.

## Follow-up (separate)
Full pass of the `version` suite (206 actions) is **additionally gated on a phantom-CS-version bug**: termx materialises extra versions of a code system that no fixture defines (e.g. `simple` ends up at 0.1.0 **and** 1.0.0/2.0.0 from a single 0.1.0 fixture), so the expansion binds to the wrong "latest" version and the valid-versions list is wrong. Tracked separately — that's the next lever for the `version` suite.