### PR TITLE
feat(fhir): map SNOMED designation uses to defined properties; derive SNOMED display

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -58,6 +58,52 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
   private static final String DISPLAY = "display";
   private static final String DEFINITION = "definition";
   private static final Set<String> IMPLICIT_PROPERTY_DEFINITIONS = Set.of(DISPLAY, DEFINITION);
+  private static final String SNOMED_URL = "http://snomed.info/sct";
+  // Well-known designation `use` codings (keyed by `system#code`) ↔ the termx defined designation-property
+  // name. Mapping a use to its known name lets a designation link to the shared defined property (by name)
+  // and round-trip its system+code; an unknown use keeps its bare code (a CS-specific type) and is logged.
+  private static final Map<String, String> DESIGNATION_USE_NAME = Map.of(
+      "http://terminology.hl7.org/CodeSystem/designation-usage#display", DISPLAY,
+      "https://termx.org/fhir/CodeSystem/designation-usage#definition", DEFINITION,
+      "https://termx.org/fhir/CodeSystem/designation-usage#alias", "alias",
+      SNOMED_URL + "#900000000000013009", "snomed-synonym",
+      SNOMED_URL + "#900000000000003001", "snomed-fsn",
+      SNOMED_URL + "#900000000000548007", "snomed-preferred");
+  // Reverse: a known designation-property name → its use Coding {system, code}, for export reconstruction.
+  private static final Map<String, String[]> DESIGNATION_NAME_USE = Map.of(
+      "snomed-synonym", new String[]{SNOMED_URL, "900000000000013009"},
+      "snomed-fsn", new String[]{SNOMED_URL, "900000000000003001"},
+      "snomed-preferred", new String[]{SNOMED_URL, "900000000000548007"},
+      "alias", new String[]{"https://termx.org/fhir/CodeSystem/designation-usage", "alias"});
+  // SNOMED concepts carry their label as designations; with no explicit display, derive it in this priority.
+  private static final List<String> SNOMED_DISPLAY_PRIORITY = List.of("snomed-preferred", "snomed-fsn", "snomed-synonym");
+
+  /** Resolves a FHIR designation.use to a termx designation-property name: a known use → its defined name; otherwise the bare code (a CS-specific type), logged. */
+  private static String designationUseName(Coding use) {
+    if (use == null || use.getCode() == null) {
+      return DISPLAY;
+    }
+    String key = (use.getSystem() != null ? use.getSystem() + "#" : "") + use.getCode();
+    String mapped = DESIGNATION_USE_NAME.get(key);
+    if (mapped != null) {
+      return mapped;
+    }
+    if (use.getSystem() != null) {
+      log.warn("Unrecognised designation.use '{}' — kept as code-only type '{}'. Consider adding a defined designation property.", key, use.getCode());
+    }
+    return use.getCode();
+  }
+
+  /** The use Coding for an exported designation: a known designation-property name → its {system, code}; otherwise a bare code. */
+  private static Coding designationUseCoding(String designationType) {
+    String[] sysCode = DESIGNATION_NAME_USE.get(designationType);
+    return sysCode != null ? new Coding(sysCode[0], sysCode[1]) : new Coding(designationType);
+  }
+
+  /** The full {@code system#code} URI for a designation use, or null when it has no system. */
+  private static String designationUseUri(Coding use) {
+    return use != null && use.getSystem() != null && use.getCode() != null ? use.getSystem() + "#" + use.getCode() : null;
+  }
   private static final String PROPERTY_VALUE_SET_EXTENSION_URL = "http://hl7.org/fhir/StructureDefinition/codesystem-property-valueset";
   private static final String PROPERTY_CODE_SYSTEM_EXTENSION_URL = "https://termx.org/fhir/StructureDefinition/codesystem-property-codesystem";
 
@@ -266,7 +312,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     return designations.stream().map(d -> new CodeSystemConceptDesignation()
             .setLanguage(d.getLanguage())
             .setValue(d.getName())
-            .setUse(new Coding(d.getDesignationType())))
+            .setUse(designationUseCoding(d.getDesignationType())))
         .sorted(Comparator.comparing(d -> d.getLanguage() == null ? "" : d.getLanguage()))
         .sorted(Comparator.comparing(d -> d.getUse().getCode()))
         .toList();
