### PR TITLE
Bump kefhir R5.10; disable inbound terminology validation (conformance: 39→83/599)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.9
+kefhirVersion=R5.10
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -122,6 +122,14 @@ loinc:
 terminology-ecosystem:
   coordination-server-url: ${TERMINOLOGY_ECOSYSTEM_URL:http://tx.fhir.org/tx-reg}
 
+kefhir:
+  validation:
+    # TermX IS the terminology authority — it validates codes through its own operations
+    # ($validate-code/$expand), not the inbound FHIR profile validator. Strict terminology checks on
+    # inbound resources reject ones referencing code systems not in the validator's context (e.g. a
+    # passed-in tx-resource's CodeSystem.versionAlgorithm), which 400s otherwise-valid operation calls.
+    no-terminology-checks: ${KEFHIR_NO_TERMINOLOGY_CHECKS:true}
+
 chef.url: https://demo.termx.org/chef
 #github:
 #  client:


### PR DESCRIPTION
Consumes **kefhir R5.10** (termx-health/kefhir#9), which adds `kefhir.validation.no-terminology-checks`, and enables it.

TermX is the terminology authority — it validates codes through its own operations (`$validate-code`/`$expand`), not the inbound FHIR profile validator. Strict terminology checks during inbound validation **reject otherwise-valid operation calls** whose tx-resources reference code systems absent from the validator's context (e.g. `CodeSystem.versionAlgorithm` → `http://hl7.org/fhir/version-algorithm`), returning **HTTP 400 before the operation runs**. This was the single biggest tx-ecosystem conformance blocker — the HL7 tester sends the whole suite's resources inline as tx-resources on every call.

Enables `no-terminology-checks` in `application.yml` (overridable via `KEFHIR_NO_TERMINOLOGY_CHECKS`).

## Measured impact (full tx-ecosystem run)
- Overall **39 → 83 / 599** (0.06 → 0.13)
- `version` suite **0 → 35/206**, `validation` **0 → 9/54** — the remaining failures are now *content* diffs (the next phases), no longer 400s.

## Verification
- `terminology` 254/0; `termx-integtest` **124/0** — no regression from relaxing inbound terminology validation.
- Verified the previously-400ing `validation-simple-code-good` now returns a `Parameters` (result=true) with **0** `version-algorithm` errors.

> ⚠️ Merge order: requires kefhir **R5.10** to be in GitHub Packages first (kefhir#9 merged; its Build & Publish CI is running).