### PR TITLE
fix(terminology): include all supplement designations regardless of displayLanguage

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
@@ -99,9 +99,13 @@ public class ConceptSupplementService {
           List<String> codes = csMembers.stream().map(m -> m.getConcept().getCode()).filter(StringUtils::isNotBlank).distinct().toList();
           Map<String, List<Designation>> byCode = new LinkedHashMap<>();
           supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), baseCodeSystem, codes, supplement.version(), params).forEach(concept -> {
+            // Include ALL of the supplement's designations, not just the displayLanguage's: per FHIR,
+            // includeDesignations returns every designation, and displayLanguage only selects which one
+            // becomes the display (done in applySupplementDesignations below). Filtering here dropped a
+            // useSupplement-named supplement's designations whenever displayLanguage differed (e.g. an
+            // explicit Russian supplement requested with displayLanguage=en surfaced nothing).
             List<Designation> designations = concept.getVersions() == null ? List.of() : concept.getVersions().stream()
                 .flatMap(v -> Optional.ofNullable(v.getDesignations()).orElse(List.of()).stream())
-                .filter(d -> languageMatches(d.getLanguage(), params.getDisplayLanguage()))
                 .map(d -> d.setSupplement(true))
                 .toList();
             if (CollectionUtils.isNotEmpty(designations)) {
@@ -148,9 +152,10 @@ public class ConceptSupplementService {
 
     Map<String, List<Designation>> supplementDesignations = new LinkedHashMap<>();
     supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), baseCodeSystem, codes, supplement.version(), params).forEach(concept -> {
+      // Include ALL supplement designations regardless of displayLanguage (it only selects the display) —
+      // see mergeSupplementsIntoExpansion.
       List<Designation> designations = concept.getVersions() == null ? List.of() : concept.getVersions().stream()
           .flatMap(v -> Optional.ofNullable(v.getDesignations()).orElse(List.of()).stream())
-          .filter(d -> languageMatches(d.getLanguage(), params.getDisplayLanguage()))
           .map(d -> d.setSupplement(true))
           .toList();
       if (CollectionUtils.isNotEmpty(designations)) {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -176,6 +176,26 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
     contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
   }
 
+  def "inline \$expand with useSupplement and a matching displayLanguage uses the supplement display AND surfaces its designation (http example #17)"() {
+    given: "an inline value set over the BASE, naming the lt supplement, with displayLanguage=lt (matching)"
+    def req = inlineExpand("""
+      {"resourceType":"Parameters","parameter":[
+        {"name":"displayLanguage","valueCode":"lt"},
+        {"name":"useSupplement","valueCanonical":"http://example.org/CodeSystem/suppl-lt"},
+        {"name":"includeDesignations","valueBoolean":true},
+        {"name":"valueSet","resource":{
+          "resourceType":"ValueSet","url":"http://example.org/ValueSet/inline-suppl-use-matching","status":"active",
+          "compose":{"include":[{"system":"http://example.org/CodeSystem/suppl-base"}]}}}]}""")
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "code1" }
+
+    then: "the display is re-picked to the supplement's Lithuanian value and the lt designation surfaces"
+    contains != null
+    contains.display == "Gliukozė"
+    contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
+  }
+
   private static Parameters inlineExpand(String json) {
     com.kodality.zmei.fhir.FhirMapper.fromJson(json, Parameters)
   }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -156,6 +156,26 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
     contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
   }
 
+  def "inline \$expand with useSupplement surfaces the supplement's designations even when displayLanguage is a different language"() {
+    given: "an inline value set over the BASE, naming the lt supplement, but displayLanguage=en (a different language)"
+    def req = inlineExpand("""
+      {"resourceType":"Parameters","parameter":[
+        {"name":"displayLanguage","valueCode":"en"},
+        {"name":"useSupplement","valueCanonical":"http://example.org/CodeSystem/suppl-lt"},
+        {"name":"includeDesignations","valueBoolean":true},
+        {"name":"valueSet","resource":{
+          "resourceType":"ValueSet","url":"http://example.org/ValueSet/inline-suppl-otherlang","status":"active",
+          "compose":{"include":[{"system":"http://example.org/CodeSystem/suppl-base"}]}}}]}""")
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "code1" }
+
+    then: "displayLanguage=en only picks the display (base English); the explicitly-named supplement's lt designation still surfaces"
+    contains != null
+    contains.display == "Glucose"
+    contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
+  }
+
   private static Parameters inlineExpand(String json) {
     com.kodality.zmei.fhir.FhirMapper.fromJson(json, Parameters)
   }


### PR DESCRIPTION
## Problem

A supplement's designations were filtered by `displayLanguage` before being merged into the expansion, so an explicitly `useSupplement`-named supplement surfaced **no designations** whenever `displayLanguage` named a different language — e.g. the Russian supplement requested with `displayLanguage=en` returned no Russian designations, even though it was explicitly named.

## Fix

Per FHIR, `includeDesignations` returns *every* designation and `displayLanguage` only selects which one becomes the **display**. So include all of a resolved supplement's designations; the display is still picked by `displayLanguage` in `applySupplementDesignations`. Applies to both the `$expand` merge and the `$lookup`/`$validate-code` runtime merge.

## Tests (`ValueSetSupplementExpandIT`)

- `useSupplement` + `displayLanguage` in a **different** language → display stays base, supplement designation still surfaces (the reported bug).
- `useSupplement` + a **matching** `displayLanguage` → display re-picked to the supplement value + designation surfaces.

Regression green — terminology 254, integtest 128.