### PR TITLE
test+docs: local useSupplement $lookup coverage; reconcile inline-supplement docs

### DIFF
--- a/docs/rest-client/README.md
+++ b/docs/rest-client/README.md
@@ -29,8 +29,10 @@ re-run safely.
 
 - **Stored vs inline.** A *stored* ValueSet expands through the full pipeline — it honours
   `displayLanguage` and resolves the `valueset-supplement` extension, so supplement translations
-  show up. *Inline* `$expand` (passing the ValueSet in the request body) runs the server's JSON
-  expand: it returns the composed concepts but does **not** re-pick `displayLanguage` or resolve
-  supplements. Use a stored ValueSet to demonstrate supplement/language behaviour.
+  show up. *Inline* `$expand` (passing the ValueSet in the request body) also surfaces supplement
+  translations, but the supplements aren't declared on the inline ValueSet, so you tell the server
+  which to apply: pass `displayLanguage` to auto-discover supplements with that language (suite
+  test #16), or name them explicitly with one or more `useSupplement` parameters (tests #17–18).
+  A bare inline expand with neither returns only the base code system's own designations.
 - **Cleanup.** The suite leaves its `tx-rest-demo-*` resources on the server. Cancel/retire them
   from the UI (or your own DELETE requests) if you don't want them to linger on a shared instance.

--- a/docs/rest-client/fhir-terminology-supplement.http
+++ b/docs/rest-client/fhir-terminology-supplement.http
@@ -268,11 +268,12 @@ Content-Type: application/fhir+json
   ]
 }
 
-### 15. Inline $expand of the BASE with includeDesignations — shows the supplement contrast
+### 15. Inline $expand of the BASE with includeDesignations only — the no-hint baseline
 # expect: red/green/blue with English displays and NO Estonian/Russian designations.
-#         The et/ru translations live in separate supplement code systems; inline expansion of
-#         the base does not resolve supplements. To surface supplement translations, expand a
-#         STORED value set that references the supplement (tests #8 / #10).
+#         A bare inline expand doesn't know which supplements to apply: the et/ru translations
+#         live in separate supplement code systems and are pulled in only when you ask for them —
+#         pass displayLanguage (test #16) or useSupplement (tests #17-18). Stored value sets that
+#         reference a supplement via the extension surface them automatically (tests #8 / #10).
 POST {{fhir}}/ValueSet/$expand
 Authorization: Bearer {{token}}
 Content-Type: application/fhir+json

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/CodeSystemLookupSupplementIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/CodeSystemLookupSupplementIT.groovy
@@ -1,0 +1,85 @@
+package org.termx.terminology.fhir
+
+import com.kodality.kefhir.structure.api.ResourceContent
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.codesystem.operations.CodeSystemLookupOperation
+import org.termx.terminology.terminology.codesystem.concept.ConceptService
+import org.termx.ts.codesystem.ConceptQueryParams
+
+/**
+ * A CodeSystem supplement bound to a LOCAL base code system must merge its designations when requested
+ * via the {@code useSupplement} parameter on {@code $lookup} — the same way it does for a SNOMED
+ * (external-provider) base. This reproduces the gap on the local repository path in
+ * {@link org.termx.terminology.terminology.codesystem.concept.ConceptService#query}.
+ *
+ * Reuses the {@code suppl-base} / {@code suppl-lt} fixtures: base has concept {@code code1}="Glucose";
+ * the supplement adds an {@code lt} designation "Gliukozė" to {@code code1}.
+ */
+@MicronautTest(transactional = true)
+class CodeSystemLookupSupplementIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject CodeSystemLookupOperation csLookup
+  @Inject ConceptService conceptService
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    // Base first so the supplement import can link baseEntityVersionId to the base concept version.
+    csImportService.importCodeSystem(fixture("fhir/supplement/cs-base.json"), "suppl-base")
+    csImportService.importCodeSystem(fixture("fhir/supplement/cs-supplement-lt.json"), "suppl-lt")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "ConceptService.query with useSupplement merges the local supplement's designation"() {
+    given: "a query for the base concept naming the supplement explicitly"
+    def params = new ConceptQueryParams()
+        .setCodeSystem("suppl-base")
+        .setCodeEq("code1")
+        .setIncludeSupplement(true)
+        .setUseSupplement("http://example.org/CodeSystem/suppl-lt")
+    params.limit(1)
+
+    when:
+    def concept = conceptService.query(params).findFirst().orElseThrow()
+    def designations = concept.versions.collectMany { it.designations ?: [] }
+
+    then: "the supplement's lt designation is merged onto the concept"
+    designations.any { it.language == "lt" && it.name == "Gliukozė" }
+  }
+
+  def "\$lookup with useSupplement surfaces the local supplement's designation"() {
+    given: "a \$lookup request for the base concept naming the supplement"
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("system").setValueUri("http://example.org/CodeSystem/suppl-base"),
+        new ParametersParameter().setName("code").setValueCode("code1"),
+        new ParametersParameter().setName("useSupplement").setValueCanonical("http://example.org/CodeSystem/suppl-lt")])
+
+    when:
+    def resp = FhirMapper.fromJson(csLookup.run(new ResourceContent(FhirMapper.toJson(req), "json")).getValue(), Parameters)
+    def designations = resp.parameter.findAll { it.name == "designation" }
+
+    then: "the supplement's lt designation is returned"
+    designations.any { d ->
+      d.part.find { it.name == "value" }?.valueString == "Gliukozė" &&
+          d.part.find { it.name == "language" }?.valueString == "lt"
+    }
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+}


### PR DESCRIPTION
Two small, related cleanups after the inline-supplement work (#253/#254/#256):

1. **`CodeSystemLookupSupplementIT`** — pins that `ConceptService.query` and FHIR `$lookup` with `useSupplement` merge a **local** supplement's designation (reusing the `suppl-base`/`suppl-lt` fixtures). Green on `main` — the gap was already closed; this guards against regression on the local repository path (the SNOMED path was already covered).
2. **Docs reconcile** — the REST Client suite/README still said *inline expansion does not resolve supplements*, which now contradicts the inline-supplement examples (#16–18). Updated to: inline $expand surfaces supplements when you pass `displayLanguage` (auto-discovery) or `useSupplement`; a bare inline expand returns only the base designations.