### PR TITLE
feat(fhir): honor the $expand designation parameter (filter returned designations)

### DIFF
--- a/docs/rest-client/fhir-terminology-expand-designations.http
+++ b/docs/rest-client/fhir-terminology-expand-designations.http
@@ -1,0 +1,122 @@
+# TermX FHIR terminology — REST Client suite ($expand designations)
+#
+# Open this file in VS Code with the "REST Client" extension (humao.rest-client) and click
+# "Send Request" above each request. Run them top to bottom: the SETUP block creates the
+# resources the test blocks depend on. Every request lists its expected result so the
+# correctness can be verified at a glance.
+#
+# Demonstrates the FHIR $expand designation controls:
+#   • includeDesignations — surface contains[].designation (language + use + value)
+#   • designation (0..*)  — restrict which designations appear, by language or use token
+#   • displayLanguage     — which designation becomes the contains[].display
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# Configure these for your server, then run the requests in order.
+# @fhir   — the FHIR base URL of your TermX server (no trailing slash).
+# @token  — a Bearer token with write access. Local dev (auth.dev.allowed=true): yupi{"privileges":["*.*.*"]}
+@fhir  = https://dev.termx.org/api/fhir
+@token = yupi{"privileges":["*.*.*"]}
+
+@cs = http://example.org/fhir/CodeSystem/tx-rest-demo-designations
+@vs = http://example.org/fhir/ValueSet/tx-rest-demo-designations
+
+
+###############################################################################
+# SETUP — a CodeSystem whose concept carries designations in several languages
+#         (and one with a SNOMED `use` coding), plus a ValueSet over it.
+###############################################################################
+
+### 1. Base CodeSystem — concept "c1" with et / ru designations + an en synonym (use coding)
+# expect: 200/201.
+PUT {{fhir}}/CodeSystem/tx-rest-demo-designations
+Authorization: Bearer {{token}}
+Content-Type: application/fhir+json
+
+{
+  "resourceType": "CodeSystem",
+  "id": "tx-rest-demo-designations",
+  "url": "{{cs}}",
+  "version": "1.0.0",
+  "name": "TxRestDemoDesignations",
+  "title": "TermX REST demo — designations",
+  "status": "active",
+  "content": "complete",
+  "language": "en",
+  "concept": [
+    {
+      "code": "c1",
+      "display": "Color one",
+      "designation": [
+        { "language": "et", "value": "Värv üks" },
+        { "language": "ru", "value": "Цвет один" },
+        { "use": { "system": "http://snomed.info/sct", "code": "900000000000013009" }, "language": "en", "value": "colour one (synonym)" }
+      ]
+    }
+  ]
+}
+
+### 2. ValueSet over the whole code system
+# expect: 200/201.
+POST {{fhir}}/ValueSet
+Authorization: Bearer {{token}}
+Content-Type: application/fhir+json
+
+{
+  "resourceType": "ValueSet",
+  "id": "tx-rest-demo-designations",
+  "url": "{{vs}}",
+  "version": "1.0.0",
+  "name": "TxRestDemoDesignationsVs",
+  "title": "TermX REST demo — designations VS",
+  "status": "active",
+  "compose": { "include": [ { "system": "{{cs}}" } ] }
+}
+
+
+###############################################################################
+# $expand — designation output and the `designation` filter
+###############################################################################
+
+### 3. includeDesignations=true — every designation is returned
+# expect: contains[0].designation lists ALL of: en "Color one" (use display), en "colour one (synonym)"
+#         (use 900000000000013009), ru "Цвет один", et "Värv üks". display = "Color one".
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?includeDesignations=true
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 4. designation=et — restrict the returned designations to Estonian
+# expect: contains[0].designation has ONLY the et designation ("Värv üks"); display stays "Color one".
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?includeDesignations=true&designation=et
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 5. designation=ru — restrict to Russian
+# expect: contains[0].designation has ONLY the ru designation ("Цвет один").
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?includeDesignations=true&designation=ru
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 6. designation=urn:ietf:bcp:47|et — a system|code LANGUAGE token (same as #4)
+# expect: contains[0].designation has ONLY the et designation.
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?includeDesignations=true&designation=urn:ietf:bcp:47|et
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 7. designation=et&designation=ru — multiple tokens union the matches
+# expect: contains[0].designation has BOTH the et and ru designations (and nothing else).
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?includeDesignations=true&designation=et&designation=ru
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 8. designation by USE coding — http://snomed.info/sct|900000000000013009
+# expect: contains[0].designation has ONLY the en synonym ("colour one (synonym)") that carries that use.
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?includeDesignations=true&designation=http://snomed.info/sct|900000000000013009
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 9. displayLanguage=et — picks the Estonian designation as the display
+# expect: contains[0].display = "Värv üks" (the displayLanguage selects the display; the `designation`
+#         filter is independent of it).
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?displayLanguage=et&includeDesignations=true
+Authorization: Bearer {{token}}
+Accept: application/fhir+json

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -313,6 +313,32 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     }).collect(toList());
   }
 
