### PR TITLE
fix(fhir): emit the real designation.use system+code in $expand and $lookup

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -71,10 +71,12 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
       SNOMED_URL + "#900000000000548007", "snomed-preferred");
   // Reverse: a known designation-property name → its use Coding {system, code}, for export reconstruction.
   private static final Map<String, String[]> DESIGNATION_NAME_USE = Map.of(
+      DISPLAY, new String[]{"http://terminology.hl7.org/CodeSystem/designation-usage", "display"},
+      DEFINITION, new String[]{"https://termx.org/fhir/CodeSystem/designation-usage", "definition"},
+      "alias", new String[]{"https://termx.org/fhir/CodeSystem/designation-usage", "alias"},
       "snomed-synonym", new String[]{SNOMED_URL, "900000000000013009"},
       "snomed-fsn", new String[]{SNOMED_URL, "900000000000003001"},
-      "snomed-preferred", new String[]{SNOMED_URL, "900000000000548007"},
-      "alias", new String[]{"https://termx.org/fhir/CodeSystem/designation-usage", "alias"});
+      "snomed-preferred", new String[]{SNOMED_URL, "900000000000548007"});
   // SNOMED concepts carry their label as designations; with no explicit display, derive it in this priority.
   private static final List<String> SNOMED_DISPLAY_PRIORITY = List.of("snomed-preferred", "snomed-fsn", "snomed-synonym");
 
@@ -94,8 +96,8 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     return use.getCode();
   }
 
-  /** The use Coding for an exported designation: a known designation-property name → its {system, code}; otherwise a bare code. */
-  private static Coding designationUseCoding(String designationType) {
+  /** The use Coding for an exported designation: a known designation-property name → its {system, code}; otherwise a bare code. Shared with $expand/$lookup. */
+  public static Coding designationUseCoding(String designationType) {
     String[] sysCode = DESIGNATION_NAME_USE.get(designationType);
     return sysCode != null ? new Coding(sysCode[0], sysCode[1]) : new Coding(designationType);
   }

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
@@ -165,7 +165,8 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
         .filter(d -> d != display && d != definition)
         .filter(d -> languageMatches(d.getLanguage(), displayLanguage))
         .forEach(d -> resp.addParameter(new ParametersParameter("designation")
-            .addPart(new ParametersParameter("use").setValueCoding(new Coding(d.getDesignationType())))
+            .addPart(new ParametersParameter("use").setValueCoding(
+                org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(d.getDesignationType())))
             .addPart(new ParametersParameter("value").setValueString(d.getName()))
             .addPart(new ParametersParameter("language").setValueString(d.getLanguage()))));
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -545,7 +545,10 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
           ValueSetComposeIncludeConceptDesignation d = new ValueSetComposeIncludeConceptDesignation();
           d.setValue(designation.getName());
           d.setLanguage(designation.getLanguage());
-          d.setUse(new Coding(designation.getDesignationType() == null ? "display" : designation.getDesignationType()));
+          // Reconstruct the use Coding's system+code from the designation type (a known type → its real
+          // {system, code}; an unknown CS-specific type → a bare code), instead of emitting the bare name.
+          d.setUse(org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(
+              designation.getDesignationType() == null ? "display" : designation.getDesignationType()));
           return d;
         }).collect(toList()) : new ArrayList<>());
     if (c.getDisplay() != null && (lang != null && !c.getDisplay().getLanguage().startsWith(lang))) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -508,6 +508,8 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
                       new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation();
                   designation.setLanguage(d.getLanguage());
                   designation.setValue(d.getName());
+                  designation.setUse(org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(
+                      d.getDesignationType() == null ? "display" : d.getDesignationType()));
                   return designation;
                 }).toList());
           }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
@@ -43,6 +43,24 @@ class ValueSetExpandDesignationIT extends TermxIntegTest {
     contains.designation.collect { it.language }
   }
 
+  def "the designation use Coding is reconstructed with its system+code (not the bare type name)"() {
+    when: "expanding with designations; c1 carries a SNOMED-synonym designation"
+    def params = [
+        new ParametersParameter().setName("url").setValueUri("http://example.org/dg-vs"),
+        new ParametersParameter().setName("includeDesignations").setValueBoolean(true)]
+    def contains = vsExpand.run(new Parameters().setParameter(params)).expansion.contains.find { it.code == "c1" }
+
+    then: "the SNOMED synonym designation's use carries the real system+code, not 'snomed-synonym'"
+    def syn = contains.designation.find { it.value == "colour one (synonym)" }
+    syn.use.system == "http://snomed.info/sct"
+    syn.use.code == "900000000000013009"
+
+    and: "a plain (display-type) designation uses the standard designation-usage system, not a bare code"
+    def et = contains.designation.find { it.language == "et" }
+    et.use.system == "http://terminology.hl7.org/CodeSystem/designation-usage"
+    et.use.code == "display"
+  }
+
   def "includeDesignations with no designation filter returns every designation"() {
     expect:
     expandDesignationLanguages().toSorted() == ["en", "en", "et", "ru"]


### PR DESCRIPTION
## What

[#261](https://github.com/termx-health/termx-server/pull/261) mapped designation uses to defined-property names on import, but `$expand` and `$lookup` still emitted the bare type **name** as the use code — e.g. `use = {code: "snomed-synonym"}` or `{code: "display"}` — losing the system.

They now reconstruct the full use Coding from the designation type, the same way the CodeSystem export (#261) does:
- **$expand** stored path (`ValueSetFhirMapper`), **inline** path (`ValueSetExpandOperation` — previously emitted no `use` at all), and **$lookup** (`CodeSystemLookupOperation`) all reuse `CodeSystemFhirMapper.designationUseCoding`.
- The reverse map gains `display`/`definition`, so a plain display designation emits `{system: http://terminology.hl7.org/CodeSystem/designation-usage, code: display}` instead of a bare `{code: display}`; SNOMED uses emit `http://snomed.info/sct#<id>`.

## Verified (live, all three paths)
- `$lookup` → `{system: http://snomed.info/sct, code: 900000000000013009}`
- `$expand` stored + inline → synonym `{snomed, 900…009}`, display `{designation-usage, display}`

`ValueSetExpandDesignationIT` asserts the use Coding carries system+code. Regression green — terminology 257, integtest 141.