### PR TITLE
feat(fhir): honor the $expand property parameter (request concept properties)

### DIFF
--- a/docs/rest-client/fhir-terminology-expand-designations.http
+++ b/docs/rest-client/fhir-terminology-expand-designations.http
@@ -1,14 +1,15 @@
-# TermX FHIR terminology — REST Client suite ($expand designations)
+# TermX FHIR terminology — REST Client suite ($expand designations + properties)
 #
 # Open this file in VS Code with the "REST Client" extension (humao.rest-client) and click
 # "Send Request" above each request. Run them top to bottom: the SETUP block creates the
 # resources the test blocks depend on. Every request lists its expected result so the
 # correctness can be verified at a glance.
 #
-# Demonstrates the FHIR $expand designation controls:
+# Demonstrates the FHIR $expand designation + property controls:
 #   • includeDesignations — surface contains[].designation (language + use + value)
 #   • designation (0..*)  — restrict which designations appear, by language or use token
 #   • displayLanguage     — which designation becomes the contains[].display
+#   • property (0..*)     — request concept properties into contains[].property
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # Configure these for your server, then run the requests in order.
@@ -42,10 +43,12 @@ Content-Type: application/fhir+json
   "status": "active",
   "content": "complete",
   "language": "en",
+  "property": [ { "code": "kind", "type": "string" } ],
   "concept": [
     {
       "code": "c1",
       "display": "Color one",
+      "property": [ { "code": "kind", "valueString": "primary" } ],
       "designation": [
         { "language": "et", "value": "Värv üks" },
         { "language": "ru", "value": "Цвет один" },
@@ -118,5 +121,23 @@ Accept: application/fhir+json
 # expect: contains[0].display = "Värv üks" (the displayLanguage selects the display; the `designation`
 #         filter is independent of it).
 GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?displayLanguage=et&includeDesignations=true
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+
+###############################################################################
+# $expand — the `property` parameter (request concept properties in the expansion)
+###############################################################################
+
+### 10. property=kind — request the concept property in the expansion
+# expect: expansion.property declares { code: kind }; contains[0].property = { code: kind,
+#         valueString: "primary" }. (Works even though the value set does not declare the property.)
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand?property=kind
+Authorization: Bearer {{token}}
+Accept: application/fhir+json
+
+### 11. no property parameter — no contains[].property is emitted
+# expect: contains[0] has no `property` (the request must ask for it).
+GET {{fhir}}/ValueSet/tx-rest-demo-designations/$expand
 Authorization: Bearer {{token}}
 Accept: application/fhir+json

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -30,6 +30,7 @@ import org.termx.ts.codesystem.Designation;
 import org.termx.ts.codesystem.DesignationType;
 import org.termx.ts.codesystem.EntityProperty;
 import org.termx.ts.codesystem.EntityPropertyType;
+import org.termx.ts.codesystem.EntityPropertyValue;
 import org.termx.ts.mapset.MapSet;
 import org.termx.ts.relatedartifact.RelatedArtifactType;
 import org.termx.ts.valueset.ValueSet;
@@ -381,8 +382,16 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     return fhirValueSet;
   }
 
-  private static ValueSetExpansion toFhirExpansion(ValueSetSnapshot snapshot, List<String> properties, Parameters param) {
+  private static ValueSetExpansion toFhirExpansion(ValueSetSnapshot snapshot, List<String> declaredProperties, Parameters param) {
     List<ValueSetVersionConcept> concepts = snapshot.getExpansion();
+    // A request-level `property` parameter asks for properties to appear in the expansion even when the value
+    // set itself does not declare them (FHIR $expand). Treat the declared properties UNION the requested ones
+    // as the set that may appear in contains.property / expansion.property.
+    List<String> requestedPropertyParams = (param == null || param.getParameter() == null) ? List.of() :
+        param.getParameter().stream().filter(p -> "property".equals(p.getName()))
+            .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).filter(StringUtils::isNotEmpty).toList();
+    List<String> properties = java.util.stream.Stream.concat(
+        Optional.ofNullable(declaredProperties).orElse(List.of()).stream(), requestedPropertyParams.stream()).distinct().toList();
 
     boolean active = Optional.ofNullable(param).map(p -> p.findParameter("activeOnly")
         .map(pp -> pp.getValueBoolean() != null ? pp.getValueBoolean() : "true".equals(pp.getValueString()))
@@ -412,13 +421,11 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
     expansion.setParameter(parameters.isEmpty() ? null : parameters);
     expansion.setTimestamp(snapshot.getCreatedAt());
 
-    // Declare the properties that may appear in contains.property: the value set's declared properties,
-    // narrowed by any request-level `property` parameter. A contains.property must reference a declared
-    // expansion.property to be valid FHIR.
-    List<String> requestedProperties = (param == null || param.getParameter() == null) ? List.of() :
-        param.getParameter().stream().filter(p -> "property".equals(p.getName())).map(ParametersParameter::getValueString).filter(StringUtils::isNotEmpty).toList();
-    expansion.setProperty(Optional.ofNullable(properties).orElse(List.of()).stream().distinct()
-        .filter(code -> requestedProperties.isEmpty() || requestedProperties.contains(code))
+    // Declare the properties that may appear in contains.property: the value set's declared properties plus
+    // any requested via the `property` parameter, narrowed to the request when one is given. A
+    // contains.property must reference a declared expansion.property to be valid FHIR.
+    expansion.setProperty(properties.stream().distinct()
+        .filter(code -> requestedPropertyParams.isEmpty() || requestedPropertyParams.contains(code))
         .map(code -> new ValueSetExpansionProperty().setCode(code))
         .collect(toList()));
 
@@ -512,7 +519,8 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
             .orElse(false)).orElse(false);
     String lang = Optional.ofNullable(param).map(Resource::getLanguage).orElse(null);
     List<String> properties = ((param == null) || (param.getParameter() == null)) ? List.of() :
-        param.getParameter().stream().filter(p -> "property".equals(p.getName())).map(ParametersParameter::getValueString).toList();
+        param.getParameter().stream().filter(p -> "property".equals(p.getName()))
+            .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).filter(StringUtils::isNotEmpty).toList();
     // FHIR $expand `designation` parameter (0..*): each token names a language or a use. When present, the
     // expansion's contains[].designation is restricted to designations that match one of them (instead of
     // emitting every designation). A bare token is a language; a `system|code` token matches a use coding
@@ -550,17 +558,34 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
           extension.setValueString(d.getName());
           return extension;
         }).toList() : null);
