### PR TITLE
test(integtest): align tx-resource validate-code IT with richer outcome shape

### DIFF
--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetValidateCodeTxResourceIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetValidateCodeTxResourceIT.groovy
@@ -60,8 +60,10 @@ class ValueSetValidateCodeTxResourceIT extends TermxIntegTest {
     when:
     def resp = validate("c3", ["c1", "c2"])
 
-    then:
+    then: "result is false, the message reports the code is not found, and a structured issues OperationOutcome is returned"
     !resp.findParameter("result").orElseThrow().valueBoolean
-    resp.findParameter("message").orElseThrow().valueString.contains("not in the value set")
+    resp.findParameter("message").orElseThrow().valueString.contains("not found in the value set")
+    def issue = resp.findParameter("issues").orElseThrow().resource.getIssue().first()
+    issue.getDetails().getCoding().first().getCode() == "not-in-vs"
   }
 }


### PR DESCRIPTION
Follow-up to [#249](https://github.com/termx-health/termx-server/pull/249). That PR changed the inline `$validate-code` 'code not in value set' response to the HL7 wording (`… was not found in the value set …`) and added a structured `issues` OperationOutcome, but `ValueSetValidateCodeTxResourceIT` still asserted the old `not in the value set` substring and so failed.

Updates the assertion to the new message and additionally asserts the `not-in-vs` issue. `:termx-integtest:test` green (124).