### PR TITLE
FHIR $validate-code: structured OperationOutcome issues on error responses (Phase 1)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -1,0 +1,44 @@
+package org.termx.terminology.fhir;
+
+import com.kodality.zmei.fhir.datatypes.CodeableConcept;
+import com.kodality.zmei.fhir.datatypes.Coding;
+import com.kodality.zmei.fhir.resource.other.OperationOutcome;
+import com.kodality.zmei.fhir.resource.other.OperationOutcome.OperationOutcomeIssue;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Builders for the {@code issues} OperationOutcome that FHIR terminology operations attach to their
+ * responses. The HL7 tx-ecosystem expects {@code $validate-code}/{@code $expand}/{@code $lookup} to report
+ * problems (unknown system/version/code, code-not-in-value-set, deprecation, …) as a 200 response carrying a
+ * structured OperationOutcome — each issue with a severity, an FHIR issue code, a
+ * {@code http://hl7.org/fhir/tools/CodeSystem/tx-issue-type} coding, a human text, and the location it
+ * applies to — rather than a flat message or a 4xx. This centralises that shape.
+ */
+public final class TxIssues {
+  /** The tx-ecosystem issue-type code system used in OperationOutcome {@code details.coding}. */
+  public static final String TX_ISSUE_TYPE = "http://hl7.org/fhir/tools/CodeSystem/tx-issue-type";
+
+  private TxIssues() {
+  }
+
+  /** A single OperationOutcome issue: FHIR {@code severity}/{@code code}, a tx-issue-type detail coding + text, and the location(s) it applies to. */
+  public static OperationOutcomeIssue issue(String severity, String code, String txIssueType, String text, String... location) {
+    OperationOutcomeIssue issue = new OperationOutcomeIssue()
+        .setSeverity(severity)
+        .setCode(code)
+        .setDetails(new CodeableConcept(new Coding(TX_ISSUE_TYPE, txIssueType)).setText(text));
+    if (location != null && location.length > 0) {
+      issue.setLocation(Arrays.asList(location));
+      issue.setExpression(Arrays.asList(location));
+    }
+    return issue;
+  }
+
+  /** Wraps issues into an OperationOutcome (for the {@code issues} response parameter). */
+  public static OperationOutcome outcome(OperationOutcomeIssue... issues) {
+    OperationOutcome outcome = new OperationOutcome();
+    outcome.setIssue(List.of(issues));
+    return outcome;
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -146,7 +146,7 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
 
     Concept concept = conceptService.query(cp).findFirst().orElse(null);
     if (concept == null) {
-      return error("Code '" + code + "' is invalid");
+      return invalidCode(csId, code, versionUri);
     }
 
     Set<String> validDisplays = extractDisplays(concept, displayLanguage);
@@ -179,6 +179,37 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     return new Parameters()
         .addParameter(new ParametersParameter("result").setValueBoolean(false))
         .addParameter(new ParametersParameter("message").setValueString(message));
+  }
+
+  /**
+   * Response for a code that is not in the code system: 200 with result=false, the resolved system/version
+   * echoed, and a structured {@code issues} OperationOutcome ({@code code-invalid} / tx-issue-type
+   * {@code invalid-code} at {@code code}) — the FHIR tx ecosystem shape, instead of a flat message.
+   */
+  private Parameters invalidCode(String csId, String code, String versionUri) {
+    CodeSystem cs = codeSystemService.load(csId).orElse(null);
+    String csUri = cs != null && StringUtils.isNotEmpty(cs.getUri()) ? cs.getUri() : csId;
+    String version = versionUri;
+    if (version == null) {
+      CodeSystemVersion last = codeSystemVersionService.loadLastVersion(csId);
+      version = last == null ? null : last.getVersion();
+    }
+    String message = "Unknown code '" + code + "' in the CodeSystem '" + csUri + "'"
+        + (StringUtils.isNotEmpty(version) ? " version '" + version + "'" : "");
+    Parameters result = new Parameters()
+        .addParameter(new ParametersParameter("result").setValueBoolean(false))
+        .addParameter(new ParametersParameter("code").setValueCode(code));
+    if (cs != null && StringUtils.isNotEmpty(cs.getUri())) {
+      result.addParameter(new ParametersParameter("system").setValueUri(cs.getUri()));
+    }
+    if (StringUtils.isNotEmpty(version)) {
+      result.addParameter(new ParametersParameter("version").setValueString(version));
+    }
+    result.addParameter(new ParametersParameter("message").setValueString(message));
+    result.addParameter(new ParametersParameter("issues").setResource(
+        org.termx.terminology.fhir.TxIssues.outcome(
+            org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "invalid-code", message, "code"))));
+    return result;
   }
 
   /** Finds a CodeSystem supplied inline via a tx-resource parameter whose url matches the requested url. */

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -238,7 +238,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     }
 
     if (concept == null) {
-      return error(String.format("The provided code %s is not in the value set", (system != null ? system  + "#" : "") + code));
+      return notInValueSet(finalCode, finalSystem, vsConcepts);
     }
 
     Parameters parameters = new Parameters();
