### PR TITLE
fix(fhir): default $expand display language to the value set's resource language

### DIFF
--- a/docs/rest-client/fhir-terminology-supplement.http
+++ b/docs/rest-client/fhir-terminology-supplement.http
@@ -102,6 +102,7 @@ Content-Type: application/fhir+json
 
 ### 4. STATIC ValueSet — includes the BASE and references the Estonian supplement
 #    via the standard `valueset-supplement` extension (include.system = base CS).
+#    The resource `language` = et makes $expand default its display to Estonian (see #7).
 # expect: 200/201.
 POST {{fhir}}/ValueSet
 Authorization: Bearer {{token}}
@@ -112,6 +113,7 @@ Content-Type: application/fhir+json
   "id": "tx-rest-demo-color-vs-et",
   "url": "{{vsEt}}",
   "version": "1.0.0",
+  "language": "et",
   "name": "TxRestDemoColorVsEt",
   "title": "TermX REST demo — colors VS (Estonian)",
   "status": "active",
@@ -135,6 +137,7 @@ Content-Type: application/fhir+json
   "id": "tx-rest-demo-color-vs-ru",
   "url": "{{vsRu}}",
   "version": "1.0.0",
+  "language": "ru",
   "name": "TxRestDemoColorVsRu",
   "title": "TermX REST demo — colors VS (Russian)",
   "status": "active",
@@ -158,8 +161,11 @@ GET {{fhir}}/ValueSet/tx-rest-demo-color-vs-et
 Authorization: Bearer {{token}}
 Accept: application/fhir+json
 
-### 7. $expand (by id), default language
-# expect: expansion.contains = red/green/blue with ENGLISH displays (Red/Green/Blue).
+### 7. $expand (by id), NO displayLanguage — defaults to the value set's resource language
+#    The value set declares language=et (#4), so with no displayLanguage the display defaults
+#    to Estonian (its supplement displays) instead of always English. A value set WITHOUT a
+#    resource language defaults to English. An explicit displayLanguage always wins (#8/#9).
+# expect: red/green/blue with ESTONIAN displays — punane / roheline / sinine.
 GET {{fhir}}/ValueSet/tx-rest-demo-color-vs-et/$expand
 Authorization: Bearer {{token}}
 Accept: application/fhir+json

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -170,10 +170,17 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       throw new FhirException(404, IssueType.NOTFOUND, "value set version not found");
     }
 
-    String displayLanguage = req == null ? null : req.findParameter("displayLanguage").map(ParametersParameter::getValueCode)
+    String requestedLanguage = req == null ? null : req.findParameter("displayLanguage").map(ParametersParameter::getValueCode)
         .orElse(req.findParameter("displayLanguage").map(ParametersParameter::getValueString)
         .orElse(req.findParameter("defaultLanguage").map(ParametersParameter::getValueCode)
         .orElse(req.findParameter("defaultLanguage").map(ParametersParameter::getValueString).orElse(null))));
+    // Default the display language: an explicit request wins; otherwise fall back to the value set's own
+    // resource language (FHIR ValueSet.language → version.preferredLanguage), and finally to "en". So a
+    // localized value set (e.g. language=et with an Estonian supplement) renders its Estonian displays by
+    // default instead of always English.
+    String vsLanguage = version.getPreferredLanguage();
+    String displayLanguage = StringUtils.isNotEmpty(requestedLanguage) ? requestedLanguage
+        : StringUtils.isNotEmpty(vsLanguage) ? vsLanguage : "en";
     boolean includeDesignations = req != null && req.findParameter("includeDesignations")
         .map(pr -> pr.getValueBoolean() != null && pr.getValueBoolean() || "true".equals(pr.getValueString()))
         .orElse(false);
@@ -183,10 +190,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
 
     // Layer supplements (e.g. a SNOMED-based supplement's localized designations) onto the expanded
     // members. The external SNOMED expand provider fetches base concepts from Snowstorm but never applies
-    // supplements, so they were absent from $expand. Only run on the freshly-computed (non-cached) view —
-    // a displayLanguage or includeDesignations request bypasses the request-agnostic default snapshot, so
-    // the members here are safe to enrich in place.
-    if (StringUtils.isNotEmpty(displayLanguage) || includeDesignations) {
+    // supplements, so they were absent from $expand. Fire only when a language/designations were actually
+    // requested, the value set declares its own resource language (its displays are meant to be localized),
+    // or a supplement is explicitly named — NOT for a plain English-default expand, so the common path
+    // keeps its request-agnostic snapshot without paying for supplement auto-discovery.
+    boolean applySupplements = StringUtils.isNotEmpty(requestedLanguage) || StringUtils.isNotEmpty(vsLanguage)
+        || includeDesignations || StringUtils.isNotEmpty(extractUseSupplement(req));
+    if (applySupplements) {
       conceptSupplementService.mergeSupplementsIntoExpansion(expandedConcepts, supplementParams(displayLanguage, req));
     }
     List<Provenance> provenances = provenanceService.find("ValueSetVersion|" + version.getId());

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -164,7 +164,7 @@ public class ValueSetVersionConceptService {
       }
       v.getDesignations().stream()
           .filter(d -> "display".equals(d.getDesignationType()) && !PublicationStatus.retired.equals(d.getStatus()))
-          .filter(d -> d.getLanguage() != null && (d.getLanguage().equals(language) || d.getLanguage().startsWith(language)))
+          .filter(d -> d.getLanguage() != null && language != null && (d.getLanguage().equals(language) || d.getLanguage().startsWith(language)))
           .min(Comparator.comparing(Designation::isPreferred).reversed())
           .ifPresent(d -> result.putIfAbsent(v.getId(), d));
     }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -903,7 +903,8 @@ class ValueSetExpandOperationTest extends Specification {
 
     valueSetService.query(_) >> new QueryResult<>([vs])
     valueSetVersionService.loadLastVersion("vs1") >> vsv
-    valueSetVersionConceptService.expand("vs1", "1.0.0", null, false) >> snapshot
+    // No displayLanguage requested, so the operation falls back to the value set version's preferredLanguage ("en").
+    valueSetVersionConceptService.expand("vs1", "1.0.0", "en", false) >> snapshot
     provenanceService.find("ValueSetVersion|7") >> []
   }
 }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetSupplementExpandIT.groovy
