### PR TITLE
feat(fhir): version-aware $validate-code/$expand resolution

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/FhirVersions.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/FhirVersions.java
@@ -1,0 +1,167 @@
+package org.termx.terminology.fhir;
+
+import io.micronaut.core.util.StringUtils;
+import java.util.List;
+
+/**
+ * Semantic-version matching for FHIR terminology, mirroring the reference engine
+ * ({@code org.hl7.fhir.utilities.VersionUtilities} in {@code org.hl7.fhir.core}, the implementation behind the
+ * tx-ecosystem tests). A code system version carried by a {@code ValueSet.compose.include.version}, a
+ * {@code Coding.version}, or a {@code system-version}/{@code force-system-version}/{@code check-system-version}
+ * parameter may be a concrete version ({@code 1.0.0}), a wildcard pattern ({@code 1.x.x}, {@code 1.0.x}), or a
+ * trailing-{@code ?} pattern ({@code 1.0?}); a value that is NOT valid semver-with-wildcards (e.g. a bare
+ * {@code 1}) is treated as an exact literal — so {@code 1} does not match {@code 1.0.0}.
+ */
+public final class FhirVersions {
+  private FhirVersions() {
+  }
+
+  private record Semver(String major, String minor, String patch, String label, String build, boolean valid) {
+  }
+
+  /**
+   * Parses {@code major.minor.patch[-label][+build]}. With {@code allowWildcards}, the numeric parts may be a
+   * wildcard token ({@code x}/{@code X}/{@code *}); otherwise they must be numeric. Major is required; minor and
+   * patch are optional (a criteria may stop early, e.g. {@code 1.x}).
+   */
+  private static Semver parse(String v, boolean allowWildcards) {
+    if (StringUtils.isEmpty(v)) {
+      return new Semver(null, null, null, null, null, false);
+    }
+    String rest = v;
+    String build = null;
+    String label = null;
+    int plus = rest.indexOf('+');
+    if (plus >= 0) {
+      build = rest.substring(plus + 1);
+      rest = rest.substring(0, plus);
+    }
+    int dash = rest.indexOf('-');
+    if (dash >= 0) {
+      label = rest.substring(dash + 1);
+      rest = rest.substring(0, dash);
+    }
+    String[] parts = rest.split("\\.", -1);
+    if (parts.length == 0 || parts.length > 3) {
+      return new Semver(null, null, null, null, null, false);
+    }
+    for (String p : parts) {
+      if (!isNumericOrWildcard(p, allowWildcards)) {
+        return new Semver(null, null, null, null, null, false);
+      }
+    }
+    String major = parts[0];
+    String minor = parts.length > 1 ? parts[1] : null;
+    String patch = parts.length > 2 ? parts[2] : null;
+    return new Semver(major, minor, patch, label, build, true);
+  }
+
+  private static boolean isNumericOrWildcard(String p, boolean allowWildcards) {
+    if (StringUtils.isEmpty(p)) {
+      return false;
+    }
+    if (allowWildcards && (p.equals("x") || p.equals("X") || p.equals("*"))) {
+      return true;
+    }
+    return p.chars().allMatch(Character::isDigit);
+  }
+
+  /** Whether {@code v} is a valid semantic version; {@code allowWildcards} permits {@code x}/{@code X}/{@code *} parts. */
+  public static boolean isSemVer(String v, boolean allowWildcards) {
+    return parse(v, allowWildcards).valid();
+  }
+
+  /** Whether {@code v} parses as semver AND actually carries a wildcard ({@code x}/{@code X}/{@code *} or trailing {@code ?}). */
+  public static boolean isSemVerWithWildcards(String v) {
+    if (v != null && v.endsWith("?")) {
+      return isSemVer(v.substring(0, v.length() - 1), true) && versionHasWildcards(v);
+    }
+    return isSemVer(v, true) && versionHasWildcards(v);
+  }
+
+  /** Whether {@code v} contains a wildcard token: {@code *} anywhere, trailing {@code ?}, or {@code x}/{@code X} in the numeric part. */
+  public static boolean versionHasWildcards(String v) {
+    if (StringUtils.isEmpty(v)) {
+      return false;
+    }
+    if (v.endsWith("?") || v.contains("*")) {
+      return true;
+    }
+    String numeric = v;
+    int dash = numeric.indexOf('-');
+    int plus = numeric.indexOf('+');
+    if (dash >= 0 && plus >= 0) {
+      numeric = numeric.substring(0, Math.min(dash, plus));
+    } else if (dash >= 0) {
+      numeric = numeric.substring(0, dash);
+    } else if (plus >= 0) {
+      numeric = numeric.substring(0, plus);
+    }
+    return numeric.contains("x") || numeric.contains("X");
+  }
+
+  /**
+   * Whether the concrete {@code candidate} version satisfies the {@code criteria} pattern. A wildcard part
+   * ({@code x}/{@code X}/{@code *}) matches any present value; a trailing {@code ?} makes the remaining parts
+   * optional; everything else must be exactly equal. A {@code criteria} that is not valid semver-with-wildcards
+   * is compared as an exact literal — so {@code "1"} does NOT match {@code "1.0.0"}.
+   */
+  public static boolean versionMatches(String criteria, String candidate) {
+    if (StringUtils.isEmpty(criteria) || StringUtils.isEmpty(candidate)) {
+      return false;
+    }
+    boolean endsWithQ = criteria.endsWith("?");
+    String crit = endsWithQ ? criteria.substring(0, criteria.length() - 1) : criteria;
+    if (crit.equals("*") || crit.equals("x") || crit.equals("X")) {
+      return true;
+    }
+    Semver pc = parse(crit, true);
+    Semver pv = parse(candidate, false);
+    if (!pc.valid() || !pv.valid()) {
+      return criteria.equals(candidate);
+    }
+    if (!partMatches(pc.major(), pv.major())) {
+      return false;
+    }
+    if (endsWithQ && pc.minor() == null) {
+      return true;
+    }
+    if (!partMatches(pc.minor(), pv.minor())) {
+      return false;
+    }
+    if (endsWithQ && pc.patch() == null) {
+      return true;
+    }
+    if (!partMatches(pc.patch(), pv.patch())) {
+      return false;
+    }
+    if (endsWithQ && pc.label() == null && pc.build() == null) {
+      return true;
+    }
+    return partMatches(pc.label(), pv.label()) && partMatches(pc.build(), pv.build());
+  }
+
+  private static boolean partMatches(String criteria, String candidate) {
+    if (criteria == null) {
+      return candidate == null;
+    }
+    if (criteria.equals("x") || criteria.equals("X") || criteria.equals("*")) {
+      return candidate != null;
+    }
+    return criteria.equals(candidate);
+  }
+
+  /** True if any version in {@code candidates} matches {@code criteria}. */
+  public static boolean versionMatchesList(String criteria, List<String> candidates) {
+    return candidates != null && candidates.stream().anyMatch(c -> versionMatches(criteria, c));
+  }
+
+  /**
+   * Whether {@code candidate} is a strictly more detailed form of the {@code criteria} pattern — i.e. criteria
+   * is a wildcard semver, candidate is a concrete semver, and candidate matches it (so {@code 1.0.0} is "more
+   * detailed than" {@code 1.x.x}, and the concrete coding version should replace the pattern).
+   */
+  public static boolean isMoreDetailed(String criteria, String candidate) {
+    return isSemVerWithWildcards(criteria) && isSemVer(candidate, false) && versionMatches(criteria, candidate);
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -41,4 +41,21 @@ public final class TxIssues {
     outcome.setIssue(List.of(issues));
     return outcome;
   }
+
+  /**
+   * A {@code not-found} {@link com.kodality.kefhir.core.exception.FhirException} whose OperationOutcome issue
+   * carries the {@code tx-issue-type}/{@code not-found} detail coding plus the message text — the shape the
+   * tx-ecosystem expects for an unresolvable system/version/value-set (e.g. an unknown {@code valueSetVersion}),
+   * rather than the bare {@code details.text} a plain {@code FhirException(status, IssueType, text)} produces.
+   */
+  public static com.kodality.kefhir.core.exception.FhirException notFoundException(int status, String text) {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.NOTFOUND);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept()
+        .addCoding(new org.hl7.fhir.r5.model.Coding(TX_ISSUE_TYPE, "not-found", null))
+        .setText(text));
+    return new com.kodality.kefhir.core.exception.FhirException(status, issue);
+  }
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -114,7 +114,21 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
             : pp.getValueCanonical() != null ? pp.getValueCanonical()
             : pp.getValueString())
         .orElseThrow(() -> new FhirException(400, IssueType.INVALID, "parameter 'url' or 'valueSet' required"));
