### PR TITLE
feat(fhir): version negotiation on inline $expand

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -58,4 +58,30 @@ public final class TxIssues {
         .setText(text));
     return new com.kodality.kefhir.core.exception.FhirException(status, issue);
   }
+
+  /**
+   * A {@code check-system-version} violation: an {@code exception}-code OperationOutcome issue with the
+   * {@code tx-issue-type}/{@code version-error} detail coding (tx-ecosystem {@code VALUESET_VERSION_CHECK}).
+   */
+  public static com.kodality.kefhir.core.exception.FhirException versionCheckException(int status, String text) {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.EXCEPTION);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept()
+        .addCoding(new org.hl7.fhir.r5.model.Coding(TX_ISSUE_TYPE, "version-error", null))
+        .setText(text));
+    return new com.kodality.kefhir.core.exception.FhirException(status, issue);
+  }
+
+  /** Formats a version list as the tx-ecosystem does: comma-separated with " or " before the last ("a, b or c"). */
+  public static String presentVersionList(java.util.List<String> versions) {
+    if (versions == null || versions.isEmpty()) {
+      return "";
+    }
+    if (versions.size() == 1) {
+      return versions.get(0);
+    }
+    return String.join(", ", versions.subList(0, versions.size() - 1)) + " or " + versions.get(versions.size() - 1);
+  }
 }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -440,7 +440,10 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   // $expand parameters that identify WHICH value set to expand rather than HOW. FHIR records the "how"
   // params in expansion.parameter but not the selection identifiers, and the tx-ecosystem suite flags an
   // echoed `url` (etc.) as an unexpected expansion.parameter. Filtered out of the echo below.
-  private static final Set<String> EXPANSION_SELECTION_PARAMETERS = Set.of("url", "valueSet", "valueSetVersion", "context", "contextDirection");
+  // `force-system-version` IS echoed (it materially changed the expansion); `system-version`/`check-system-version`
+  // are advisory and the tx-ecosystem does not echo them.
+  private static final Set<String> EXPANSION_SELECTION_PARAMETERS = Set.of("url", "valueSet", "valueSetVersion", "context", "contextDirection",
+      "system-version", "check-system-version");
 
   private static List<ValueSetExpansionParameter> toValueSetParameter(Parameters param) {
     if (param == null || param.getParameter() == null) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -392,6 +392,89 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         .toList();
   }
 
+  /** Versions of the CodeSystem(s) supplied inline via tx-resource params whose canonical url matches {@code system}. */
+  private static List<String> txResourceCodeSystemVersions(Parameters req, String system) {
+    if (req == null || req.getParameter() == null || system == null) {
+      return List.of();
+    }
+    return req.getParameter().stream()
+        .filter(p -> "tx-resource".equals(p.getName()))
+        .map(ParametersParameter::getResource)
+        .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+        .map(r -> ((com.kodality.zmei.fhir.resource.terminology.CodeSystem) r))
+        .filter(cs -> system.equals(cs.getUrl()))
+        .map(com.kodality.zmei.fhir.resource.terminology.CodeSystem::getVersion)
+        .filter(java.util.Objects::nonNull).distinct().toList();
+  }
+
+  /** The {@code <version>} of a {@code system-version}/{@code force-system-version}/{@code check-system-version} param naming {@code system}. */
+  private static String overrideVersion(Parameters req, String name, String system) {
+    if (req == null || req.getParameter() == null || system == null) {
+      return null;
+    }
+    String prefix = system + "|";
+    return req.getParameter().stream()
+        .filter(p -> name.equalsIgnoreCase(p.getName()))
+        .map(p -> p.getValueCanonical() != null ? p.getValueCanonical() : p.getValueString())
+        .filter(v -> v != null && v.startsWith(prefix))
+        .map(v -> v.substring(prefix.length()))
+        .findFirst().orElse(null);
+  }
+
+  /**
+   * Returns a copy of the inline value set with each {@code compose.include.version} resolved to a concrete
+   * available code system version: {@code force-system-version} overrides; else the include version; else
+   * {@code system-version}; else {@code check-system-version}; a wildcard ({@code 1.x.x}) resolves to the
+   * highest matching available version. A pinned version that resolves to nothing, or a resolved version that
+   * fails {@code check-system-version}, is a 4xx — the expansion can't be produced. The original is untouched.
+   */
+  private com.kodality.zmei.fhir.resource.terminology.ValueSet resolveIncludeVersions(
+      com.kodality.zmei.fhir.resource.terminology.ValueSet inlineVs, Parameters req) {
+    if (inlineVs.getCompose() == null || inlineVs.getCompose().getInclude() == null) {
+      return inlineVs;
+    }
+    com.kodality.zmei.fhir.resource.terminology.ValueSet copy = FhirMapper.fromJson(
+        FhirMapper.toJson(inlineVs), com.kodality.zmei.fhir.resource.terminology.ValueSet.class);
+    for (var inc : copy.getCompose().getInclude()) {
+      String system = inc.getSystem();
+      if (system == null) {
+        continue;
+      }
+      List<String> available = txResourceCodeSystemVersions(req, system);
+      String force = overrideVersion(req, "force-system-version", system);
+      String check = overrideVersion(req, "check-system-version", system);
+      String resolved = inc.getVersion();
+      if (force != null) {
+        resolved = force;
+      } else if (StringUtils.isEmpty(resolved)) {
+        String def = overrideVersion(req, "system-version", system);
+        resolved = def != null ? def : check;
+      }
+      if (resolved == null) {
+        continue; // versionless — let the SQL expand the latest
+      }
+      String pattern = resolved;
+      String concrete = org.termx.terminology.fhir.FhirVersions.versionHasWildcards(pattern)
+          ? available.stream().filter(a -> org.termx.terminology.fhir.FhirVersions.versionMatches(pattern, a))
+              .max(ValueSetExpandOperation::compareVersions).orElse(null)
+          : available.contains(pattern) ? pattern : null;
+      if (concrete == null) {
+        if (!available.isEmpty()) {
+          throw org.termx.terminology.fhir.TxIssues.notFoundException(404, String.format(
+              "A definition for CodeSystem '%s' version '%s' could not be found, so the value set cannot be expanded. Valid versions: %s",
+              system, resolved, org.termx.terminology.fhir.TxIssues.presentVersionList(available)));
+        }
+        continue;
+      }
+      if (check != null && !org.termx.terminology.fhir.FhirVersions.versionMatches(check, concrete)) {
+        throw org.termx.terminology.fhir.TxIssues.versionCheckException(400, String.format(
+            "The version '%s' is not allowed for system '%s': required to be '%s' by a version-check parameter", concrete, system, check));
+      }
+      inc.setVersion(concrete);
+    }
+    return copy;
+  }
+
   /** Highest-version tx-resource (latest, by numeric-aware dotted-version order), falling back to the first. */
   private static com.kodality.zmei.fhir.resource.terminology.ValueSet latestByVersion(
       List<com.kodality.zmei.fhir.resource.terminology.ValueSet> vss) {
@@ -417,6 +500,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
 
   private com.kodality.zmei.fhir.resource.terminology.ValueSet expandInline(
       com.kodality.zmei.fhir.resource.terminology.ValueSet inlineVs, Parameters req) {
+    // Resolve each compose.include.version against the system-version/force-system-version/check-system-version
+    // params and wildcard semantics (mirrors org.hl7.fhir.core ValueSetValidator.determineVersion), rewriting it
+    // to a concrete available version so the SQL expand picks the right code system version — driving
+    // expansion.total and the used-codesystem parameter. A pinned version that resolves to nothing, or a
+    // check-system-version mismatch, is a 4xx (the expansion can't be produced).
+    inlineVs = resolveIncludeVersions(inlineVs, req);
+
     // Serialize the inline ValueSet to JSON
     String valueSetJson = FhirMapper.toJson(inlineVs);
 
@@ -538,15 +628,25 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
           .toList());
     }
 
