### PR TITLE
FHIR ValueSet $validate-code: match the base system for supplement-bound value sets

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -216,7 +216,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     List<ValueSetVersionConcept> vsConcepts = valueSetVersionConceptService.expand(vsVersion, displayLanguage);
     ValueSetVersionConcept concept = vsConcepts.stream()
         .filter(c -> finalCode.equals(c.getConcept().getCode()))
-        .filter(c -> finalSystem == null || finalSystem.equals(c.getConcept().getCodeSystemUri()))
+        .filter(c -> systemMatches(c, finalSystem))
         .filter(c -> finalVersion == null || (c.getConcept().getCodeSystemVersions() != null && c.getConcept().getCodeSystemVersions().contains(finalVersion)))
         .findFirst().orElse(null);
 
@@ -227,7 +227,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     if (concept == null && finalVersion != null && finalSystem != null) {
       ValueSetVersionConcept anyVersion = vsConcepts.stream()
           .filter(c -> finalCode.equals(c.getConcept().getCode()))
-          .filter(c -> finalSystem.equals(c.getConcept().getCodeSystemUri()))
+          .filter(c -> systemMatches(c, finalSystem))
           .findFirst().orElse(null);
       if (anyVersion != null) {
         List<String> available = Optional.ofNullable(anyVersion.getConcept().getCodeSystemVersions()).orElse(List.of());
@@ -261,6 +261,18 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       parameters.addParameter(new ParametersParameter("issues").setResource(outcome));
     }
     return parameters;
+  }
+
+  /**
+   * Whether a value set member satisfies the requested {@code system}. A member matches its own code system
+   * uri, but ALSO its base code system uri: a {@code valueset-supplement}-bound value set carries the
+   * supplement as the member's code system, yet the codes belong to (and are presented/validated against) the
+   * base — so {@code $validate-code} with {@code system=<base>} must still find them. A null system matches any.
+   */
+  private static boolean systemMatches(ValueSetVersionConcept c, String system) {
+    return system == null
+        || system.equals(c.getConcept().getCodeSystemUri())
+        || system.equals(c.getConcept().getBaseCodeSystemUri());
   }
 
   /**

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -10,6 +10,7 @@ import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
 import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
 import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
+import org.termx.terminology.fhir.valueset.operations.ValueSetValidateCodeOperation
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
 
@@ -30,6 +31,7 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
   @Inject ValueSetVersionService vsVersionService
   @Inject ValueSetVersionConceptService vsConceptService
   @Inject ValueSetExpandOperation vsExpand
+  @Inject ValueSetValidateCodeOperation vsValidate
 
   void setup() {
     def sessionInfo = new SessionInfo()
@@ -83,6 +85,47 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
 
     and: "the supplement's lt designation appears exactly once (not duplicated by the base+supplement merge)"
     contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
+  }
+
+  def "\$validate-code on a supplement-bound value set validates a code under the BASE system"() {
+    given: "a validate-code request naming the BASE code system (the value set rule is bound to the supplement)"
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri("http://example.org/ValueSet/suppl-vs"),
+        new ParametersParameter().setName("system").setValueUri("http://example.org/CodeSystem/suppl-base"),
+        new ParametersParameter().setName("code").setValueCode("code1")])
+
+    when:
+    def resp = vsValidate.run(req)
+
+    then: "the base system matches the member (whose code system is the supplement) via its base code system uri"
+    resp.findParameter("result").orElseThrow().valueBoolean
+    resp.findParameter("code").orElseThrow().valueCode == "code1"
+  }
+
+  def "\$validate-code on a supplement-bound value set also accepts the supplement system and no system"() {
+    expect:
+    validate(system, "code1").findParameter("result").orElseThrow().valueBoolean
+
+    where:
+    system << ["http://example.org/CodeSystem/suppl-lt", null]
+  }
+
+  def "\$validate-code on a supplement-bound value set rejects a code not in the value set"() {
+    when:
+    def resp = validate("http://example.org/CodeSystem/suppl-base", "nope")
+
+    then:
+    !resp.findParameter("result").orElseThrow().valueBoolean
+  }
+
+  private Parameters validate(String system, String code) {
+    def params = [
+        new ParametersParameter().setName("url").setValueUri("http://example.org/ValueSet/suppl-vs"),
+        new ParametersParameter().setName("code").setValueCode(code)]
+    if (system != null) {
+      params.add(new ParametersParameter().setName("system").setValueUri(system))
+    }
+    vsValidate.run(new Parameters().setParameter(params))
   }
 
   private String fixture(String path) {


### PR DESCRIPTION
A value set that references a supplement via the `valueset-supplement` extension binds its rule to the **supplement** code system, so expanded members carry the supplement as their code system while `$expand` presents (and users validate against) the **base**. `$validate-code` matched only the member's own `codeSystemUri`, so validating a base concept with `system=<base>` returned *"not in the value set"* — even though `$expand` showed `system=<base>`.

Fix: match the requested system against the member's **base** code system uri as well as its own. Validating with `system=<base>`, `system=<supplement>`, or no system all resolve the code now.

Found by running the docs REST-client suite (`docs/rest-client/fhir-terminology-supplement.http`) end-to-end — request #11 (expected `result=true`) was returning false; all other 14 requests passed. It's a pre-existing bug (the filter predates the kodality→termx rename), not a session regression.

## Verification
- All 15 `.http` requests now behave as documented (base/Estonian/Russian displays, designations once, both validate-code cases, inline expand).
- `ValueSetSupplementExpandIT` extended: base-system → true, supplement-system/no-system → true, not-in-VS → false. **7/0.**
- `terminology` unit 254/0; full VS/FHIR integtest green.