-    String versionNr = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(null);
+    // Pipe-form canonical `<url>|<version>` (FHIR & tx-ecosystem) — split as terminology-explorer's
+    // CanonicalUrlParser does (version = everything after the first '|'). Keep the original `url` for the
+    // SNOMED implicit-ValueSet handling below (its own `|edition/version` syntax differs); resolve stored and
+    // tx-resource ValueSets by the bare canonical, with the pipe version as the requested version when
+    // `valueSetVersion` isn't separately supplied.
+    String canonicalUrl = url;
+    String pipeVersion = null;
+    if (!url.startsWith("http://snomed.info/sct")) {
+      int pipe = url.indexOf('|');
+      if (pipe >= 0) {
+        canonicalUrl = url.substring(0, pipe);
+        pipeVersion = url.substring(pipe + 1);
+      }
+    }
+    String versionNr = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(pipeVersion);
 
     // 3. SNOMED CT implicit-ValueSet URLs (`http://snomed.info/sct[/<edition>/version/<date>]?fhir_vs[=...]`)
     //    are recognised before the stored-VS lookup and delegated to the
@@ -126,15 +140,27 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     }
 
     // 3b. tx-resource: the FHIR validator passes referenced resources inline. When `url` names a ValueSet
-    //     supplied as a tx-resource, expand that inline definition instead of looking it up in storage.
-    com.kodality.zmei.fhir.resource.terminology.ValueSet txResourceVs = findTxResourceValueSet(req, url);
-    if (txResourceVs != null) {
+    //     supplied as a tx-resource, expand that inline definition instead of looking it up in storage. When
+    //     several versions of the same canonical are supplied, a pinned version must resolve to exactly that
+    //     one (unknown version → 404); otherwise the latest is used.
+    List<com.kodality.zmei.fhir.resource.terminology.ValueSet> txVs = txResourceValueSets(req, canonicalUrl);
+    if (!txVs.isEmpty()) {
+      com.kodality.zmei.fhir.resource.terminology.ValueSet txResourceVs;
+      if (versionNr != null) {
+        String canonical = canonicalUrl;
+        String pinned = versionNr;
+        txResourceVs = txVs.stream().filter(vs -> pinned.equals(vs.getVersion())).findFirst()
+            .orElseThrow(() -> org.termx.terminology.fhir.TxIssues.notFoundException(404,
+                String.format("A definition for the value Set '%s|%s' could not be found", canonical, pinned)));
+      } else {
+        txResourceVs = latestByVersion(txVs);
+      }
       return expandInline(txResourceVs, req);
     }
 
     // 4. Stored ValueSet lookup.
     ValueSetQueryParams vsParams = new ValueSetQueryParams();
-    vsParams.setUri(url);
+    vsParams.setUri(canonicalUrl);
     vsParams.setLimit(1);
     vsParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
     ValueSet valueSet = valueSetService.query(vsParams).findFirst().orElse(null);
@@ -349,8 +375,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
 
   /** Finds a ValueSet supplied inline via a tx-resource parameter whose url matches the requested url. */
   private static com.kodality.zmei.fhir.resource.terminology.ValueSet findTxResourceValueSet(Parameters req, String url) {
+    return txResourceValueSets(req, url).stream().findFirst().orElse(null);
+  }
+
+  /** All ValueSets supplied inline via tx-resource params whose canonical url matches (any version). */
+  private static List<com.kodality.zmei.fhir.resource.terminology.ValueSet> txResourceValueSets(Parameters req, String url) {
     if (req.getParameter() == null || url == null) {
-      return null;
+      return List.of();
     }
     return req.getParameter().stream()
         .filter(p -> "tx-resource".equals(p.getName()))
@@ -358,7 +389,30 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.ValueSet)
         .map(r -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) r)
         .filter(vs -> url.equals(vs.getUrl()))