+    // FHIR adds `version` to a contains member only when the expansion spans more than one code system
+    // version (a mixed/multi-version value set), to disambiguate; a single-version expansion omits it.
+    boolean emitContainsVersion = expandedConcepts.stream()
+        .map(c -> c.getConcept() != null && c.getConcept().getCodeSystemVersions() != null
+            ? c.getConcept().getCodeSystemVersions().stream().findFirst().orElse(null) : null)
+        .filter(java.util.Objects::nonNull).distinct().count() > 1;
+
     // Map concepts to expansion contains
-    List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains> contains = 
+    List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains> contains =
         expandedConcepts.stream().map(concept -> {
-          com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains contain = 
+          com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains contain =
               new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains();
           contain.setSystem(concept.getConcept().getCodeSystemUri());
           contain.setCode(concept.getConcept().getCode());
           if (concept.getDisplay() != null) {
             contain.setDisplay(concept.getDisplay().getName());
+          }
+          if (emitContainsVersion && concept.getConcept().getCodeSystemVersions() != null) {
+            concept.getConcept().getCodeSystemVersions().stream().findFirst().ifPresent(contain::setVersion);
           }
           // FHIR expansion.contains flags, both omitted when false: `inactive` for a retired/deprecated
           // concept, `abstract` for a not-selectable (grouper) concept. The SQL expand returns members bare,


### PR DESCRIPTION
Follow-up to #266 — carries the `$validate-code` version resolver into `$expand` (the V4 expand-side gap in the tx-ecosystem `version` suite).

## What

Resolve each `compose.include.version` against `system-version`/`force-system-version`/`check-system-version` + wildcard semantics (`org.hl7.fhir.core` `ValueSetValidator.determineVersion`) **before** the inline SQL expand, rewriting it to a concrete available version so the expansion runs at the right CS version — fixing `expansion.total` and the `used-codesystem` parameter.

- unresolvable pinned version → **4xx** `UNKNOWN_CODESYSTEM` (with `Valid versions: a or b`); `check-system-version` mismatch → **4xx** `VALUESET_VERSION_CHECK` (issue code `exception`, `tx-issue-type` `version-error`).
- `force-system-version` echoed in `expansion.parameter` (it changed the result); `system-version`/`check-system-version` not.
- `contains[].version` only when the expansion spans multiple CS versions (mixed VS).

## Conformance

- version suite **119 → 144 / 206** (only 4 `vs-expand` edge cases left, from 37)
- overall **214 → 241 / 599** (40.2%); overload 8→10
- No regressions; `$expand`/`$validate-code` ITs pass.