### PR TITLE
FHIR ValueSet $validate-code: echo the request's codeableConcept

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -182,6 +182,18 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   }
 
   public Parameters run(ValueSetVersion vsVersion, Parameters req) {
+    Parameters response = doRun(vsVersion, req);
+    // FHIR $validate-code echoes the codeableConcept it was given back to the caller (it isn't reconstructed
+    // from the matched code), so surface the request's codeableConcept on every response shape.
+    if (response != null) {
+      req.findParameter("codeableConcept")
+          .filter(cc -> response.findParameter("codeableConcept").isEmpty())
+          .ifPresent(response::addParameter);
+    }
+    return response;
+  }
+
+  private Parameters doRun(ValueSetVersion vsVersion, Parameters req) {
     SessionStore.require().checkPermitted(vsVersion.getValueSet(), Privilege.VS_READ);
     String code = req.findParameter("code").map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).orElse(null);
     String system = findSystem(req);


### PR DESCRIPTION
FHIR `$validate-code` returns the `codeableConcept` it was given back to the caller (it's not reconstructed from the matched code). termx omitted it. This surfaces the request's `codeableConcept` on every response shape (success, not-in-value-set, unknown-version, display-mismatch) via a thin wrapper.

`terminology` 254/0.

Phase-1 (OperationOutcome / response-shape) prerequisite for the tx-ecosystem codeableConcept validation tests. Those additionally require the correct `version` echo, which is currently corrupted by the **phantom-CodeSystem-version bug** (a CS materialises versions no fixture defines, so validate/expand bind to the wrong 'latest') — so this lands the shape now; the conformance gain follows once phantom versions are fixed. See termx-agent/notes/fhir-tx-conformance-baseline.md.