-    Set<String> seenProperties = new HashSet<>();
-    contains.setProperty(c.getPropertyValues() == null ? new ArrayList<>() :
-        c.getPropertyValues().stream()
-            // Only surface properties the value set declares (compose.property); a request-level `property`
-            // parameter narrows it further. Without this, every internal property leaks into the expansion
-            // as an undeclared `contains.property`, which bloats the response and is not valid per FHIR.
-            .filter(p -> allProperties.contains(p.getEntityProperty()))
-            .filter(p -> CollectionUtils.isEmpty(properties) || properties.contains(p.getEntityProperty()))
-            // Guard against duplicate property rows carried by legacy snapshots.
-            .filter(p -> seenProperties.add(p.getEntityProperty() + "|" + p.getValue()))
-            .map(p -> {
+    // Only surface properties the value set declares (compose.property); a request-level `property`
+    // parameter narrows it further. Without this, every internal property leaks into the expansion as an
+    // undeclared `contains.property`, which bloats the response and is not valid per FHIR.
+    contains.setProperty(toFhirContainsProperties(c.getPropertyValues(),
+        code -> allProperties.contains(code) && (CollectionUtils.isEmpty(properties) || properties.contains(code)), lang));
+    if (allProperties.contains("status") && (CollectionUtils.isEmpty(properties) || properties.contains("status"))) {
+      contains.getProperty().add(new ValueSetExpansionContainsProperty().setCode("status").setValueCode(PublicationStatus.getStatus(c.getStatus())));
+    }
+    addAssociations(c, allProperties, properties, contains, "parent");
+    addAssociations(c, allProperties, properties, contains, "groupedBy");
+    return contains;
+  }
+
+  /**
+   * Builds the FHIR {@code contains.property} list from a concept's property values, keeping only those whose
+   * code passes {@code codeAllowed} (deduped). Shared by the stored ($expand of a stored value set) and inline
+   * (tx-resource) expand paths so both render the FHIR $expand {@code property} output the same way.
+   */
+  public static List<ValueSetExpansionContainsProperty> toFhirContainsProperties(List<EntityPropertyValue> propertyValues,
+                                                                                 java.util.function.Predicate<String> codeAllowed, String lang) {
+    if (CollectionUtils.isEmpty(propertyValues)) {
+      return new ArrayList<>();
+    }
+    Set<String> seen = new HashSet<>();
+    return propertyValues.stream()
+        .filter(p -> codeAllowed.test(p.getEntityProperty()))
+        .filter(p -> seen.add(p.getEntityProperty() + "|" + p.getValue()))
+        .map(p -> {
           ValueSetExpansionContainsProperty property = new ValueSetExpansionContainsProperty();
           property.setCode(p.getEntityProperty());
           switch (p.getEntityPropertyType()) {
@@ -577,8 +602,6 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
               var coding = p.asCodingValue();
               if (coding != null && coding.getCodeSystem() != null && coding.getCode() != null) {
                 Coding valueCoding = new Coding(coding.getCodeSystem(), coding.getCode()).setVersion(coding.getVersion());
-                // Surface the localized display the coding-refresh enrichment resolved onto the value
-                // (stored as a list of {name, language, use}); pick the requested language, same as CodeSystemFhirMapper.
                 if (coding.getDisplay() != null) {
                   String displayStr = coding.getDisplay() instanceof String s ? s : JsonUtil.toJson(coding.getDisplay());
                   valueCoding.setDisplay(codingDisplay(displayStr, lang));
@@ -595,13 +618,7 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
             }
           }
           return property;
-        }).collect(toList()));
-    if (allProperties.contains("status") && (CollectionUtils.isEmpty(properties) || properties.contains("status"))) {
-      contains.getProperty().add(new ValueSetExpansionContainsProperty().setCode("status").setValueCode(PublicationStatus.getStatus(c.getStatus())));
-    }
-    addAssociations(c, allProperties, properties, contains, "parent");
-    addAssociations(c, allProperties, properties, contains, "groupedBy");
-    return contains;
+        }).collect(toList());
   }
 
   private static void addAssociations(ValueSetVersionConcept c, List<String> allProperties, List<String> properties, ValueSetExpansionContains contains, String key) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -199,6 +199,11 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     if (applySupplements) {
       conceptSupplementService.mergeSupplementsIntoExpansion(expandedConcepts, supplementParams(displayLanguage, req));
     }