-        .findFirst().orElse(null);
+        .toList();
+  }
+
+  /** Highest-version tx-resource (latest, by numeric-aware dotted-version order), falling back to the first. */
+  private static com.kodality.zmei.fhir.resource.terminology.ValueSet latestByVersion(
+      List<com.kodality.zmei.fhir.resource.terminology.ValueSet> vss) {
+    return vss.stream().max(java.util.Comparator.comparing(
+        com.kodality.zmei.fhir.resource.terminology.ValueSet::getVersion,
+        java.util.Comparator.nullsFirst(ValueSetExpandOperation::compareVersions))).orElse(vss.get(0));
+  }
+
+  /** Numeric-aware comparison of dotted version strings ("1.10.0" &gt; "1.2.0"), tolerant of non-numeric parts. */
+  private static int compareVersions(String a, String b) {
+    String[] pa = a.split("\\.");
+    String[] pb = b.split("\\.");
+    for (int i = 0; i < Math.max(pa.length, pb.length); i++) {
+      String sa = i < pa.length ? pa[i] : "0";
+      String sb = i < pb.length ? pb[i] : "0";
+      int c = sa.matches("\\d+") && sb.matches("\\d+") ? Long.compare(Long.parseLong(sa), Long.parseLong(sb)) : sa.compareTo(sb);
+      if (c != 0) {
+        return c;
+      }
+    }
+    return 0;
   }
 
   private com.kodality.zmei.fhir.resource.terminology.ValueSet expandInline(

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -73,40 +73,77 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   }
 
   public Parameters run(Parameters req) {
-    String url = req.findParameter("url")
+    String rawUrl = req.findParameter("url")
         .map(pp -> pp.getValueUrl() != null ? pp.getValueUrl() : pp.getValueUri() != null ? pp.getValueUri() : pp.getValueString())
         .orElse(null);
+    // A canonical `url` may carry its version inline as `<url>|<version>` (FHIR & tx-ecosystem). Split it the
+    // same way terminology-explorer's CanonicalUrlParser does — the version is everything after the first '|' —
+    // and treat that pipe version as the requested valueSetVersion when the parameter isn't separately given.
+    String url = rawUrl;
+    String pipeVersion = null;
+    if (rawUrl != null) {
+      int pipe = rawUrl.indexOf('|');
+      if (pipe >= 0) {
+        url = rawUrl.substring(0, pipe);
+        pipeVersion = rawUrl.substring(pipe + 1);
+      }
+    }
+    String version = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(pipeVersion);
 
     // tx-resource / inline: validate against a ValueSet supplied inline (the FHIR validator passes the
     // value set in the request rather than relying on stored content) — either an explicit `valueSet`
     // parameter or a `tx-resource` whose url matches the requested url. This path is unauthenticated-safe
     // (no per-resource read privilege check), which is what the conformance runner exercises as a guest,
     // so it must itself produce the full tx-ecosystem response shape (issues, version).
-    com.kodality.zmei.fhir.resource.terminology.ValueSet inlineVs = req.findParameter("valueSet")
+    Optional<com.kodality.zmei.fhir.resource.terminology.ValueSet> explicit = req.findParameter("valueSet")
         .filter(pp -> pp.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.ValueSet)
-        .map(pp -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) pp.getResource())
-        .orElseGet(() -> findTxResourceValueSet(req, url));
+        .map(pp -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) pp.getResource());
+    com.kodality.zmei.fhir.resource.terminology.ValueSet inlineVs;
+    if (explicit.isPresent()) {
+      inlineVs = explicit.get();
+    } else {
+      List<com.kodality.zmei.fhir.resource.terminology.ValueSet> txVs = txResourceValueSets(req, url);
+      if (txVs.isEmpty()) {
+        inlineVs = null;
+      } else if (version != null) {
+        // A pinned valueSetVersion must resolve to a tx-resource of exactly that version; an unknown version
+        // is a hard 404 ("Unable_to_resolve_value_Set_"), not a silent fall back to another inline version.
+        String canonical = url;
+        inlineVs = txVs.stream().filter(vs -> version.equals(vs.getVersion())).findFirst()
+            .orElseThrow(() -> valueSetNotResolvable(canonical, version));
+      } else {
+        inlineVs = latestByVersion(txVs);
+      }
+    }
     if (inlineVs != null) {
-      return validateInline(inlineVs, req);
+      Parameters resp = validateInline(inlineVs, req);
+      // FHIR $validate-code echoes the codeableConcept it was given (it isn't reconstructed from the match) —
+      // the stored path does this in run(ValueSetVersion, …); the inline path must too.
+      req.findParameter("codeableConcept")
+          .filter(cc -> resp.findParameter("codeableConcept").isEmpty())
+          .ifPresent(resp::addParameter);
+      return sorted(resp);
     }
 
     if (url == null) {
       throw new FhirException(400, IssueType.INVALID, "url parameter required");
     }
