### PR TITLE
fix(terminology): stop folding distinct canonicals into one resource on id collision

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conformance/TxConformanceSetupLoader.java
@@ -103,10 +103,31 @@ public class TxConformanceSetupLoader {
     try (Stream<Path> s = Files.walk(root)) {
       return s.filter(Files::isRegularFile)
           .filter(p -> isSetupFile(p.getFileName().toString(), prefix))
-          .sorted(Comparator.comparing(Path::toString))
+          // Canonical resources (FHIR id == url's last segment) FIRST, so they claim their natural id before
+          // a resource that reuses that id under a different url. The tx-ecosystem ships
+          // codesystem-overload-1.json with id "simple" but url ".../overload"; loaded before the real
+          // codesystem-simple.json it would hijack the "simple" code system and pollute it with phantom
+          // versions. termx keys on the resource id, so order matters; this makes it deterministic.
+          .sorted(Comparator.comparingInt(TxConformanceSetupLoader::canonicalRank).thenComparing(Path::toString))
           .toList();
     } catch (Exception e) {
       throw new RuntimeException("failed scanning test package " + root, e);
+    }
+  }
+
+  /** 0 when the resource's FHIR id matches its url's last segment (a "canonical" resource), 1 otherwise. */
+  static int canonicalRank(Path p) {
+    try {
+      JsonNode r = JsonUtil.getObjectMapper().readTree(p.toFile());
+      String id = r.path("id").asText("");
+      String url = r.path("url").asText("");
+      if (id.isEmpty() || url.isEmpty()) {
+        return 0;
+      }
+      String last = url.contains("/") ? url.substring(url.lastIndexOf('/') + 1) : url;
+      return id.equals(last) ? 0 : 1;
+    } catch (Exception e) {
+      return 0;
     }
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemImportService.java
@@ -155,20 +155,38 @@ public class CodeSystemImportService {
     if (StringUtils.isEmpty(codeSystem.getUri())) {
       return;
     }
-    codeSystemService.query(new org.termx.ts.codesystem.CodeSystemQueryParams().setUri(codeSystem.getUri()).limit(1)).findFirst()
+    // (1) The same canonical (url) is already stored under a different id — adopt that id so this import
+    // becomes a NEW VERSION of it (the tx-ecosystem ships versions of one canonical as separate resources).
+    String byUri = codeSystemService.query(new org.termx.ts.codesystem.CodeSystemQueryParams().setUri(codeSystem.getUri()).limit(1)).findFirst()
         .map(CodeSystem::getId)
         .filter(existingId -> !existingId.equals(codeSystem.getId()))
-        .ifPresent(existingId -> {
-          log.info("Reconciling code system '{}' to existing canonical id '{}' (uri {})", codeSystem.getId(), existingId, codeSystem.getUri());
-          codeSystem.setId(existingId);
-          // Propagate the adopted id to every nested reference (versions, concepts and their entity versions),
-          // whose code_system FK still points at the old id.
-          Optional.ofNullable(codeSystem.getVersions()).orElse(List.of()).forEach(v -> v.setCodeSystem(existingId));
-          Optional.ofNullable(codeSystem.getConcepts()).orElse(List.of()).forEach(concept -> {
-            concept.setCodeSystem(existingId);
-            Optional.ofNullable(concept.getVersions()).orElse(List.of()).forEach(ev -> ev.setCodeSystem(existingId));
-          });
-        });
+        .orElse(null);
+    if (byUri != null) {
+      rekey(codeSystem, byUri, "Reconciling code system to existing canonical id");
+      return;
+    }
+    // (2) Our id is already taken by a code system with a DIFFERENT url. A FHIR resource id is not the
+    // canonical identity (the url is) — the tx-ecosystem deliberately reuses id "simple" for url "overload".
+    // Keying on the resource id would fold this distinct canonical into the other one (phantom versions), so
+    // re-key off our own url instead.
+    CodeSystem clash = StringUtils.isEmpty(codeSystem.getId()) ? null : codeSystemService.load(codeSystem.getId()).orElse(null);
+    if (clash != null && !codeSystem.getUri().equals(clash.getUri())) {
+      String urlId = org.termx.core.fhir.BaseFhirMapper.fhirIdOrFromUrl(null, codeSystem.getUri());
+      if (StringUtils.isNotEmpty(urlId) && !urlId.equals(codeSystem.getId())) {
+        rekey(codeSystem, urlId, "Re-keying code system off url (id collides with a different canonical)");
+      }
+    }
+  }
+
+  /** Re-points a code system and all its nested versions/concepts/entity-versions at {@code newId}. */
+  private void rekey(CodeSystem codeSystem, String newId, String why) {
+    log.info("{}: '{}' -> '{}' (uri {})", why, codeSystem.getId(), newId, codeSystem.getUri());
+    codeSystem.setId(newId);
+    Optional.ofNullable(codeSystem.getVersions()).orElse(List.of()).forEach(v -> v.setCodeSystem(newId));
+    Optional.ofNullable(codeSystem.getConcepts()).orElse(List.of()).forEach(concept -> {
+      concept.setCodeSystem(newId);
+      Optional.ofNullable(concept.getVersions()).orElse(List.of()).forEach(ev -> ev.setCodeSystem(newId));
+    });
   }
 
   private void saveCodeSystem(CodeSystem codeSystem) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetImportService.java
@@ -88,15 +88,32 @@ public class ValueSetImportService {
     if (StringUtils.isEmpty(valueSet.getUri())) {
       return;
     }
-    valueSetService.query(new org.termx.ts.valueset.ValueSetQueryParams().setUri(valueSet.getUri()).limit(1)).findFirst()
+    // (1) Same canonical (url) already stored under a different id — adopt it (a new version of it).
+    String byUri = valueSetService.query(new org.termx.ts.valueset.ValueSetQueryParams().setUri(valueSet.getUri()).limit(1)).findFirst()
         .map(ValueSet::getId)
         .filter(existingId -> !existingId.equals(valueSet.getId()))
-        .ifPresent(existingId -> {
-          log.info("Reconciling value set '{}' to existing canonical id '{}' (uri {})", valueSet.getId(), existingId, valueSet.getUri());
-          valueSet.setId(existingId);
-          // Propagate the adopted id to the nested versions, whose value_set FK still points at the old id.
-          Optional.ofNullable(valueSet.getVersions()).orElse(List.of()).forEach(v -> v.setValueSet(existingId));
-        });
+        .orElse(null);
+    if (byUri != null) {
+      rekey(valueSet, byUri, "Reconciling value set to existing canonical id");
+      return;
+    }
+    // (2) Our id is already taken by a value set with a DIFFERENT url. The url is the canonical identity, not
+    // the FHIR resource id (the tx-ecosystem reuses id "sct-procedures" across several urls). Re-key off our
+    // own url so this distinct canonical doesn't fold into the other one.
+    ValueSet clash = StringUtils.isEmpty(valueSet.getId()) ? null : valueSetService.load(valueSet.getId());
+    if (clash != null && !valueSet.getUri().equals(clash.getUri())) {
+      String urlId = org.termx.core.fhir.BaseFhirMapper.fhirIdOrFromUrl(null, valueSet.getUri());
+      if (StringUtils.isNotEmpty(urlId) && !urlId.equals(valueSet.getId())) {
+        rekey(valueSet, urlId, "Re-keying value set off url (id collides with a different canonical)");
+      }
+    }
+  }
+
+  /** Re-points a value set and its nested versions at {@code newId}. */
+  private void rekey(ValueSet valueSet, String newId, String why) {
+    log.info("{}: '{}' -> '{}' (uri {})", why, valueSet.getId(), newId, valueSet.getUri());
+    valueSet.setId(newId);
+    Optional.ofNullable(valueSet.getVersions()).orElse(List.of()).forEach(v -> v.setValueSet(newId));
   }
 
   private void saveValueSet(ValueSet valueSet) {


### PR DESCRIPTION
## Problem

A FHIR resource's identity is its canonical `url`, not its resource `id`. The tx-ecosystem deliberately reuses a resource id across different urls — e.g. `codesystem-overload-1.json` carries `id: "simple"` but `url: ".../overload"`. TermX keys CodeSystems/ValueSets by resource id, so importing such a resource **folded it into the existing canonical** with the same id:

- `GET /ts/code-systems/simple/versions` returned **0.1.0 + 1.0.0 + 2.0.0**, where only `0.1.0` is actually defined (1.0.0/2.0.0 leaked in from the overload fixtures).
- Expansions and `$validate-code` then bound `simple` codes to the wrong "latest" version, corrupting the `version` field in conformance responses.

## Fix

- **`reconcileCanonicalId`** (CodeSystemImportService + ValueSetImportService) gains a second arm: when our `id` is already taken by a resource with a **different** `url`, re-key off our own url (`fhirIdOrFromUrl`) instead of colliding into the other canonical.
- **`TxConformanceSetupLoader`** loads canonical resources (FHIR id == url's last segment) first, so they claim their natural id before a resource that reuses that id under a different url — making the import order-independent.

## Verification

After a clean load: `simple` has **only 0.1.0**; `overload` exists **separately** at 1.0.0/2.0.0. Regression green — terminology 254/254, integtest 124/124.