### PR TITLE
fix(fhir): tolerate malformed supporting tx-resources + graceful unknown-system in $validate-code

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -533,6 +533,17 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     String vsCanonical = inlineVs.getUrl() + (inlineVs.getVersion() != null ? "|" + inlineVs.getVersion() : "");
     Parameters resp = new Parameters();
     if (match == null) {
+      // Unknown code system: when the code's system has no resolvable definition at all — no member in the
+      // expansion, no tx-resource CodeSystem, not among the tx-resource concepts — the reference server degrades
+      // gracefully (a 200, not a 4xx) to a not-found issue at `system` + an `x-caused-by-unknown-system`, rather
+      // than the not-in-vs/invalid-code shape (which assumes the system is known and just lacks the code).
+      boolean systemHasMembers = system != null && Optional.ofNullable(expanded.getExpansion())
+          .map(com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion::getContains).orElse(List.of()).stream()
+          .anyMatch(c -> finalSystem.equals(c.getSystem()));
+      if (!req.findParameter("codeableConcept").isPresent() && system != null && !systemHasMembers
+          && txResourceCodeSystemVersions(req, system).isEmpty() && !txCsConcept(req, system, code).found()) {
+        return unknownSystem(code, system);
+      }
       // Code not in the value set: the tx-ecosystem expects a 200 with result=false, the code/system/version
       // echoed, and a structured `issues` OperationOutcome (not-in-vs at the value set + invalid-code at the
       // code system), not a flat message alone. Mirror the stored-content path's shape.
@@ -794,6 +805,29 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
    * UNKNOWN_CODESYSTEM_VERSION error (with the valid versions) plus the versionless-include mismatch warning.
    * Mirrors the FHIR tx ecosystem's "graceful degradation" — a 200, not a 4xx.
    */
+  /**
+   * Graceful degradation for an entirely unknown code system (no version qualifier): a 200 with result=false, a
+   * not-found issue at {@code system}, and {@code x-caused-by-unknown-system} carrying the system canonical — the
+   * code cannot be validated because the system has no definition. Mirrors org.hl7.fhir.core's unknown-system path.
+   */
+  private Parameters unknownSystem(String code, String system) {
+    String message = String.format("A definition for CodeSystem '%s' could not be found, so the code cannot be validated", system);
+    OperationOutcomeIssue notFound = new OperationOutcomeIssue()
+        .setSeverity("error").setCode("not-found")
+        .setDetails(new CodeableConcept(new Coding("http://hl7.org/fhir/tools/CodeSystem/tx-issue-type", "not-found")).setText(message))
+        .setLocation(List.of("system")).setExpression(List.of("system"));
+    OperationOutcome outcome = new OperationOutcome();
+    outcome.setIssue(List.of(notFound));
+    Parameters parameters = new Parameters();
+    parameters.addParameter(new ParametersParameter("code").setValueCode(code));
+    parameters.addParameter(new ParametersParameter("issues").setResource(outcome));
+    parameters.addParameter(new ParametersParameter("message").setValueString(message));
+    parameters.addParameter(new ParametersParameter("result").setValueBoolean(false));
+    parameters.addParameter(new ParametersParameter("system").setValueUri(system));
+    parameters.addParameter(new ParametersParameter("x-caused-by-unknown-system").setValueCanonical(system));
+    return parameters;
+  }
+
   private Parameters unknownSystemVersion(String code, String displayName, String system, String requestedVersion,
                                           List<String> availableVersions) {
     String availableVersion = availableVersions.stream().findFirst().orElse(null);

--- a/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
+++ b/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
@@ -74,14 +74,14 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
     if (StringUtils.isEmpty(parameters.getValue())) {
       return;
     }
-    validateProfile(parameters);
+    validateProfile(parameters, true);
   }
 
   @Override
   public void handle(ResourceId id, ResourceContent content, String interaction) {
     Resource resource = validateParse(content);
     validateType(id.getResourceType(), resource.getResourceType().name());
-    validateProfile(content);
+    validateProfile(content, false);
   }
 
   private Resource validateParse(ResourceContent content) {
@@ -98,7 +98,16 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
     }
   }
 