-    String version = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(null);
 
     ValueSetVersion vsVersion = version == null ? valueSetVersionService.loadLastVersionByUri(url) :
         valueSetVersionService.query(new ValueSetVersionQueryParams().setValueSetUri(url).setVersion(version)).findFirst().orElse(null);
     if (vsVersion == null) {
+      if (version != null) {
+        throw valueSetNotResolvable(url, version);
+      }
       return error("valueset version not found");
     }
     return run(vsVersion, req);
   }
 
-  /** Finds a ValueSet supplied inline via a tx-resource parameter whose url matches the requested url. */
-  private static com.kodality.zmei.fhir.resource.terminology.ValueSet findTxResourceValueSet(Parameters req, String url) {
+  /** All ValueSets supplied inline via tx-resource params whose canonical url matches (any version). */
+  private static List<com.kodality.zmei.fhir.resource.terminology.ValueSet> txResourceValueSets(Parameters req, String url) {
     if (req.getParameter() == null || url == null) {
-      return null;
+      return List.of();
     }
     return req.getParameter().stream()
         .filter(p -> "tx-resource".equals(p.getName()))
@@ -114,7 +151,209 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.ValueSet)
         .map(r -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) r)
         .filter(vs -> url.equals(vs.getUrl()))
+        .toList();
+  }
+
+  /** Versions of the CodeSystem(s) supplied inline via tx-resource params whose canonical url matches {@code system}. */
+  private static List<String> txResourceCodeSystemVersions(Parameters req, String system) {
+    if (req.getParameter() == null || system == null) {
+      return List.of();
+    }
+    return req.getParameter().stream()
+        .filter(p -> "tx-resource".equals(p.getName()))
+        .map(ParametersParameter::getResource)
+        .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+        .map(r -> ((com.kodality.zmei.fhir.resource.terminology.CodeSystem) r))
+        .filter(cs -> system.equals(cs.getUrl()))
+        .map(com.kodality.zmei.fhir.resource.terminology.CodeSystem::getVersion)
+        .filter(java.util.Objects::nonNull).distinct().toList();
+  }
+
+  private record VersionResolution(String echoVersion, List<OperationOutcomeIssue> issues, boolean hasError, String message, String xCausedBy) {
+  }
+
+  /** The {@code compose.include.version} that applies to {@code system}+{@code code} — preferring an include that enumerates the code (mixed value sets). */
+  private static String includeVersionFor(com.kodality.zmei.fhir.resource.terminology.ValueSet vs, String system, String code) {
+    if (vs.getCompose() == null || vs.getCompose().getInclude() == null) {
+      return null;
+    }
+    com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude fallback = null;
+    for (var inc : vs.getCompose().getInclude()) {
+      if (system == null || system.equals(inc.getSystem())) {
+        boolean listsCode = inc.getConcept() != null && inc.getConcept().stream().anyMatch(c -> code.equals(c.getCode()));
+        if (listsCode) {
+          return inc.getVersion();
+        }
+        if (fallback == null) {
+          fallback = inc;
+        }
+      }
+    }
+    return fallback == null ? null : fallback.getVersion();
+  }
+
+  /** The {@code <version>} of a {@code system-version}/{@code force-system-version}/{@code check-system-version} param naming {@code system} (its value is {@code system|version}). */
+  private static String overrideVersion(Parameters req, String name, String system) {
+    if (req.getParameter() == null || system == null) {
+      return null;
+    }
+    String prefix = system + "|";
+    return req.getParameter().stream()
+        .filter(p -> name.equalsIgnoreCase(p.getName()))
+        .map(p -> p.getValueCanonical() != null ? p.getValueCanonical() : p.getValueString())
+        .filter(v -> v != null && v.startsWith(prefix))
+        .map(v -> v.substring(prefix.length()))
         .findFirst().orElse(null);
+  }
+
+  /** Resolves a pattern/concrete version to an actual available code system version (latest wildcard match / exact / latest when unpinned); null when no available version satisfies it. */
+  private static String concretize(String resolved, List<String> available) {
+    if (resolved == null) {
+      return available.stream().max(ValueSetValidateCodeOperation::compareVersions).orElse(null);
+    }
+    if (org.termx.terminology.fhir.FhirVersions.versionHasWildcards(resolved)) {
+      return available.stream().filter(a -> org.termx.terminology.fhir.FhirVersions.versionMatches(resolved, a))
+          .max(ValueSetValidateCodeOperation::compareVersions).orElse(null);
+    }
+    return available.contains(resolved) ? resolved : null;
+  }
+
+  private static String versionLocation(Parameters req) {
+    if (req.findParameter("codeableConcept").isPresent()) {
+      return "CodeableConcept.coding[0].version";
+    }
+    return req.findParameter("coding").isPresent() ? "Coding.version" : "version";
+  }
+
+  /**
+   * Reimplements org.hl7.fhir.core {@code ValueSetValidator.determineVersion}: resolve the effective code
+   * system version (force &gt; include &gt; system-version &gt; check-system-version, then a more-detailed coding
+   * version refines a wildcard), enforce {@code check-system-version}, and flag the right
+   * {@code VALUESET_VALUE_MISMATCH} variant plus {@code UNKNOWN_CODESYSTEM_VERSION} when the coding's version
+   * differs/doesn't exist. Operates off the tx-resource CodeSystem versions (the inline expand carries none).
+   */
+  private VersionResolution resolveVersion(Parameters req, String system, String includeVersion, String codingVersion, List<String> available) {
+    List<OperationOutcomeIssue> issues = new ArrayList<>();
+    boolean hasError = false;
+    String loc = versionLocation(req);
+
+    String resolved = includeVersion;
+    String force = overrideVersion(req, "force-system-version", system);
+    String check = overrideVersion(req, "check-system-version", system);
+    if (force != null) {
+      resolved = force;
+    } else if (StringUtils.isEmpty(resolved)) {
+      String def = overrideVersion(req, "system-version", system);
+      resolved = def != null ? def : check;
+    }
+    if (codingVersion != null && resolved != null && org.termx.terminology.fhir.FhirVersions.isMoreDetailed(resolved, codingVersion)) {
+      resolved = codingVersion;
+    }
+
+    String csVersion = concretize(resolved, available);
+    boolean csExists = csVersion != null;
+
+    // check-system-version: the resolved version must match the checked one, else a version-error.
+    if (check != null && csVersion != null && !org.termx.terminology.fhir.FhirVersions.versionMatches(check, csVersion)) {
+      String msg = String.format("The version '%s' is not allowed for system '%s': required to be '%s' by a version-check parameter", csVersion, system, check);
+      issues.add(org.termx.terminology.fhir.TxIssues.issue("error", "exception", "version-error", msg, loc));
+      hasError = true;
+    }
+
+    // Mismatch between the coding's version and the resolved code system version. An unknown coding version
+    // (UNKNOWN_CODESYSTEM_VERSION, an error) is collected first so it sorts ahead of the mismatch and drives
+    // the `message`/`x-caused-by-unknown-system`; the mismatch variant (DEFAULT warning / CHANGED / plain) follows.
+    String xCausedBy = null;
+    if (codingVersion != null && !(csVersion != null && codingVersion.equals(csVersion))) {
+      if (csExists && !available.isEmpty() && !available.contains(codingVersion)) {
+        issues.add(org.termx.terminology.fhir.TxIssues.issue("error", "not-found", "not-found", String.format(
+            "A definition for CodeSystem '%s' version '%s' could not be found, so the code cannot be validated. Valid versions: %s",
+            system, codingVersion, String.join(", ", available)), "system"));
+        hasError = true;
+        xCausedBy = system + "|" + codingVersion;
+      }
+      if (csExists) {
+        if (resolved == null) {
+          issues.add(org.termx.terminology.fhir.TxIssues.issue("warning", "invalid", "vs-invalid", String.format(
+              "The code system '%s' version '%s' for the versionless include in the ValueSet include is different to the one in the value ('%s')",
+              system, csVersion, codingVersion), loc));
+        } else if (!resolved.equals(includeVersion)) {
+          issues.add(org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "vs-invalid", String.format(
+              "The code system '%s' version '%s' resulting from the version '%s' in the ValueSet include is different to the one in the value ('%s')",
+              system, resolved, notNull(includeVersion), codingVersion), loc));
+          hasError = true;
+        } else if (!notNull(includeVersion).equals(codingVersion)) {
+          issues.add(org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "vs-invalid", String.format(
+              "The code system '%s' version '%s' in the ValueSet include is different to the one in the value ('%s')",
+              system, notNull(includeVersion), codingVersion), loc));
+          hasError = true;
+        }
+      } else {
+        issues.add(org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "vs-invalid", String.format(
+            "The code system '%s' version '%s' in the ValueSet include is different to the one in the value ('%s')",
+            system, resolved, codingVersion), loc));
+        hasError = true;
+      }
+    }
+
+    String echo = csVersion != null ? csVersion
+        : codingVersion != null && available.contains(codingVersion) ? codingVersion
+        : available.stream().max(ValueSetValidateCodeOperation::compareVersions).orElse(null);
+    // The `message` echoes the primary (first error) issue text — error before warning.
+    String message = issues.stream().filter(i -> "error".equals(i.getSeverity()))
+        .map(i -> i.getDetails() == null ? null : i.getDetails().getText()).filter(java.util.Objects::nonNull)
+        .findFirst().orElse(null);
+    return new VersionResolution(echo, issues, hasError, message, xCausedBy);
+  }
+
+  private static String notNull(String s) {
+    return s == null ? "" : s;
+  }
+
+  /** Highest-version tx-resource (the latest, by semantic-version order), falling back to the first. */
+  private static com.kodality.zmei.fhir.resource.terminology.ValueSet latestByVersion(
+      List<com.kodality.zmei.fhir.resource.terminology.ValueSet> vss) {
+    return vss.stream().max(java.util.Comparator.comparing(
+        com.kodality.zmei.fhir.resource.terminology.ValueSet::getVersion,
+        java.util.Comparator.nullsFirst(ValueSetValidateCodeOperation::compareVersions))).orElse(vss.get(0));
+  }
+
+  /** Numeric-aware comparison of dotted version strings ("1.10.0" &gt; "1.2.0"), tolerant of non-numeric parts. */
+  private static int compareVersions(String a, String b) {
+    String[] pa = a.split("\\.");
+    String[] pb = b.split("\\.");
+    for (int i = 0; i < Math.max(pa.length, pb.length); i++) {
+      String sa = i < pa.length ? pa[i] : "0";
+      String sb = i < pb.length ? pb[i] : "0";
+      int c;
+      if (sa.matches("\\d+") && sb.matches("\\d+")) {
+        c = Long.compare(Long.parseLong(sa), Long.parseLong(sb));
+      } else {
+        c = sa.compareTo(sb);
+      }
+      if (c != 0) {
+        return c;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * A pinned ValueSet version that resolves to nothing is a 404 OperationOutcome (tx-ecosystem
+   * "Unable_to_resolve_value_Set_") — carrying the {@code tx-issue-type} {@code not-found} detail coding the
+   * ecosystem matches on, not a bare {@code details.text}.
+   */
+  static FhirException valueSetNotResolvable(String url, String version) {
+    return org.termx.terminology.fhir.TxIssues.notFoundException(404,
+        String.format("A definition for the value Set '%s|%s' could not be found", url, version));
+  }
+
+  /** Sorts response parameters by name — the tx-ecosystem TxTester diffs parameters positionally against an alphabetically-ordered expected list. */
+  private static Parameters sorted(Parameters p) {
+    if (p != null && p.getParameter() != null) {
+      p.getParameter().sort(java.util.Comparator.comparing(ParametersParameter::getName, java.util.Comparator.nullsLast(String::compareTo)));
+    }
+    return p;
   }
 
   /**
@@ -127,17 +366,20 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     String code = req.findParameter("code").map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).orElse(null);
     String system = findSystem(req);
     String display = req.findParameter("display").map(ParametersParameter::getValueString).orElse(null);
+    String reqCsVersion = req.findParameter("systemVersion").map(ParametersParameter::getValueString).orElse(null);
     if (req.findParameter("coding").isPresent()) {
       Coding coding = req.findParameter("coding").map(ParametersParameter::getValueCoding).orElse(null);
       code = coding != null && coding.getCode() != null ? coding.getCode() : code;
       system = coding != null && coding.getSystem() != null ? coding.getSystem() : system;
       display = coding != null && coding.getDisplay() != null ? coding.getDisplay() : display;
+      reqCsVersion = coding != null && coding.getVersion() != null ? coding.getVersion() : reqCsVersion;
     }
     if (req.findParameter("codeableConcept").isPresent()) {
       CodeableConcept cc = req.findParameter("codeableConcept").map(ParametersParameter::getValueCodeableConcept).orElse(null);
       Coding coding = cc != null && cc.getCoding() != null ? cc.getCoding().stream().findFirst().orElse(null) : null;
       code = coding != null && coding.getCode() != null ? coding.getCode() : code;
       system = coding != null && coding.getSystem() != null ? coding.getSystem() : system;
+      reqCsVersion = coding != null && coding.getVersion() != null ? coding.getVersion() : reqCsVersion;
     }
     if (code == null) {
       throw new FhirException(400, IssueType.INVALID, "code, coding or codeableConcept parameter required");
@@ -156,6 +398,10 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         .map(com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion::getContains).orElse(List.of()).stream()
         .filter(c -> finalCode.equals(c.getCode()) && (finalSystem == null || finalSystem.equals(c.getSystem())))
         .findFirst().orElse(null);
+
+    // The inline SQL expand can't reach external providers, so the resolved code system version isn't on the
+    // expansion members — derive it from the tx-resource CodeSystem(s) the validator passed for `system`.
+    List<String> availableCsVersions = txResourceCodeSystemVersions(req, system);
 
     String vsCanonical = inlineVs.getUrl() + (inlineVs.getVersion() != null ? "|" + inlineVs.getVersion() : "");
     Parameters resp = new Parameters();
@@ -188,17 +434,30 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
               org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "invalid-code", unknownCode, codeLoc))));
       return resp;
     }
+    // Version negotiation — mirrors org.hl7.fhir.core ValueSetValidator.determineVersion (the engine behind the
+    // tx-ecosystem): resolve the code system version from the include version, the
+    // system-version/force-system-version/check-system-version override params and the coding's own version,
+    // then flag VALUESET_VALUE_MISMATCH(_CHANGED/_DEFAULT) / UNKNOWN_CODESYSTEM_VERSION / version-check errors.
+    String includeVersion = includeVersionFor(inlineVs, system, code);
+    VersionResolution vr = resolveVersion(req, system, includeVersion, reqCsVersion, availableCsVersions);
+
     String finalDisplay = display;
     boolean displayValid = finalDisplay == null || finalDisplay.equals(match.getDisplay())
         || Optional.ofNullable(match.getDesignation()).orElse(List.of()).stream().anyMatch(d -> finalDisplay.equals(d.getValue()));
-    resp.addParameter(new ParametersParameter("result").setValueBoolean(displayValid));
+
+    List<OperationOutcomeIssue> issues = new ArrayList<>(vr.issues());
+    resp.addParameter(new ParametersParameter("result").setValueBoolean(displayValid && !vr.hasError()));
     resp.addParameter(new ParametersParameter("code").setValueCode(match.getCode()));
     if (match.getSystem() != null) {
       resp.addParameter(new ParametersParameter("system").setValueUri(match.getSystem()));
     }
     resp.addParameter(new ParametersParameter("display").setValueString(match.getDisplay()));
-    if (match.getVersion() != null) {
-      resp.addParameter(new ParametersParameter("version").setValueString(match.getVersion()));
+    String echoVersion = vr.echoVersion() != null ? vr.echoVersion() : match.getVersion();
+    if (echoVersion != null) {
+      resp.addParameter(new ParametersParameter("version").setValueString(echoVersion));
+    }
+    if (vr.xCausedBy() != null) {
+      resp.addParameter(new ParametersParameter("x-caused-by-unknown-system").setValueCanonical(vr.xCausedBy()));
     }
     if (!displayValid) {
       // Invalid display: 200 with result=false plus a structured `issues` OperationOutcome (invalid-display
@@ -207,9 +466,19 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
           display, match.getSystem(), match.getCode(), match.getDisplay(),
           StringUtils.isEmpty(displayLanguage) ? "--" : displayLanguage);
       resp.addParameter(new ParametersParameter("message").setValueString(message));
+      issues.add(org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "invalid-display", message, displayLocation(req)));
+    } else if (vr.message() != null) {
+      resp.addParameter(new ParametersParameter("message").setValueString(vr.message()));
+    }
+    if (!issues.isEmpty()) {
+      // Errors before warnings before information — the tx-ecosystem orders an OperationOutcome's issues by severity.
+      java.util.List<String> sev = List.of("fatal", "error", "warning", "information");
+      issues.sort(java.util.Comparator.comparingInt(i -> {
+        int idx = sev.indexOf(i.getSeverity());
+        return idx < 0 ? sev.size() : idx;
+      }));
       resp.addParameter(new ParametersParameter("issues").setResource(
-          org.termx.terminology.fhir.TxIssues.outcome(
-              org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "invalid-display", message, displayLocation(req)))));
+          org.termx.terminology.fhir.TxIssues.outcome(issues.toArray(OperationOutcomeIssue[]::new))));
     }
     return resp;
   }
@@ -223,7 +492,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
           .filter(cc -> response.findParameter("codeableConcept").isEmpty())
           .ifPresent(response::addParameter);
     }
-    return response;
+    return sorted(response);
   }
 
   private Parameters doRun(ValueSetVersion vsVersion, Parameters req) {
@@ -277,7 +546,8 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       if (anyVersion != null) {
         List<String> available = Optional.ofNullable(anyVersion.getConcept().getCodeSystemVersions()).orElse(List.of());
         if (!available.contains(finalVersion)) {
-          return unknownSystemVersion(anyVersion, finalSystem, finalVersion, available, display, displayLanguage);
+          return unknownSystemVersion(anyVersion.getConcept().getCode(), findDisplay(anyVersion, display, displayLanguage),
+              finalSystem, finalVersion, available);
         }
       }
     }
@@ -337,8 +607,8 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
    * UNKNOWN_CODESYSTEM_VERSION error (with the valid versions) plus the versionless-include mismatch warning.
    * Mirrors the FHIR tx ecosystem's "graceful degradation" — a 200, not a 4xx.
    */
-  private Parameters unknownSystemVersion(ValueSetVersionConcept concept, String system, String requestedVersion,
-                                          List<String> availableVersions, String display, String displayLanguage) {
+  private Parameters unknownSystemVersion(String code, String displayName, String system, String requestedVersion,
+                                          List<String> availableVersions) {
     String availableVersion = availableVersions.stream().findFirst().orElse(null);
     String message = String.format(
         "A definition for CodeSystem '%s' version '%s' could not be found, so the code cannot be validated. Valid versions: %s",
@@ -359,10 +629,9 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     outcome.setIssue(List.of(notFound, mismatch));
 
     Parameters parameters = new Parameters();
-    parameters.addParameter(new ParametersParameter("code").setValueCode(concept.getConcept().getCode()));
-    String conceptDisplay = findDisplay(concept, display, displayLanguage);
-    if (conceptDisplay != null) {
-      parameters.addParameter(new ParametersParameter("display").setValueString(conceptDisplay));
+    parameters.addParameter(new ParametersParameter("code").setValueCode(code));
+    if (displayName != null) {
+      parameters.addParameter(new ParametersParameter("display").setValueString(displayName));
     }
     parameters.addParameter(new ParametersParameter("issues").setResource(outcome));
     parameters.addParameter(new ParametersParameter("message").setValueString(message));

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/FhirVersionsSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/FhirVersionsSpec.groovy
@@ -1,0 +1,62 @@
+package org.termx.terminology.fhir
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Locks {@link FhirVersions} to the reference engine's semantics (org.hl7.fhir.core 6.9.10
+ * {@code VersionUtilities}), the implementation behind the tx-ecosystem version suite.
+ */
+class FhirVersionsSpec extends Specification {
+
+  @Unroll
+  def "versionMatches(#criteria, #candidate) == #expected"() {
+    expect:
+    FhirVersions.versionMatches(criteria, candidate) == expected
+
+    where:
+    criteria  | candidate || expected
+    "1.x.x"   | "1.0.0"   || true     // wildcard minor/patch match any
+    "1.x.x"   | "1.2.0"   || true
+    "1.x.x"   | "2.0.0"   || false    // major differs
+    "1.0.x"   | "1.0.0"   || true     // patch wildcard
+    "1.0.x"   | "1.2.0"   || false    // minor differs
+    "1.0.0"   | "1.0.0"   || true     // exact
+    "1.0.0"   | "1.2.0"   || false
+    "1"       | "1.0.0"   || false    // bare "1" is a literal, NOT a prefix of 1.0.0
+    "1"       | "1"       || true
+    "*"       | "1.0.0"   || true     // full wildcard
+    "1.0?"    | "1.0.0"   || true     // trailing-? makes patch optional
+    "1.0?"    | "1.0.9"   || true
+    "1.1?"    | "1.0.0"   || false
+  }
+
+  @Unroll
+  def "isMoreDetailed(#criteria, #candidate) == #expected"() {
+    expect:
+    FhirVersions.isMoreDetailed(criteria, candidate) == expected
+
+    where:
+    criteria | candidate || expected
+    "1.x.x"  | "1.0.0"   || true   // concrete coding refines the wildcard include
+    "1.0.x"  | "1.0.0"   || true
+    "1.x.x"  | "2.0.0"   || false  // doesn't match
+    "1"      | "1.0.0"   || false  // literal, not a wildcard
+    "1.0.0"  | "1.0.0"   || false  // already concrete
+  }
+
+  @Unroll
+  def "versionHasWildcards(#v) == #expected"() {
+    expect:
+    FhirVersions.versionHasWildcards(v) == expected
+
+    where:
+    v       || expected
+    "1.x.x" || true
+    "1.0.x" || true
+    "1.0?"  || true
+    "1.*"   || true
+    "1"     || false
+    "1.0.0" || false
+  }
+}


### PR DESCRIPTION
Resolves and negotiates code system / value set versions in the inline (`tx-resource`) `$validate-code` and `$expand` paths the FHIR validator exercises, mirroring the reference engine (`org.hl7.fhir.core` 6.9.10 `ValueSetValidator.determineVersion`) that generates the tx-ecosystem fixtures.

## What

- **`<url>|<version>` canonical parsing** in `$validate-code` and `$expand`, consistent with terminology-explorer's `CanonicalUrlParser` (version = everything after the first `|`).
- **404 on an unresolvable pinned version** — an unknown `valueSetVersion` now returns a 404 `OperationOutcome` carrying the `tx-issue-type` `not-found` detail coding (`TxIssues.notFoundException`), instead of silently falling back to another version.
- **`FhirVersions`** — semver wildcard matching (`1.x.x` / `1.0.x` / trailing-`?`; a bare `1` is an exact literal that does *not* match `1.0.0`), mirroring `VersionUtilities.versionMatches`. Unit-tested in `FhirVersionsSpec`.
- **Version negotiation** — precedence `force-system-version` > include version > `system-version` > `check-system-version`, then a more-detailed `Coding.version` refines a wildcard; emits the correct `VALUESET_VALUE_MISMATCH` (`/_CHANGED`/`_DEFAULT`), `UNKNOWN_CODESYSTEM_VERSION`, and version-check issues, plus `x-caused-by-unknown-system`.
- **Envelope** — echo `codeableConcept` on the inline path; sort response parameters (alphabetical) and issues (error-first) to the ecosystem's order.

## Conformance impact (tx-ecosystem `hl7.fhir.uv.tx-ecosystem#current`, runner 6.9.10)

- version suite: **35 → 85 / 206**
- overall: **103 → 169 / 599**
- No regressions in any suite.

Internal: `FhirVersionsSpec` + the `$validate-code` / `$expand` / supplement ITs pass.