### PR TITLE
feat(fhir): apply the $expand designation filter on the inline (tx-resource) path too

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -322,7 +322,15 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
    * or equals its use/type code; a {@code system|code} token matches the use coding's system+code, or — when
    * the system is a language system — the language.
    */
-  private static boolean designationMatchesFilter(Designation d, List<String> tokens) {
+  /** The {@code designation} parameter tokens of an $expand request (a language, or a {@code system|code} use/language token), in order. */
+  public static List<String> designationFilterTokens(Parameters param) {
+    return ((param == null) || (param.getParameter() == null)) ? List.of() :
+        param.getParameter().stream().filter(p -> "designation".equals(p.getName()))
+            .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString())
+            .filter(StringUtils::isNotEmpty).toList();
+  }
+
+  public static boolean designationMatchesFilter(Designation d, List<String> tokens) {
     if (CollectionUtils.isEmpty(tokens)) {
       return true;
     }
@@ -509,10 +517,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     // expansion's contains[].designation is restricted to designations that match one of them (instead of
     // emitting every designation). A bare token is a language; a `system|code` token matches a use coding
     // (or a language when the system is the BCP-47 language system).
-    List<String> designationFilter = ((param == null) || (param.getParameter() == null)) ? List.of() :
-        param.getParameter().stream().filter(p -> "designation".equals(p.getName()))
-            .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString())
-            .filter(StringUtils::isNotEmpty).toList();
+    List<String> designationFilter = designationFilterTokens(param);
 
     ValueSetExpansionContains contains = new ValueSetExpansionContains();
     contains.setCode(c.getConcept().getCode());

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -372,6 +372,9 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     boolean includeDesignations = req != null && req.findParameter("includeDesignations")
         .map(pr -> pr.getValueBoolean() != null && pr.getValueBoolean() || "true".equals(pr.getValueString()))
         .orElse(false);
+    // FHIR $expand `designation` filter tokens (same semantics as the stored path) — restrict which
+    // designations the inline expansion returns. Empty = return all.
+    List<String> designationFilter = ValueSetFhirMapper.designationFilterTokens(req);
 
     // The SQL expand can't reach external providers (e.g. SNOMED via Snowstorm), so those members arrive
     // bare. Enrich them with display/designations from the providers, then layer supplements onto the
@@ -485,8 +488,9 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
           }
           if (includeDesignations && concept.getAdditionalDesignations() != null) {
             contain.setDesignation(concept.getAdditionalDesignations().stream()
+                .filter(d -> ValueSetFhirMapper.designationMatchesFilter(d, designationFilter))
                 .map(d -> {
-                  com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation designation = 
+                  com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation designation =
                       new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation();
                   designation.setLanguage(d.getLanguage());
                   designation.setValue(d.getName());

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
@@ -65,6 +65,24 @@ class ValueSetExpandDesignationIT extends TermxIntegTest {
         new ParametersParameter().setName("designation").setValueCode("ru")).toSorted() == ["et", "ru"]
   }
 
+  def "the designation filter also applies to the inline (tx-resource) expand path"() {
+    given: "an INLINE value set (passed in the request) over the same base, restricted to et designations"
+    def req = com.kodality.zmei.fhir.FhirMapper.fromJson("""
+      {"resourceType":"Parameters","parameter":[
+        {"name":"includeDesignations","valueBoolean":true},
+        {"name":"designation","valueCode":"et"},
+        {"name":"valueSet","resource":{
+          "resourceType":"ValueSet","url":"http://example.org/dg-vs-inline","status":"active",
+          "compose":{"include":[{"system":"http://example.org/dg-cs"}]}}}]}""", Parameters)
+
+    when:
+    def contains = vsExpand.run(req).expansion.contains.find { it.code == "c1" }
+
+    then: "only the Estonian designation is returned on the inline path too"
+    contains != null
+    contains.designation.collect { it.language } == ["et"]
+  }
+
   private String fixture(String path) {
     def stream = getClass().getClassLoader().getResourceAsStream(path)
     assert stream != null, "fixture not found: ${path}"


### PR DESCRIPTION
Follow-up to [#257](https://github.com/termx-health/termx-server/pull/257), which honored the FHIR `designation` parameter on the **stored** `$expand` path. This extends it to the **inline** path (a `valueSet` supplied in the request body / as a tx-resource) so both render the same filtered designations.

The token-parsing and matcher are promoted to public helpers on `ValueSetFhirMapper` (`designationFilterTokens`, `designationMatchesFilter`) and reused by `ValueSetExpandOperation.expandInline` — no logic duplicated.

`ValueSetExpandDesignationIT` gains an inline-path case (`designation=et` on an inline value set returns only the Estonian designation). Regression green — terminology 254, integtest 137.