+    // The stored snapshot doesn't carry concept property values; load them on demand when the request asks
+    // for properties (FHIR $expand `property`), so contains[].property can be populated. Skipped otherwise.
+    if (!designationOrPropertyRequested(req, "property").isEmpty()) {
+      decoratePropertyValues(expandedConcepts);
+    }
     List<Provenance> provenances = provenanceService.find("ValueSetVersion|" + version.getId());
 
     // FHIR R5 ValueSet/$expand `filter`: free-text typeahead filter applied to the
@@ -375,6 +380,9 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // FHIR $expand `designation` filter tokens (same semantics as the stored path) — restrict which
     // designations the inline expansion returns. Empty = return all.
     List<String> designationFilter = ValueSetFhirMapper.designationFilterTokens(req);
+    // FHIR $expand `property` tokens — which concept properties to surface in contains[].property. The
+    // decorateExpansionFlags step below loads the members' property values, so they are available here.
+    List<String> requestedProperties = designationOrPropertyRequested(req, "property");
 
     // The SQL expand can't reach external providers (e.g. SNOMED via Snowstorm), so those members arrive
     // bare. Enrich them with display/designations from the providers, then layer supplements onto the
@@ -466,6 +474,12 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter> expansionParameters =
         ValueSetFhirMapper.expansionParameters(req, expandedConcepts);
     expansion.setParameter(expansionParameters.isEmpty() ? null : expansionParameters);