@@ -87,6 +87,36 @@ class ValueSetSupplementExpandIT extends TermxIntegTest {
     contains.designation.findAll { it.language == "lt" && it.value == "Gliukozė" }.size() == 1
   }
 
+  def "\$expand with NO displayLanguage defaults the display to the value set's resource language"() {
+    given: "suppl-vs-lt declares the supplement binding AND language=lt; request omits displayLanguage"
+    vsImportService.importValueSet(fixture("fhir/supplement/vs-supplement-lt.json"), "suppl-vs-lt")
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri("http://example.org/ValueSet/suppl-vs-lt"),
+        new ParametersParameter().setName("includeDesignations").setValueBoolean(true)])
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "code1" }
+
+    then: "the display defaults to the resource language (lt) — the supplement's Lithuanian value — not English"
+    contains != null
+    contains.display == "Gliukozė"
+  }
+
+  def "\$expand with NO displayLanguage and a value set with no resource language defaults the display to English"() {
+    given: "suppl-vs-nolang declares the same supplement binding but no language"
+    vsImportService.importValueSet(fixture("fhir/supplement/vs-supplement-nolang.json"), "suppl-vs-nolang")
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri("http://example.org/ValueSet/suppl-vs-nolang"),
+        new ParametersParameter().setName("includeDesignations").setValueBoolean(true)])
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "code1" }
+
+    then: "with no resource language the display falls back to English (the base)"
+    contains != null
+    contains.display == "Glucose"
+  }
+
   def "\$validate-code on a supplement-bound value set validates a code under the BASE system"() {
     given: "a validate-code request naming the BASE code system (the value set rule is bound to the supplement)"
     def req = new Parameters().setParameter([

--- a/termx-integtest/src/test/resources/fhir/supplement/vs-supplement-lt.json
+++ b/termx-integtest/src/test/resources/fhir/supplement/vs-supplement-lt.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "ValueSet",
+  "id": "suppl-vs-lt",
+  "url": "http://example.org/ValueSet/suppl-vs-lt",
+  "version": "1.0.0",
+  "language": "lt",
+  "name": "supplVsLt",
+  "title": "Suppl VS (Lithuanian)",
+  "status": "active",
+  "extension": [ { "url": "http://hl7.org/fhir/StructureDefinition/valueset-supplement", "valueCanonical": "http://example.org/CodeSystem/suppl-lt|1.0.0" } ],
+  "compose": { "include": [ { "system": "http://example.org/CodeSystem/suppl-base", "version": "1.0.0" } ] }
+}

--- a/termx-integtest/src/test/resources/fhir/supplement/vs-supplement-nolang.json
+++ b/termx-integtest/src/test/resources/fhir/supplement/vs-supplement-nolang.json
@@ -1,0 +1,11 @@
+{
+  "resourceType": "ValueSet",
+  "id": "suppl-vs-nolang",
+  "url": "http://example.org/ValueSet/suppl-vs-nolang",
+  "version": "1.0.0",
+  "name": "supplVsNoLang",
+  "title": "Suppl VS (no language)",
+  "status": "active",
+  "extension": [ { "url": "http://hl7.org/fhir/StructureDefinition/valueset-supplement", "valueCanonical": "http://example.org/CodeSystem/suppl-lt|1.0.0" } ],
+  "compose": { "include": [ { "system": "http://example.org/CodeSystem/suppl-base", "version": "1.0.0" } ] }
+}


### PR DESCRIPTION
## Problem

`$expand` without a `displayLanguage` always rendered English, even for a value set that declares a resource `language` (FHIR `ValueSet.language`) — e.g. an Estonian value set bound to an Estonian supplement. `GET .../ValueSet/<et-vs>/$expand` returned English instead of Estonian.

## Fix

The display language now resolves as: **explicit request → the value set version's `preferredLanguage` (the resource language) → `en`**. So a localized value set renders its own language by default; one with no resource language defaults to English; an explicit `displayLanguage` always wins.

The supplement merge now fires when a language/designations were requested, the value set declares its own resource language, or a supplement is explicitly named — **not** for a plain English-default expand, so the common path keeps its request-agnostic snapshot without paying for supplement auto-discovery.

Also guards `loadDisplayDesignations` against a null `language` — an `$expand` with `includeDesignations=true` but no `displayLanguage` on a published snapshot NPE'd in the language-render path (exposed by the new test).

## Tests

`ValueSetSupplementExpandIT`: resource `language=lt` defaults the display to Lithuanian; a value set with no language defaults to English. `ValueSetExpandOperationTest` mock updated for the new default. Regression green — terminology 254, integtest 130. Updates `fhir-terminology-supplement.http` (language on the stored VSs; #7 now demonstrates the resource-language default).

Note: scoped to the stored `$expand` path; the inline (tx-resource) conformance path is untouched.