@@ -418,6 +418,35 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     return new Parameters()
         .addParameter(new ParametersParameter("result").setValueBoolean(false))
         .addParameter(new ParametersParameter("message").setValueString(message));
+  }
+
+  /**
+   * Response for a code that is not in the value set: 200 with result=false, the code/system/version echoed,
+   * and a structured {@code issues} OperationOutcome ({@code code-invalid} with tx-issue-type {@code not-in-vs}
+   * and {@code invalid-code} at {@code code}) — the FHIR tx ecosystem shape, instead of a flat message only.
+   */
+  private static Parameters notInValueSet(String code, String system, List<ValueSetVersionConcept> vsConcepts) {
+    String version = vsConcepts.stream()
+        .filter(c -> system == null || systemMatches(c, system))
+        .map(c -> c.getConcept().getCodeSystemVersions())
+        .filter(java.util.Objects::nonNull).flatMap(List::stream)
+        .findFirst().orElse(null);
+    String message = String.format("The provided code %s is not in the value set", (system != null ? system + "#" : "") + code);
+    Parameters result = new Parameters()
+        .addParameter(new ParametersParameter("result").setValueBoolean(false))
+        .addParameter(new ParametersParameter("code").setValueCode(code));
+    if (system != null) {
+      result.addParameter(new ParametersParameter("system").setValueUri(system));
+    }
+    if (version != null) {
+      result.addParameter(new ParametersParameter("version").setValueString(version));
+    }
+    result.addParameter(new ParametersParameter("message").setValueString(message));
+    result.addParameter(new ParametersParameter("issues").setResource(
+        org.termx.terminology.fhir.TxIssues.outcome(
+            org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "not-in-vs", message, "code"),
+            org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "invalid-code", message, "code"))));
+    return result;
   }
 
 }


### PR DESCRIPTION
**Phase 1 (graceful degradation / OperationOutcome) slice.** validate-code error responses carried only a flat `message`; the FHIR tx ecosystem expects a structured `issues` OperationOutcome — severity, FHIR issue code, a `http://hl7.org/fhir/tools/CodeSystem/tx-issue-type` detail coding, text, and `location`.

- New `TxIssues` helper centralises the issue/outcome shape.
- ValueSet `$validate-code` *code not in value set* → 200, `result=false`, code/system/version echoed, + issues `[code-invalid/not-in-vs, code-invalid/invalid-code]` at `code`.
- CodeSystem `$validate-code` *invalid code* → message `Unknown code '<c>' in the CodeSystem '<url>' version '<v>'` + issue `code-invalid/invalid-code` at `code`, with code/system/version echoed.

Builds on #243 (unknown systemVersion). `terminology` 254/0; integtest validate/supplement 15/0; docs REST-client suite still passes.

## ⚠️ Critical blocker found (separate, larger)
This makes the validate-code error *shape* correct, but the conformance gain is **gated** on a bigger issue I uncovered while measuring: the HL7 tx validator sends the whole suite's resources **inline as `tx-resource`** on every call, and termx runs the **HL7 FHIR InstanceValidator on inbound operation Parameters** (kefhir `validation-profile` interceptor), which **rejects** those tx-resources on unknown terminology — e.g. `CodeSystem.versionAlgorithm` → *"Unknown Code System 'http://hl7.org/fhir/version-algorithm'"* → **HTTP 400 before the operation runs**. This 400s ~every validate/expand call and is the true source of the "278 4xx" bucket. `kefhir.validation-profile.enabled=false` did not disable it in kefhir R5.9 — needs a kefhir-level fix (tolerant terminology validation, or skip validation of tx-resources / terminology-operation inputs). Tracked separately; it's the #1 lever for the whole program.