+  /** The FHIR language token systems for a {@code designation} parameter — a {@code system|code} with one of these matches by language. */
+  private static final Set<String> LANGUAGE_SYSTEMS = Set.of("urn:ietf:bcp:47", "http://hl7.org/fhir/ValueSet/languages");
+
+  /**
+   * Whether a designation passes the {@code designation} parameter filter. An empty filter matches everything
+   * (no restriction). A token matches when it equals (or is a language-prefix of) the designation's language,
+   * or equals its use/type code; a {@code system|code} token matches the use coding's system+code, or — when
+   * the system is a language system — the language.
+   */
+  private static boolean designationMatchesFilter(Designation d, List<String> tokens) {
+    if (CollectionUtils.isEmpty(tokens)) {
+      return true;
+    }
+    return tokens.stream().anyMatch(token -> {
+      String[] parts = token.contains("|") ? PipeUtil.parsePipe(token) : new String[]{null, token};
+      String system = parts.length > 1 ? parts[0] : null;
+      String code = parts.length > 1 ? parts[1] : parts[0];
+      if (system != null && !LANGUAGE_SYSTEMS.contains(system)) {
+        return code != null && code.equals(d.getDesignationType());
+      }
+      boolean languageMatch = d.getLanguage() != null && code != null
+          && (d.getLanguage().equals(code) || d.getLanguage().startsWith(code + "-"));
+      return languageMatch || (code != null && code.equals(d.getDesignationType()));
+    });
+  }
+
   private static ValueSetComposeIncludeConceptDesignation toFhirDesignation(Designation d) {
     ValueSetComposeIncludeConceptDesignation designation = new ValueSetComposeIncludeConceptDesignation();
     designation.setValue(d.getName());
@@ -479,6 +505,14 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     String lang = Optional.ofNullable(param).map(Resource::getLanguage).orElse(null);
     List<String> properties = ((param == null) || (param.getParameter() == null)) ? List.of() :
         param.getParameter().stream().filter(p -> "property".equals(p.getName())).map(ParametersParameter::getValueString).toList();
+    // FHIR $expand `designation` parameter (0..*): each token names a language or a use. When present, the
+    // expansion's contains[].designation is restricted to designations that match one of them (instead of
+    // emitting every designation). A bare token is a language; a `system|code` token matches a use coding
+    // (or a language when the system is the BCP-47 language system).
+    List<String> designationFilter = ((param == null) || (param.getParameter() == null)) ? List.of() :
+        param.getParameter().stream().filter(p -> "designation".equals(p.getName()))
+            .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString())
+            .filter(StringUtils::isNotEmpty).toList();
 
     ValueSetExpansionContains contains = new ValueSetExpansionContains();
     contains.setCode(c.getConcept().getCode());