+    // Declare the requested properties so contains[].property references a declared expansion.property (valid FHIR).
+    if (!requestedProperties.isEmpty()) {
+      expansion.setProperty(requestedProperties.stream()
+          .map(code -> new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionProperty().setCode(code))
+          .toList());
+    }
 
     // Map concepts to expansion contains
     List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains> contains = 
@@ -497,6 +511,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
                   return designation;
                 }).toList());
           }
+          if (!requestedProperties.isEmpty()) {
+            List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty> props =
+                ValueSetFhirMapper.toFhirContainsProperties(concept.getPropertyValues(), requestedProperties::contains, displayLanguage);
+            if (!props.isEmpty()) {
+              contain.setProperty(props);
+            }
+          }
           return contain;
         }).toList();
     expansion.setContains(contains);
@@ -511,6 +532,37 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
    * member's code system entity version id (which the SQL expand DOES populate). The inline SQL path returns
    * members without these, so without this they'd all look active and selectable.
    */
+  /** The values of a repeated request parameter (e.g. {@code property}, {@code designation}), code or string. */
+  private static List<String> designationOrPropertyRequested(Parameters req, String name) {
+    return req == null || req.getParameter() == null ? List.of() :
+        req.getParameter().stream().filter(p -> name.equals(p.getName()))
+            .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString())
+            .filter(StringUtils::isNotEmpty).toList();
+  }
+
+  /** Loads concept property values onto the (already expanded) members, by code system entity version id — the stored snapshot omits them. */
+  private void decoratePropertyValues(List<ValueSetVersionConcept> concepts) {
+    String ids = concepts.stream()
+        .map(c -> c.getConcept() != null ? c.getConcept().getConceptVersionId() : null)
+        .filter(java.util.Objects::nonNull).distinct().map(String::valueOf)
+        .collect(java.util.stream.Collectors.joining(","));
+    if (StringUtils.isEmpty(ids)) {
+      return;
+    }
+    org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams params = new org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams();
+    params.setIds(ids);
+    params.setLimit(-1);
+    java.util.Map<Long, CodeSystemEntityVersion> byId = codeSystemEntityVersionService.query(params).getData().stream()
+        .collect(java.util.stream.Collectors.toMap(CodeSystemEntityVersion::getId, v -> v, (a, b) -> a));
+    concepts.forEach(c -> {
+      Long vid = c.getConcept() != null ? c.getConcept().getConceptVersionId() : null;
+      CodeSystemEntityVersion v = vid != null ? byId.get(vid) : null;
+      if (v != null && (c.getPropertyValues() == null || c.getPropertyValues().isEmpty())) {
+        c.setPropertyValues(v.getPropertyValues());
+      }
+    });
+  }
+
   private void decorateExpansionFlags(List<ValueSetVersionConcept> concepts) {
     String ids = concepts.stream()
         .map(c -> c.getConcept() != null ? c.getConcept().getConceptVersionId() : null)

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandPropertyIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandPropertyIT.groovy
@@ -1,0 +1,83 @@
+package org.termx.terminology.fhir
+
+import com.kodality.zmei.fhir.resource.other.Parameters
+import com.kodality.zmei.fhir.resource.other.Parameters.ParametersParameter
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
+
+/**
+ * $expand with the FHIR {@code property} parameter: a requested concept property is surfaced in
+ * contains[].property (and declared in expansion.property) even when the value set does not declare it.
+ * The stored snapshot carries no property values, so they are loaded on demand; the inline (tx-resource)
+ * path renders the same shape. Without the parameter no property is emitted.
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandPropertyIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject ValueSetExpandOperation vsExpand
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    csImportService.importCodeSystem(fixture("fhir/property/cs-property.json"), "prop-cs")
+    vsImportService.importValueSet(fixture("fhir/property/vs-property.json"), "prop-vs")
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "the stored expand surfaces a requested property in contains[].property"() {
+    when:
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri("http://example.org/prop-vs"),
+        new ParametersParameter().setName("property").setValueCode("kind")])
+    def expanded = vsExpand.run(req)
+
+    then: "expansion.property declares kind and each member carries its kind value"
+    expanded.expansion.property.collect { it.code } == ["kind"]
+    def a = expanded.expansion.contains.find { it.code == "a" }
+    a.property.find { it.code == "kind" }.valueString == "fruit"
+    def c = expanded.expansion.contains.find { it.code == "c" }
+    c.property.find { it.code == "kind" }.valueString == "veg"
+  }
+
+  def "no property parameter emits no contains[].property"() {
+    when:
+    def req = new Parameters().setParameter([
+        new ParametersParameter().setName("url").setValueUri("http://example.org/prop-vs")])
+    def a = vsExpand.run(req).expansion.contains.find { it.code == "a" }
+
+    then:
+    a.property == null || a.property.isEmpty()
+  }
+
+  def "the inline (tx-resource) expand path surfaces the requested property too"() {
+    when:
+    def req = com.kodality.zmei.fhir.FhirMapper.fromJson("""
+      {"resourceType":"Parameters","parameter":[
+        {"name":"property","valueCode":"kind"},
+        {"name":"valueSet","resource":{
+          "resourceType":"ValueSet","url":"http://example.org/prop-vs-inline","status":"active",
+          "compose":{"include":[{"system":"http://example.org/prop-cs"}]}}}]}""", Parameters)
+    def expanded = vsExpand.run(req)
+
+    then: "the inline path declares and emits the property identically"
+    expanded.expansion.property.collect { it.code } == ["kind"]
+    expanded.expansion.contains.find { it.code == "a" }.property.find { it.code == "kind" }.valueString == "fruit"
+  }
+
+  private String fixture(String path) {
+    def stream = getClass().getClassLoader().getResourceAsStream(path)
+    assert stream != null, "fixture not found: ${path}"
+    return new String(stream.readAllBytes()).replace("﻿", "")
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/property/cs-property.json
+++ b/termx-integtest/src/test/resources/fhir/property/cs-property.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "prop-cs",
+  "url": "http://example.org/prop-cs",
+  "version": "1.0.0",
+  "name": "PropCs",
+  "title": "Property demo CS",
+  "status": "active",
+  "content": "complete",
+  "language": "en",
+  "property": [ { "code": "kind", "type": "string" } ],
+  "concept": [
+    { "code": "a", "display": "Apple",  "property": [ { "code": "kind", "valueString": "fruit" } ] },
+    { "code": "b", "display": "Banana", "property": [ { "code": "kind", "valueString": "fruit" } ] },
+    { "code": "c", "display": "Carrot", "property": [ { "code": "kind", "valueString": "veg" } ] }
+  ]
+}

--- a/termx-integtest/src/test/resources/fhir/property/vs-property.json
+++ b/termx-integtest/src/test/resources/fhir/property/vs-property.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "ValueSet",
+  "id": "prop-vs",
+  "url": "http://example.org/prop-vs",
+  "version": "1.0.0",
+  "name": "PropVs",
+  "title": "Property demo VS",
+  "status": "active",
+  "compose": { "include": [ { "system": "http://example.org/prop-cs" } ] }
+}


### PR DESCRIPTION
## What

`$expand` ignored the FHIR **`property`** parameter — `contains[].property` was never populated because (a) the stored snapshot carries no concept property values, (b) the inline path never emitted `property` at all, and (c) only properties the value set itself *declared* were surfaced.

Now a requested property appears in `contains[].property` (and is declared in `expansion.property`) even when the value set does not declare it:
- **stored path** loads the members' property values on demand (by code system entity version id) when `property` is requested;
- **inline (tx-resource) path** emits the same shape, reusing a shared `ValueSetFhirMapper.toFhirContainsProperties` helper;
- the declared-property set is the value set's declared properties **UNION** the requested ones, narrowed to the request.

Also parse the `property`/`designation` tokens from `valueCode` as well as `valueString` — a `Parameters` request uses `valueCode`; a URL query uses `valueString` (this was the difference between the live URL test passing and the IT failing).

## Tests

`ValueSetExpandPropertyIT` (stored, inline, no-parameter) and the `fhir-terminology-expand-designations.http` REST suite extended with property examples. Regression green — terminology 254, integtest 140.