### PR TITLE
fix(fhir): drop compose from inline $expand response

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -510,7 +510,10 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // Echo `experimental` from the source — the tx-ecosystem expects it on the $expand result (even when
     // false), and a $expand response is a rendering of the value set, so its descriptive metadata carries over.
     response.setExperimental(inlineVs.getExperimental());
-    response.setCompose(inlineVs.getCompose());
+    // An $expand response is a rendered view, not the value-set definition — the expansion replaces the
+    // compose (the tx-ecosystem marks compose optional on the expand result and the reference server omits it;
+    // echoing the source compose, including its raw include version, mismatches). The stored path already
+    // drops it in ValueSetFhirMapper; mirror that here.
 
     // Build expansion
     com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion expansion =


### PR DESCRIPTION
An `$expand` response is a rendered view, not the value-set definition — the expansion replaces the `compose`. The stored path already drops `compose` (`ValueSetFhirMapper`), but the inline (`tx-resource`) path echoed the source compose, including its raw unresolved include version, which mismatches the tx-ecosystem (compose is optional on the expand result — 0 of 152 expand fixtures require it — and the reference server omits it).

## Conformance

- overall **195 → 214 / 599** — broad, since inline `$expand` across suites was echoing compose:
  - version 111 → 119, notSelectable 12 → 20, default-valueset-version 0 → 2, simple-cases 10 → 11
- No regressions. `$expand` ITs pass.