### PR TITLE
fix(terminology): inline $expand surfaces supplement designations/displays

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -306,7 +306,12 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     return new ConceptQueryParams()
         .setIncludeSupplement(true)
         .setDisplayLanguage(displayLanguage)
-        .setUseSupplement(extractUseSupplement(req));
+        .setUseSupplement(extractUseSupplement(req))
+        // The supplement's own concepts are loaded through ConceptService, which filters by permitted code
+        // systems — a null list matches NOTHING (`code_system in (null)`), so without this the supplement
+        // designations never load and the inline expansion silently keeps the base display. Scope it to the
+        // caller's CS_READ grants.
+        .setPermittedCodeSystems(SessionStore.require().getPermittedResourceIds(Privilege.CS_READ));
   }
 
   private static String extractUseSupplement(Parameters req) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
@@ -1,6 +1,5 @@
 package org.termx.terminology.terminology.codesystem.concept;
 
-import com.kodality.commons.model.QueryResult;
 import org.termx.terminology.terminology.codesystem.CodeSystemRepository;
 import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService;
 import org.termx.ts.PublicationStatus;
@@ -34,7 +33,6 @@ import org.apache.commons.lang3.StringUtils;
 @Singleton
 @RequiredArgsConstructor
 public class ConceptSupplementService {
-  private final ConceptRepository conceptRepository;
   private final CodeSystemRepository codeSystemRepository;
   private final CodeSystemVersionService codeSystemVersionService;
   private final CodeSystemEntityVersionService codeSystemEntityVersionService;
@@ -100,7 +98,7 @@ public class ConceptSupplementService {
           }
           List<String> codes = csMembers.stream().map(m -> m.getConcept().getCode()).filter(StringUtils::isNotBlank).distinct().toList();
           Map<String, List<Designation>> byCode = new LinkedHashMap<>();
-          supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), codes, supplement.version(), params).forEach(concept -> {
+          supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), baseCodeSystem, codes, supplement.version(), params).forEach(concept -> {
             List<Designation> designations = concept.getVersions() == null ? List.of() : concept.getVersions().stream()
                 .flatMap(v -> Optional.ofNullable(v.getDesignations()).orElse(List.of()).stream())
                 .filter(d -> languageMatches(d.getLanguage(), params.getDisplayLanguage()))
@@ -149,7 +147,7 @@ public class ConceptSupplementService {
     }
 
     Map<String, List<Designation>> supplementDesignations = new LinkedHashMap<>();
-    supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), codes, supplement.version(), params).forEach(concept -> {
+    supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), baseCodeSystem, codes, supplement.version(), params).forEach(concept -> {
       List<Designation> designations = concept.getVersions() == null ? List.of() : concept.getVersions().stream()
           .flatMap(v -> Optional.ofNullable(v.getDesignations()).orElse(List.of()).stream())
           .filter(d -> languageMatches(d.getLanguage(), params.getDisplayLanguage()))
@@ -163,36 +161,37 @@ public class ConceptSupplementService {
     concepts.forEach(concept -> mergeConceptDesignations(concept, supplementDesignations.getOrDefault(concept.getCode(), List.of())));
   }
 
-  private List<Concept> loadSupplementConcepts(String supplementCodeSystem, List<String> codes, String version, ConceptQueryParams params) {
-    ConceptQueryParams supplementParams = new ConceptQueryParams()
-        .setCodeSystem(supplementCodeSystem)
-        .setCodes(codes)
-        .setCodeSystemVersion(version)
-        .setPermittedCodeSystems(params.getPermittedCodeSystems())
-        .limit(codes.size());
-
-    QueryResult<Concept> result = conceptRepository.query(supplementParams);
-    result.setData(decorate(result.getData(), supplementParams));
-    return result.getData();
-  }
-
-  private List<Concept> decorate(List<Concept> concepts, ConceptQueryParams params) {
-    if (CollectionUtils.isEmpty(concepts)) {
-      return concepts;
-    }
+  /**
+   * Loads a supplement's localized designations for the given base-system codes. A {@code content=supplement}
+   * code system does NOT create its own concept rows: its designations live on code system entity versions
+   * whose ENTITY belongs to the base code system but which are MEMBERS of the supplement's code system
+   * version (linked via {@code base_entity_version_id}). So we cannot find them through {@code ConceptRepository}
+   * by entity {@code code_system} (that yielded nothing) — we load the entity versions by code-system-version
+   * membership ({@code <supplement>|<version>}) and read their designations.
+   */
+  private List<Concept> loadSupplementConcepts(String supplementCodeSystem, String baseCodeSystem, List<String> codes, String version, ConceptQueryParams params) {
     CodeSystemEntityVersionQueryParams versionParams = new CodeSystemEntityVersionQueryParams();
-    versionParams.setCodeSystem(params.getCodeSystem());
-    versionParams.setCodeSystemVersion(params.getCodeSystemVersion());
-    versionParams.setCodeSystemVersionId(params.getCodeSystemVersionId());
-    versionParams.setCodeSystemVersions(params.getCodeSystemVersions());
+    versionParams.setCodeSystemVersions(supplementCodeSystem + "|" + version);
+    versionParams.setCode(String.join(",", codes));
+    // The membership query filters permitted code systems on BOTH the entity's code system (the base) and the
+    // version's code system (the supplement); a null (unrestricted) list matches NOTHING, so pass both
+    // explicitly when unrestricted. A restricted caller's grants are honored as-is.
+    versionParams.setPermittedCodeSystems(params.getPermittedCodeSystems() != null
+        ? params.getPermittedCodeSystems()
+        : List.of(baseCodeSystem, supplementCodeSystem));
     versionParams.all();
 
-    List<String> entityIds = concepts.stream().map(Concept::getId).filter(Objects::nonNull).map(String::valueOf).toList();
-    versionParams.setCodeSystemEntityIds(String.join(",", entityIds));
-    Map<String, List<CodeSystemEntityVersion>> versions = codeSystemEntityVersionService.query(versionParams).getData().stream()
-        .collect(Collectors.groupingBy(CodeSystemEntityVersion::getCode));
-    concepts.forEach(concept -> concept.setVersions(versions.getOrDefault(concept.getCode(), concept.getVersions())));
-    return concepts;
+    return codeSystemEntityVersionService.query(versionParams).getData().stream()
+        .collect(Collectors.groupingBy(CodeSystemEntityVersion::getCode, LinkedHashMap::new, Collectors.toList()))
+        .entrySet().stream()
+        .map(entry -> {
+          Concept concept = new Concept();
+          concept.setCode(entry.getKey());
+          concept.setCodeSystem(supplementCodeSystem);
+          concept.setVersions(entry.getValue());
+          return concept;
+        })
+        .toList();
   }
 
   private Map<String, List<ResolvedSupplement>> resolveSupplements(List<Concept> concepts, ConceptQueryParams params) {

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementServiceTest.groovy
@@ -6,6 +6,7 @@ import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersi
 import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService
 import org.termx.ts.codesystem.CodeSystem
 import org.termx.ts.codesystem.CodeSystemContent
+import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams
 import org.termx.ts.codesystem.CodeSystemQueryParams
 import org.termx.ts.codesystem.CodeSystemVersion
 import org.termx.ts.codesystem.CodeSystemVersionQueryParams
@@ -14,12 +15,11 @@ import org.termx.ts.codesystem.ConceptQueryParams
 import spock.lang.Specification
 
 class ConceptSupplementServiceTest extends Specification {
-  def conceptRepository = Mock(ConceptRepository)
   def codeSystemRepository = Mock(CodeSystemRepository)
   def codeSystemVersionService = Mock(CodeSystemVersionService)
   def codeSystemEntityVersionService = Mock(CodeSystemEntityVersionService)
 
-  def service = new ConceptSupplementService(conceptRepository, codeSystemRepository, codeSystemVersionService, codeSystemEntityVersionService)
+  def service = new ConceptSupplementService(codeSystemRepository, codeSystemVersionService, codeSystemEntityVersionService)
 
   def "mergeRuntimeSupplements resolves supplements without CodeSystemService"() {
     given:
@@ -49,7 +49,14 @@ class ConceptSupplementServiceTest extends Specification {
           it.codeSystem == "ucum-supplement-lt" &&
           it.status == "active"
     }) >> new QueryResult([supplementVersion])
-    1 * conceptRepository.query({ it.codeSystem == "ucum-supplement-lt" && it.codeSystemVersion == "2026" && it.codes == ["mg"] }) >> new QueryResult([])
-    0 * codeSystemEntityVersionService._
+    // The supplement's designations are loaded by code-system-VERSION membership (a supplement creates no
+    // concept rows of its own — its designations sit on base-entity versions that are members of the
+    // supplement version), scoped to the base + supplement code systems when the session is unrestricted.
+    1 * codeSystemEntityVersionService.query({
+      it instanceof CodeSystemEntityVersionQueryParams &&
+          it.codeSystemVersions == "ucum-supplement-lt|2026" &&
+          it.code == "mg" &&
+          it.permittedCodeSystems == ["ucum", "ucum-supplement-lt"]
+    }) >> new QueryResult([])
   }
 }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -118,6 +118,48 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
     !resp.findParameter("result").orElseThrow().valueBoolean
   }
 
+  def "inline \$expand auto-discovers a supplement for displayLanguage and surfaces its localized display (http example #16)"() {
+    given: "an inline value set referencing ONLY the base code system, expanded with displayLanguage=lt"
+    def req = inlineExpand("""
+      {"resourceType":"Parameters","parameter":[
+        {"name":"displayLanguage","valueCode":"lt"},
+        {"name":"includeDesignations","valueBoolean":true},
+        {"name":"valueSet","resource":{
+          "resourceType":"ValueSet","url":"http://example.org/ValueSet/inline-suppl-auto","status":"active",
+          "compose":{"include":[{"system":"http://example.org/CodeSystem/suppl-base"}]}}}]}""")
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "code1" }
+
+    then: "the lt supplement is auto-loaded by language; its Lithuanian display + designation surface"
+    contains != null
+    contains.display == "Gliukozė"
+    contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
+  }
+
+  def "inline \$expand with useSupplement and no displayLanguage keeps the base display but adds the supplement designation (http example #18)"() {
+    given: "an inline value set over the BASE, naming the supplement explicitly, NO displayLanguage"
+    def req = inlineExpand("""
+      {"resourceType":"Parameters","parameter":[
+        {"name":"useSupplement","valueCanonical":"http://example.org/CodeSystem/suppl-lt"},
+        {"name":"includeDesignations","valueBoolean":true},
+        {"name":"valueSet","resource":{
+          "resourceType":"ValueSet","url":"http://example.org/ValueSet/inline-suppl-use","status":"active",
+          "compose":{"include":[{"system":"http://example.org/CodeSystem/suppl-base"}]}}}]}""")
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "code1" }
+
+    then: "display stays the base English; the supplement's lt designation is surfaced"
+    contains != null
+    contains.display == "Glucose"
+    contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
+  }
+
+  private static Parameters inlineExpand(String json) {
+    com.kodality.zmei.fhir.FhirMapper.fromJson(json, Parameters)
+  }
+
   private Parameters validate(String system, String code) {
     def params = [
         new ParametersParameter().setName("url").setValueUri("http://example.org/ValueSet/suppl-vs"),


### PR DESCRIPTION
## Problem

Inline `$expand` (a `valueSet` supplied as a parameter, referencing only a base code system) didn't apply supplements — the new examples #16 and #18 in `docs/rest-client/fhir-terminology-supplement.http`:
- **#16** `displayLanguage=et` auto-discovery → display stayed the base English instead of the Estonian supplement display.
- **#18** repeated `useSupplement` with no `displayLanguage` → no supplement designation surfaced.

## Root cause (two layers)

1. **Supplement designations aren't queryable by entity `code_system`.** A `content=supplement` code system creates **no concept rows of its own**: its designations sit on code-system-entity versions whose ENTITY belongs to the *base*, made members of the supplement's code system *version* via `base_entity_version_id`. `loadSupplementConcepts` queried `ConceptRepository` by entity `code_system` (the supplement) → 0 rows → nothing merged. It now loads by **code-system-version membership** (`<supplement>|<version>`) and reads those versions' designations.
2. **Null permitted list matches nothing.** The supplement concept query is permission-filtered with `code_system in (<list>)`; a null list (an unrestricted session) matches NOTHING. `supplementParams` now passes the session's `CS_READ` grants, and the membership load scopes an unrestricted session to the base + supplement code systems explicitly.

## Tests

`ValueSetSupplementExpandIT` gains coverage for both inline scenarios (auto-discovery by `displayLanguage`; explicit `useSupplement` with no `displayLanguage`); they failed before, pass after. `ConceptSupplementService` unit test updated for the membership-based load. Regression green — terminology 254, integtest 126.

Also removes the now-dead `ConceptRepository` dependency + `decorate` helper from `ConceptSupplementService`.