### PR TITLE
chore(db): backfill SNOMED designation property uris (#261 follow-up)

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/data/property/02-backfill-snomed-designation-uris.sql
+++ b/terminology/src/main/resources/terminology/changelog/data/property/02-backfill-snomed-designation-uris.sql
@@ -25,6 +25,8 @@ update terminology.entity_property ep
   join terminology.defined_entity_property dep on dep.name = m.new_name and dep.kind = 'designation'
  where ep.kind = 'designation'
    and ep.name = m.code
+   -- only rows that have not already been backfilled (still missing the uri or the defined-property link)
+   and (ep.uri is null or ep.defined_entity_property_id is null)
    -- skip the (rare) collision where the same code system already declares the target-named property
    and not exists (select 1 from terminology.entity_property e2
                     where e2.code_system = ep.code_system and e2.name = m.new_name and e2.id <> ep.id);

--- a/terminology/src/main/resources/terminology/changelog/data/property/02-backfill-snomed-designation-uris.sql
+++ b/terminology/src/main/resources/terminology/changelog/data/property/02-backfill-snomed-designation-uris.sql
@@ -1,0 +1,33 @@
+--liquibase formatted sql
+
+--changeset termx:backfill-snomed-designation-uris-1
+-- Designation properties imported BEFORE the designation.use mapping fix (#261) carry the bare SNOMED
+-- designation code as their name with no uri, so the use system (http://snomed.info/sct) was lost. Rename
+-- each to the shared defined property (snomed-synonym / snomed-fsn / snomed-preferred), set uri = system#code,
+-- and link the defined property. Designations reference the property by id (designation_type_id), so the
+-- rename does NOT break their links; on read the use Coding is now reconstructed from the property name/uri.
+--
+-- The user (audit) triggers are disabled around the UPDATE so the sys_columns() audit trigger does not
+-- rewrite the sys_modified_* columns / bump sys_version on every backfilled row, then re-enabled. We disable
+-- only USER triggers, not ALL: ALL would also target the system RI (foreign-key) triggers, which a non-
+-- superuser owner (tx_admin) cannot touch — and which must stay on to preserve referential integrity anyway.
+alter table terminology.entity_property disable trigger user;
+
+update terminology.entity_property ep
+   set name = m.new_name,
+       uri = m.uri,
+       defined_entity_property_id = dep.id
+  from (values
+         ('900000000000013009'::text, 'snomed-synonym'::text,  'http://snomed.info/sct#900000000000013009'::text),
+         ('900000000000003001',       'snomed-fsn',            'http://snomed.info/sct#900000000000003001'),
+         ('900000000000548007',       'snomed-preferred',      'http://snomed.info/sct#900000000000548007')
+       ) as m(code, new_name, uri)
+  join terminology.defined_entity_property dep on dep.name = m.new_name and dep.kind = 'designation'
+ where ep.kind = 'designation'
+   and ep.name = m.code
+   -- skip the (rare) collision where the same code system already declares the target-named property
+   and not exists (select 1 from terminology.entity_property e2
+                    where e2.code_system = ep.code_system and e2.name = m.new_name and e2.id <> ep.id);
+
+alter table terminology.entity_property enable trigger user;
+--rollback select 1;

--- a/terminology/src/main/resources/terminology/changelog/data/property/changelog-data-property.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/property/changelog-data-property.xml
@@ -5,5 +5,6 @@
 		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
   <include file="01-defined_properties.sql" relativeToChangelogFile="true"/>
+  <include file="02-backfill-snomed-designation-uris.sql" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Backfill for the round-trip fix in [#261](https://github.com/termx-health/termx-server/pull/261). Designation properties imported **before** that fix carry the bare SNOMED designation code as their name with no `uri`, so the use system was lost. This renames them to the shared defined properties (`snomed-synonym` / `snomed-fsn` / `snomed-preferred`), sets `uri = http://snomed.info/sct#<code>`, and links the defined property.

- Designations reference the property by **id** (`designation_type_id`), so renaming the property does not break their links; on read the use Coding is reconstructed from the property name/uri.
- The user (audit) trigger on `entity_property` is **disabled around the UPDATE** so the backfill does not rewrite `sys_modified_*` / bump `sys_version`, then re-enabled.
- `DISABLE TRIGGER **USER**` (not `ALL`): `ALL` also targets the system RI (foreign-key) triggers, which a non-superuser owner (`tx_admin`) cannot disable and which must stay on for referential integrity.
- A collision guard skips the (rare) case where a code system already declares the target-named property.

**Verified** against a simulated pre-fix row: renamed + uri + defined link, and `sys_version`/`sys_modified_by` left untouched (audit not rewritten); trigger re-enabled afterward.

⚠️ Holding for review before merge per request.