-  private void validateProfile(ResourceContent content) {
+  /**
+   * @param operationInput when true the content is an operation's {@code Parameters} input. A terminology operation is
+   *     handed supporting resources inside {@code parameter[].resource} (the {@code tx-resource} CodeSystems/ValueSets
+   *     on {@code $expand}/{@code $validate-code}) — these are DATA for the operation to process, not the invocation,
+   *     and the reference tx server tolerates malformed ones (the {@code errors} suite deliberately bundles a
+   *     {@code broken-filter} ValueSet whose {@code compose.include.filter} lacks the 1..1 {@code value}). Errors
+   *     located inside such a contained resource are dropped so they cannot 400 an otherwise-valid call; the operation
+   *     itself decides how to handle a broken supporting resource.
+   */
+  private void validateProfile(ResourceContent content, boolean operationInput) {
     if (hapiContextHolder.getHapiContext() == null) {
       throw new FhirServerException(500, "fhir context initialization error");
     }
@@ -107,6 +116,7 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
           .filter(m -> isError(m.getSeverity()))
           .filter(m -> !isUncheckedProfile(m))
           .filter(m -> !TOLERATED_BEST_PRACTICE_MESSAGE_IDS.contains(m.getMessageId()))
+          .filter(m -> !(operationInput && isInsideParameterResource(m.getLocationString())))
           .collect(toList());
       if (!errors.isEmpty()) {
         throw new FhirException(400, errors.stream().map(msg -> {
@@ -129,6 +139,14 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
   /** A declared profile TermX cannot resolve yields an "unchecked profile" message — tolerated, not fatal. */
   private static boolean isUncheckedProfile(SingleValidationMessage m) {
     return m.getMessage() != null && m.getMessage().contains(UNCHECKED_PROFILE);
+  }
+
+  // A supporting resource error carries a location like "Parameters.parameter[5].resource/*ValueSet/x*/.compose…".
+  private static final java.util.regex.Pattern PARAMETER_RESOURCE_LOCATION = java.util.regex.Pattern.compile("parameter\\[\\d+\\]\\.resource");
+
+  /** True when the validation message points inside a {@code parameter[].resource} (a supporting resource, not the envelope). */
+  private static boolean isInsideParameterResource(String location) {
+    return location != null && PARAMETER_RESOURCE_LOCATION.matcher(location).find();
   }
 
   private static boolean isError(ResultSeverityEnum level) {


### PR DESCRIPTION
## What
Two related fixes for the tx-ecosystem `errors` suite, verified end-to-end against the in-app conformance runner.

### 1. Operation input tolerates malformed supporting resources (`ProfileTolerantResourceValidator`)
The `txTests` runner bundles a suite's whole setup as `tx-resource` params on **every** request — including the `errors` suite's deliberately-malformed `broken-filter` ValueSet (a `compose.include.filter` with no `value`, which is `1..1` in R5). termx profile-validated the **entire** input `Parameters` and rejected unrelated requests with **400**. The reference tx server validates the operation envelope but tolerates malformed *supporting* resources — the operation decides how to handle them. We now drop profile-validation errors located inside a `parameter[].resource` on the **operation-input** path; the **save** path stays strict.

### 2. Graceful unknown-system in inline `$validate-code`
When the code's system has no resolvable definition (no expansion member, no tx-resource CodeSystem, not in tx-resource concepts), return the reference server's 200 unknown-system shape — a `not-found` issue at `system` + `x-caused-by-unknown-system` — instead of the not-in-vs/invalid-code shape.

## Result (in-app conformance, loadSetup)
**316 → 318 / 599**, **zero regressions**. Diff vs baseline: gained `errors/unknown-system1` and `other/validation-dual-filter-out`; the 400-unblock also moves `unknown-system2`/`combination`/`broken-filter` from hard-400 to operation-level (content gaps remain).

No kefhir change required — the fix lives in termx's `@Replaces` validator.