@@ -601,7 +647,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
       properties.addAll(fhirCodeSystem.getConcept().stream()
           .filter(c -> c.getDesignation() != null)
           .flatMap(c -> c.getDesignation().stream())
-          .filter(d -> d.getUse() != null && d.getUse().getCode() != null && properties.stream().noneMatch(ep -> ep.getName().equals(d.getUse().getCode())))
+          .filter(d -> d.getUse() != null && d.getUse().getCode() != null && properties.stream().noneMatch(ep -> ep.getName().equals(designationUseName(d.getUse()))))
           .map(CodeSystemFhirMapper::fromFhirProperty).toList());
     }
     return properties.stream().collect(Collectors.toMap(EntityProperty::getName, p -> p, (p, q) -> p)).values().stream().toList();
@@ -624,7 +670,8 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
 
   private static EntityProperty fromFhirProperty(CodeSystemConceptDesignation d) {
     EntityProperty ep = new EntityProperty();
-    ep.setName(d.getUse().getCode());
+    ep.setName(designationUseName(d.getUse()));
+    ep.setUri(designationUseUri(d.getUse()));
     ep.setType(EntityPropertyType.string);
     ep.setKind(EntityPropertyKind.designation);
     ep.setStatus(PublicationStatus.active);
@@ -737,7 +784,7 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     }
     List<Designation> designations = c.getDesignation().stream().map(d -> {
       Designation designation = new Designation();
-      designation.setDesignationType(d.getUse() == null ? DISPLAY : d.getUse().getCode());
+      designation.setDesignationType(designationUseName(d.getUse()));
       designation.setName(d.getValue());
       designation.setLanguage(d.getLanguage() == null ? Language.en : d.getLanguage());
       designation.setCaseSignificance(caseSignificance);
@@ -754,6 +801,17 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     display.setCaseSignificance(caseSignificance);
     display.setDesignationKind("text");
     display.setStatus("active");
+    // SNOMED CT concepts carry their label only as designations (no concept.display). For a SNOMED-URL code
+    // system, derive the display from the SNOMED designations — preferred term, else FSN, else synonym.
+    if (display.getName() == null && SNOMED_URL.equals(codeSystem.getUrl())) {
+      SNOMED_DISPLAY_PRIORITY.stream()
+          .flatMap(type -> designations.stream().filter(d -> type.equals(d.getDesignationType()) && d.getName() != null))
+          .findFirst()
+          .ifPresent(src -> {
+            display.setName(src.getName());
+            display.setLanguage(src.getLanguage());
+          });
+    }
     if (display.getName() != null && designations.stream().noneMatch(d -> isSameDesignation(d, display))) {
       designations.add(display);
     }

--- a/terminology/src/main/resources/terminology/changelog/data/property/01-defined_properties.sql
+++ b/terminology/src/main/resources/terminology/changelog/data/property/01-defined_properties.sql
@@ -41,3 +41,27 @@ with t (name, kind, type, uri, description) as (values
      where e.pexists = true and e.name = dep.name)
 select 1;
 --rollback select 1;
+
+--changeset termx:concept-defined-properties-6
+-- Designation-usage defined properties for the common SNOMED CT designation types, so a FHIR
+-- designation.use of http://snomed.info/sct#900000000000013009 / #900000000000003001 maps to a named,
+-- shared property (snomed-synonym / snomed-fsn) instead of an unrecognised bare code. The `uri` carries the
+-- full system#code, which the import matches against and the export reconstructs the use Coding from.
+with t (name, kind, type, uri, description) as (values
+  ('snomed-synonym',   'designation', 'string', 'http://snomed.info/sct#900000000000013009', '{"en": "SNOMED CT Synonym"}'::jsonb),
+  ('snomed-fsn',       'designation', 'string', 'http://snomed.info/sct#900000000000003001', '{"en": "SNOMED CT Fully Specified Name"}'::jsonb),
+  ('snomed-preferred', 'designation', 'string', 'http://snomed.info/sct#900000000000548007', '{"en": "SNOMED CT Preferred Term"}'::jsonb)
+)
+, e as (select t.*, (exists(select 1 from terminology.defined_entity_property dep where t.name = dep.name)) as pexists from t)
+, inserted as (
+    insert into terminology.defined_entity_property(name, kind, type, uri, description)
+    select e.name, e.kind, e.type, e.uri, e.description
+      from e
+     where e.pexists = false)
+, updated as (
+    update terminology.defined_entity_property dep
+       set kind = e.kind, type = e.type, uri = e.uri, description = e.description
+      from e
+     where e.pexists = true and e.name = dep.name)
+select 1;
+--rollback select 1;

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
@@ -225,4 +225,67 @@ class CodeSystemFhirMapperSpec extends Specification {
     cs.name == "simple"
     cs.title.values().contains("Simple CS")
   }
+
+  def "a SNOMED-url code system derives the concept display: preferred > FSN > synonym"() {
+    given:
+    def fhir = com.kodality.zmei.fhir.FhirMapper.fromJson('''
+      {"resourceType":"CodeSystem","url":"http://snomed.info/sct","status":"active","content":"complete","language":"en","concept":[
+        {"code":"100","designation":[
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000003001"},"language":"en","value":"Foo (finding)"},
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000013009"},"language":"en","value":"Foo"},
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000548007"},"language":"en","value":"Foo preferred"}]},
+        {"code":"200","designation":[
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000003001"},"language":"en","value":"Bar (finding)"}]},
+        {"code":"300","designation":[
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000013009"},"language":"en","value":"Baz syn"}]}]}''',
+        com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+
+    when:
+    def cs = mapper.fromFhirCodeSystem(fhir)
+
+    then: "preferred wins; else FSN; else synonym"
+    displayOf(cs, "100") == "Foo preferred"
+    displayOf(cs, "200") == "Bar (finding)"
+    displayOf(cs, "300") == "Baz syn"
+  }
+
+  def "a non-SNOMED code system does NOT derive a display from SNOMED designations"() {
+    given:
+    def fhir = com.kodality.zmei.fhir.FhirMapper.fromJson('''
+      {"resourceType":"CodeSystem","url":"http://example.org/x","status":"active","content":"complete","language":"en","concept":[
+        {"code":"a","designation":[
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000013009"},"language":"en","value":"A syn"}]}]}''',
+        com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+
+    when:
+    def cs = mapper.fromFhirCodeSystem(fhir)
+
+    then: "the display-derivation rule is SNOMED-url only"
+    displayOf(cs, "a") == null
+  }
+
+  def "a SNOMED designation use maps to the snomed-synonym designation type"() {
+    given:
+    def fhir = com.kodality.zmei.fhir.FhirMapper.fromJson('''
+      {"resourceType":"CodeSystem","url":"http://example.org/x","status":"active","content":"complete","language":"en","concept":[
+        {"code":"a","display":"A","designation":[
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000013009"},"language":"en","value":"A syn"}]}]}''',
+        com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+
+    when:
+    def cs = mapper.fromFhirCodeSystem(fhir)
+
+    then:
+    designationTypeOf(cs, "a", "A syn") == "snomed-synonym"
+  }
+
+  private static String displayOf(cs, String code) {
+    def concept = cs.concepts.find { it.code == code }
+    concept?.versions?.first()?.designations?.find { it.designationType == "display" }?.name
+  }
+
+  private static String designationTypeOf(cs, String code, String value) {
+    def concept = cs.concepts.find { it.code == code }
+    concept?.versions?.first()?.designations?.find { it.name == value }?.designationType
+  }
 }


### PR DESCRIPTION
## What

A FHIR `designation.use` is a Coding (system+code), but import kept only the **code**, so the system was lost and the use never round-tripped — a SNOMED synonym came back as a bare `{code:"900000000000013009"}` with no system.

**1. New defined designation properties** (Liquibase `concept-defined-properties-6`), keyed by their SNOMED URIs:
| name | uri |
|---|---|
| `snomed-synonym` | `http://snomed.info/sct#900000000000013009` |
| `snomed-fsn` | `http://snomed.info/sct#900000000000003001` |
| `snomed-preferred` | `http://snomed.info/sct#900000000000548007` |

**2. Import maps the use by `system#code`** to the matching defined-property name (HL7 `…#display` → existing `display`; the three SNOMED uses → the new names) and stores the full `system#code` as the property `uri`. An **unrecognised** use keeps its bare code (a CS-specific type) and is **logged** — no automatic global property is created. Export reconstructs the use Coding from the name.

**3. SNOMED display rule:** for a code system whose url is `http://snomed.info/sct`, a concept with no explicit `display` derives it from the SNOMED designations in priority **preferred term → FSN → synonym**.

## Verified

Live: a non-SNOMED CS with a SNOMED-synonym designation round-trips the full use Coding; a SNOMED-url import (reconciled into `snomed-ct`) derived displays "Foo preferred" (has preferred) / "Bar (finding)" (FSN fallback) / "Baz syn only" (synonym fallback). `CodeSystemFhirMapperSpec` covers the priority, the SNOMED-url-only gating, and the use mapping. Regression green — terminology 257, integtest 140.

## Follow-up

Backfill of existing system-less designation rows is a separate PR (as agreed).