### PR TITLE
fix(fhir): tolerate HL7 best-practice supplement advisories on tx-resource inputs

### DIFF
--- a/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
+++ b/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
@@ -50,6 +50,16 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
   // Such a message means "could not check this profile", not "the resource is invalid" — so it is tolerated.
   private static final String UNCHECKED_PROFILE = "has not been checked because it is unknown";
 
+  // HL7-jurisdiction best-practice ("SHOULD"/"SHOULD NOT") advisories the org.hl7.fhir validator escalates to
+  // ERROR. A terminology server is handed arbitrary CodeSystems/ValueSets as operation INPUTS (tx-resource on
+  // $expand/$validate-code) — it must not 400 a structurally-valid resource over an HL7 publishing best
+  // practice it does not itself assert (e.g. a CodeSystem supplement that carries caseSensitive). These are
+  // SHOULD-level only; the matching SHALL invariants (…_SUPPL_MISSING/…_SUPPL_WRONG) are left enforced.
+  private static final java.util.Set<String> TOLERATED_BEST_PRACTICE_MESSAGE_IDS = java.util.Set.of(
+      "CODESYSTEM_CS_HL7_PRESENT_ELEMENT_SUPPL",
+      "CODESYSTEM_CS_NO_VS_SUPPLEMENT1",
+      "CODESYSTEM_CS_NO_VS_SUPPLEMENT2");
+
   @Inject
   private ResourceFormatService resourceFormatService;
   @Inject
@@ -96,6 +106,7 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
       List<SingleValidationMessage> errors = hapiContextHolder.getValidator().validateWithResult(content.getValue()).getMessages().stream()
           .filter(m -> isError(m.getSeverity()))
           .filter(m -> !isUncheckedProfile(m))
+          .filter(m -> !TOLERATED_BEST_PRACTICE_MESSAGE_IDS.contains(m.getMessageId()))
           .collect(toList());
       if (!errors.isEmpty()) {
         throw new FhirException(400, errors.stream().map(msg -> {


### PR DESCRIPTION
A terminology server receives arbitrary CodeSystems/ValueSets as operation **inputs** (`tx-resource` on `$expand`/`$validate-code`). The `org.hl7.fhir` instance validator escalates HL7-jurisdiction "SHOULD"/"SHOULD NOT" best-practice advisories to ERROR, so a structurally-valid CodeSystem **supplement** that states `caseSensitive` (`CODESYSTEM_CS_HL7_PRESENT_ELEMENT_SUPPL`) made the inbound profile validator reject the whole request with **400 — before the operation ran**. The tx-ecosystem ships that supplement as `tx-resource` on every `parameters` (35) and `extensions` (11) call, so the entire suites 400'd.

## Fix

Tolerate the SHOULD-level supplement advisories by message id in `ProfileTolerantResourceValidator` (`CODESYSTEM_CS_HL7_PRESENT_ELEMENT_SUPPL`, `CODESYSTEM_CS_NO_VS_SUPPLEMENT1/2`). The matching SHALL invariants (`…_SUPPL_MISSING`/`…_SUPPL_WRONG`) stay enforced.

## Conformance

- requests now accepted: `parameters` **0 → 3/35** (the rest are now expansion-content diffs — hierarchy preservation etc.), overall 241 → 244.
- No regressions; FHIR import + `$expand` ITs pass.