### PR TITLE
feat(fhir): $expand content echoes — property uri, designation use/language

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -441,9 +441,10 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
   // params in expansion.parameter but not the selection identifiers, and the tx-ecosystem suite flags an
   // echoed `url` (etc.) as an unexpected expansion.parameter. Filtered out of the echo below.
   // `force-system-version` IS echoed (it materially changed the expansion); `system-version`/`check-system-version`
-  // are advisory and the tx-ecosystem does not echo them.
+  // are advisory and the tx-ecosystem does not echo them. `property` selects which concept properties to surface
+  // on contains[] (declared via expansion.property) — it is not echoed as an expansion.parameter either.
   private static final Set<String> EXPANSION_SELECTION_PARAMETERS = Set.of("url", "valueSet", "valueSetVersion", "context", "contextDirection",
-      "system-version", "check-system-version");
+      "system-version", "check-system-version", "property");
 
   private static List<ValueSetExpansionParameter> toValueSetParameter(Parameters param) {
     if (param == null || param.getParameter() == null) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -622,11 +622,20 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         ValueSetFhirMapper.expansionParameters(req, expandedConcepts);
     expansion.setParameter(expansionParameters.isEmpty() ? null : expansionParameters);
     // Declare the requested properties so contains[].property references a declared expansion.property (valid FHIR).
+    // Each declared property carries its uri — from the tx-resource CodeSystem's property definition, falling back
+    // to the FHIR concept-properties uri for the built-in codes (definition/status/…).
     if (!requestedProperties.isEmpty()) {
+      java.util.Map<String, String> propertyUris = propertyUris(req);
       expansion.setProperty(requestedProperties.stream()
-          .map(code -> new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionProperty().setCode(code))
+          .map(code -> new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionProperty().setCode(code)
+              .setUri(propertyUris.getOrDefault(code, "http://hl7.org/fhir/concept-properties#" + code)))
           .toList());
     }
+
+    // Designation use codings as stated by the tx-resource CodeSystem(s), keyed by use code — so a custom
+    // designation surfaces its real use system (e.g. {.../designations, olde-english}) on contains[].designation.
+    java.util.Map<String, com.kodality.zmei.fhir.datatypes.Coding> designationUses = designationUses(req);
+    java.util.Set<String> noLanguageDesignations = noLanguageDesignations(req);
 
     // FHIR adds `version` to a contains member only when the expansion spans more than one code system
     // version (a mixed/multi-version value set), to disambiguate; a single-version expansion omits it.
@@ -658,17 +667,38 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
             contain.setAbstractField(true);
           }
           if (includeDesignations && concept.getAdditionalDesignations() != null) {
-            contain.setDesignation(concept.getAdditionalDesignations().stream()
+            List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation> designations =
+                concept.getAdditionalDesignations().stream()
                 .filter(d -> ValueSetFhirMapper.designationMatchesFilter(d, designationFilter))
+                // With no explicit `designation` filter, the designation that simply repeats the member's display
+                // and the definition are surfaced via contains.display / a definition property — the tx-ecosystem
+                // omits those designation entries. When the caller explicitly filters designations, return exactly
+                // what was asked for (don't second-guess).
+                .filter(d -> !designationFilter.isEmpty()
+                    || (!"display".equals(d.getDesignationType()) && !"definition".equals(d.getDesignationType())))
                 .map(d -> {
                   com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation designation =
                       new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation();
-                  designation.setLanguage(d.getLanguage());
                   designation.setValue(d.getName());
-                  designation.setUse(org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(
-                      d.getDesignationType() == null ? "display" : d.getDesignationType()));
+                  // Emit the designation's `language`, EXCEPT where the tx-resource CodeSystem shows this
+                  // designation has no stated language (import defaults a missing language to the resource
+                  // language, but the tx-ecosystem omits it). For a stored code system the set is empty, so the
+                  // stored language is preserved.
+                  if (!noLanguageDesignations.contains(d.getName())) {
+                    designation.setLanguage(d.getLanguage());
+                  }
+                  // Prefer the designation's own use coding as stated by the (tx-resource) CodeSystem — it carries
+                  // the use system for custom designations (e.g. {.../designations, olde-english}); the static
+                  // name→use map only knows the common ones.
+                  com.kodality.zmei.fhir.datatypes.Coding use = designationUses.get(d.getDesignationType());
+                  designation.setUse(use != null ? use
+                      : org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(
+                          d.getDesignationType() == null ? "display" : d.getDesignationType()));
                   return designation;
-                }).toList());
+                }).toList();
+            if (!designations.isEmpty()) {
+              contain.setDesignation(designations);
+            }
           }
           if (!requestedProperties.isEmpty()) {
             List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty> props =
@@ -697,6 +727,87 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
 
     response.setExpansion(expansion);
     return response;
+  }
+
+  /** CodeSystem property code→uri from the tx-resource CodeSystems' property definitions. */
+  private static java.util.Map<String, String> propertyUris(Parameters req) {
+    java.util.Map<String, String> uris = new java.util.HashMap<>();
+    if (req == null || req.getParameter() == null) {
+      return uris;
+    }
+    for (ParametersParameter p : req.getParameter()) {
+      if ("tx-resource".equals(p.getName()) && p.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem cs
+          && cs.getProperty() != null) {
+        for (var prop : cs.getProperty()) {
+          if (prop.getCode() != null && prop.getUri() != null) {
+            uris.putIfAbsent(prop.getCode(), prop.getUri());
+          }
+        }
+      }
+    }
+    return uris;
+  }
+
+  /** Designation use codings stated by the tx-resource CodeSystems, keyed by the use code (so custom designations keep their use system). */
+  private static java.util.Map<String, com.kodality.zmei.fhir.datatypes.Coding> designationUses(Parameters req) {
+    java.util.Map<String, com.kodality.zmei.fhir.datatypes.Coding> uses = new java.util.HashMap<>();
+    if (req == null || req.getParameter() == null) {
+      return uses;
+    }
+    for (ParametersParameter p : req.getParameter()) {
+      if ("tx-resource".equals(p.getName()) && p.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem cs) {
+        collectDesignationUses(cs.getConcept(), uses);
+      }
+    }
+    return uses;
+  }
+
+  private static void collectDesignationUses(List<com.kodality.zmei.fhir.resource.terminology.CodeSystem.CodeSystemConcept> concepts,
+                                             java.util.Map<String, com.kodality.zmei.fhir.datatypes.Coding> uses) {
+    if (concepts == null) {
+      return;
+    }
+    for (var c : concepts) {
+      if (c.getDesignation() != null) {
+        for (var d : c.getDesignation()) {
+          if (d.getUse() != null && d.getUse().getCode() != null) {
+            uses.putIfAbsent(d.getUse().getCode(), d.getUse());
+          }
+        }
+      }
+      collectDesignationUses(c.getConcept(), uses);
+    }
+  }
+
+  /** Designation values that the tx-resource CodeSystems state WITHOUT a language (so the import-defaulted language is dropped on echo). */
+  private static java.util.Set<String> noLanguageDesignations(Parameters req) {
+    java.util.Set<String> values = new java.util.HashSet<>();
+    if (req == null || req.getParameter() == null) {
+      return values;
+    }
+    for (ParametersParameter p : req.getParameter()) {
+      if ("tx-resource".equals(p.getName()) && p.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem cs) {
+        collectNoLanguageDesignations(cs.getConcept(), values);
+      }
+    }
+    return values;
+  }
+
+  private static void collectNoLanguageDesignations(List<com.kodality.zmei.fhir.resource.terminology.CodeSystem.CodeSystemConcept> concepts,
+                                                    java.util.Set<String> values) {
+    if (concepts == null) {
+      return;
+    }
+    for (var c : concepts) {
+      if (c.getDesignation() != null) {
+        for (var d : c.getDesignation()) {
+          if (d.getValue() != null && d.getLanguage() == null) {
+            values.add(d.getValue());
+          }
+        }
+      }
+      collectNoLanguageDesignations(c.getConcept(), values);
+    }
   }
 
   /** code-system child→parent map ({@code system|code} → parent code) from the tx-resource CodeSystems' nested concept trees. */


### PR DESCRIPTION
Aligns inline `$expand` `contains`/`expansion` echoes with the tx-ecosystem (the `parameters` content layer after hierarchy #269).

## What

- **`expansion.property.uri`** — each declared property now carries its uri (from the tx-resource CodeSystem property definition; `http://hl7.org/fhir/concept-properties#<code>` fallback for built-ins like `definition`).
- **`property` not echoed** as an `expansion.parameter` (it selects which properties to surface, like `system-version` — not echoed; `includeDesignations`/`includeDefinition` still are).
- **`contains[].designation`**: a custom designation keeps its real **use system** as stated by the tx-resource CodeSystem (not a bare code); with **no explicit `designation` filter**, the entry that merely repeats the member display and the definition are dropped (surfaced via `contains.display` / a definition property); the import-defaulted **language** is dropped where the source designation states none. An explicit `designation=<lang>` filter returns exactly what was asked (the inline designation-filter IT still passes).

## Conformance

- `parameters` **11 → 17 / 35**, `validation` 17 → 18, overall **252 → 259 / 599 (43.2%)**
- No regressions; designation + property ITs pass.

Remaining `parameters`: supplement expand/lookup/validate (~9), enumerated-include nested-concept resolution (~4), and a couple of definition edges.