@@ -492,6 +526,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     Set<String> seenDesignations = new HashSet<>();
     contains.setDesignation(CollectionUtils.isNotEmpty(c.getAdditionalDesignations()) && includeDesignations ? c.getAdditionalDesignations().stream()
         .filter(d -> !"definition".equals(d.getDesignationType()))
+        .filter(d -> designationMatchesFilter(d, designationFilter))
         .filter(d -> seenDesignations.add(d.getLanguage() + "|" + d.getName() + "|" + d.getDesignationType()))
         .sorted(Comparator.comparing(d -> !d.isPreferred())).map(designation -> {
           ValueSetComposeIncludeConceptDesignation d = new ValueSetComposeIncludeConceptDesignation();

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
@@ -1,0 +1,73 @@
+package org.termx.terminology.fhir
+
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
+
+/**
+ * $expand with the FHIR {@code designation} parameter: when present (0..*), each token (a language, or a
+ * {@code system|code} use/language) restricts which designations appear in {@code contains[].designation};
+ * absent, every designation is returned.
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandDesignationIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject ValueSetExpandOperation vsExpand
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    csImportService.importCodeSystem(fixture("fhir/designation/cs-designations.json"), "dg-cs")
+    vsImportService.importValueSet(fixture("fhir/designation/vs-designations.json"), "dg-vs")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  private List<String> expandDesignationLanguages(ParametersParameter... extra) {
+    def params = [
+        new ParametersParameter().setName("url").setValueUri("http://example.org/dg-vs"),
+        new ParametersParameter().setName("includeDesignations").setValueBoolean(true)]
+    params.addAll(extra)
+    def contains = vsExpand.run(new Parameters().setParameter(params)).expansion.contains.find { it.code == "c1" }
+    contains.designation.collect { it.language }
+  }
+
+  def "includeDesignations with no designation filter returns every designation"() {
+    expect:
+    expandDesignationLanguages().toSorted() == ["en", "en", "et", "ru"]
+  }
+
+  def "the designation parameter restricts the returned designations to the named language"() {
+    expect:
+    expandDesignationLanguages(new ParametersParameter().setName("designation").setValueCode("et")) == ["et"]
+  }
+
+  def "a system|code language designation token restricts by language too"() {
+    expect:
+    expandDesignationLanguages(new ParametersParameter().setName("designation").setValueString("urn:ietf:bcp:47|ru")) == ["ru"]
+  }
+
+  def "multiple designation tokens union the matching designations"() {
+    expect:
+    expandDesignationLanguages(
+        new ParametersParameter().setName("designation").setValueCode("et"),
+        new ParametersParameter().setName("designation").setValueCode("ru")).toSorted() == ["et", "ru"]
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/designation/cs-designations.json
+++ b/termx-integtest/src/test/resources/fhir/designation/cs-designations.json
@@ -1,0 +1,22 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "dg-cs",
+  "url": "http://example.org/dg-cs",
+  "version": "1.0.0",
+  "name": "DgCs",
+  "title": "Designation demo CS",
+  "status": "active",
+  "content": "complete",
+  "language": "en",
+  "concept": [
+    {
+      "code": "c1",
+      "display": "Color one",
+      "designation": [
+        { "language": "et", "value": "Värv üks" },
+        { "language": "ru", "value": "Цвет один" },
+        { "use": { "system": "http://snomed.info/sct", "code": "900000000000013009" }, "language": "en", "value": "colour one (synonym)" }
+      ]
+    }
+  ]
+}

--- a/termx-integtest/src/test/resources/fhir/designation/vs-designations.json
+++ b/termx-integtest/src/test/resources/fhir/designation/vs-designations.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "ValueSet",
+  "id": "dg-vs",
+  "url": "http://example.org/dg-vs",
+  "version": "1.0.0",
+  "name": "DgVs",
+  "title": "Designation demo VS",
+  "status": "active",
+  "compose": { "include": [ { "system": "http://example.org/dg-cs" } ] }
+}


### PR DESCRIPTION
## What

`$expand` returned every designation when `includeDesignations=true`, ignoring the FHIR **`designation`** parameter (0..*) that restricts which designations the expansion returns.

Each token is now matched against `contains[].designation`:
- a **bare token** is a language (`designation=et`)
- a **`system|code`** token matches a **use** coding (`designation=http://snomed.info/sct|900000000000013009`), or — when the system is a language system (`urn:ietf:bcp:47`) — the language
- **multiple tokens** union their matches
- an **absent** parameter keeps the prior return-all behaviour

`displayLanguage` still selects the `contains[].display` independently of the filter.

## Tests

- `ValueSetExpandDesignationIT` — no filter returns all; `designation=et` restricts to Estonian; a `system|code` language token; multiple tokens union.
- `docs/rest-client/fhir-terminology-expand-designations.http` — a runnable REST-client suite documenting the designation output (language + use + value) and every filter form.

Regression green — terminology 254, integtest 134.