### PR TITLE
chore(deps): bump kefhir R5.10 → R5.11 (fhirest backports) + $expand ?fhir_vs fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.10
+kefhirVersion=R5.11
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -126,6 +126,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       if (pipe >= 0) {
         canonicalUrl = url.substring(0, pipe);
         pipeVersion = url.substring(pipe + 1);
+        // A query suffix (e.g. the LOINC/implicit `?fhir_vs`) sits after the pipe-version in
+        // `<canonical>|<version>?fhir_vs` — it is not part of the version. Strip it; the full
+        // `url` (query intact) still drives the implicit-ValueSet handling below.
+        int q = pipeVersion.indexOf('?');
+        if (q >= 0) {
+          pipeVersion = pipeVersion.substring(0, q);
+        }
       }
     }
     String versionNr = req.findParameter("valueSetVersion").map(ParametersParameter::getValueString).orElse(pipeVersion);


### PR DESCRIPTION
Bumps kefhir to **R5.11**, picking up the fhirest backports merged into kefhir (termx-health/kefhir#10, termx-health/kefhir#11): Coding token search, `_include` dedup, deleted-resource history, `Bundle.issues`, history `response.status`, base/system-level operations, and fhirpath search indexing.

Also fixes a pre-existing `$expand` url-parsing bug: a query suffix (e.g. LOINC `?fhir_vs`) on `<canonical>|<version>?fhir_vs` leaked into the parsed pipe-version; now stripped (the full url still drives implicit-ValueSet handling). Fixes the previously-failing `ValueSetExpandOperationTest` case.

termx test suite (terminology/core/app/snomed/ucum) passes against R5.11.