### PR TITLE
feat(fhir): error when useSupplement names a missing supplement

### DIFF
--- a/docs/fhir-tx-conformance-todo.md
+++ b/docs/fhir-tx-conformance-todo.md
@@ -118,15 +118,22 @@ Current per-suite gaps (pass/total): `version 144/206`, `permutations 23/56`, `v
 
 ---
 
-## P6 — CodeSystem **supplements** (`tx-resource`)
+## P6 — CodeSystem **supplements** (`useSupplement`)
 
-**Symptom:** `$expand`/`$lookup`/`$validate-code` `supplement-{good,bad,none}` — wrong params/contains; `supplement-bad` should `4xx`.
+NB the fixtures changed: the supplement is a **stored** CodeSystem (`content:"supplement"`, `supplements:<base>`), referenced by the **`useSupplement`** request param (canonical url). It is NOT sent inline as `tx-resource`, so it needs `loadSetup`. termx already has `ConceptSupplementService` (designation layering via `mergeSupplementsIntoExpansion` / `mergeRuntimeSupplements`) + `extractUseSupplement` in the operations.
+
 **Affected:** `parameters` (~9), `extensions` (~6). ~15 tests.
-**Root cause:** when a request carries a CodeSystem **supplement** (`content:"supplement"`, `supplements:<base>`) as `tx-resource`, its designations/properties must be layered onto the base concepts in the response; an unresolvable supplement reference (`supplement-bad`) must `4xx`. The inline path doesn't apply a request-scoped supplement.
-**Where:** `ValueSetExpandOperation.expandInline` (there is a `conceptSupplementService.mergeSupplementsIntoExpansion` already, but it merges **stored** supplements, not a `tx-resource` one), `CodeSystemLookupOperation`, `ValueSetValidateCodeOperation`.
-**HAPI:** `ValueSetExpander`/`CodeSystemProvider` apply any supplement whose `supplements` points at the system, adding its designations/properties; a `supplement` param naming a missing supplement → error.
-**Proposal:** detect `tx-resource` CodeSystems with `content=supplement` whose `supplements` matches an expanded system, and merge their `concept.designation`/`concept.property` onto the matching members in `expandInline`/`$lookup`. For `supplement-bad`, when a `supplement` request param names a supplement not supplied/stored → `4xx not-found`.
-**❓Question:** scope — apply request-`tx-resource` supplements only in the **inline** path (conformance + ad-hoc), or also persist/honour them in the stored path? And should a supplement supplied as `tx-resource` be merged automatically (HAPI does), or only when a `supplement`/`includeSupplements`-style param requests it?
+
+### P6a — `supplement-bad` → not-found error — **DONE (2026-06-20, PR #288)**
+A `useSupplement` naming a supplement the server does not host was silently ignored (200, as if no supplement). Now `ConceptSupplementService.resolveSupplements` throws a 404 `OperationOutcome` (`TxIssues.notFoundException`, `not-found` tx-issue-type, text `"Required supplement not found: <url>"` — tx-ecosystem `VALUESET_SUPPLEMENT_MISSING`) when the url resolves to no CodeSystem. Shared path → covers expand/lookup/validate-code/coding/codeableconcept bad variants. `SupplementMissingIT` green. (A supplement that exists but targets a different base = no-op, not error.)
+
+### P6b — `supplement-good`/`none` — REMAINING (empirically scoped 2026-06-20, `SupplementMissingIT` setup + diagnostic)
+Three independent gaps, in increasing cost:
+1. **`used-supplement` echo (small).** Today the expand echoes the raw request param `useSupplement=<url>`; expected is **no** `useSupplement` echo + a derived `used-supplement=<url>|<resolvedVersion>` expansion param (e.g. `…/supplement|0.1.1`). Fix: add `useSupplement` to `EXPANSION_SELECTION_PARAMETERS` (suppress echo) and have `mergeSupplementsIntoExpansion` return the resolved `(url, version)` so the operation/mapper emits `used-supplement`. `$lookup` good wants the same `used-supplement` param. **Self-contained; do next.**
+2. **Supplement designation `source` part + display (medium).** `$lookup`/`$validate` good expect the supplement-contributed designation (`nl "ectenoot"`) rendered with a `source` part = `<supplement>|<version>`, alongside base designations. termx layers the designation value already (marks `supplement=true`) but doesn't emit the `source` canonical part in the `$lookup` `parameter[].part` shape. Lives in `CodeSystemLookupOperation` designation assembly.
+3. **Supplement property layering + extensions→property machinery (large, partly OUT of P6).** `parameters-expand-supplement-good` expects `code5.property` = `label`,`order`,`prop1`,`status`. Only `prop1` is the supplement's (`prop1=value1`); **`label`/`order`/`weight` come from FHIR concept *extensions* on the base `extensions` CS** (`codesystem-label`, `codesystem-conceptOrder`, `itemWeight`) — a separate "map standard FHIR extensions to expansion properties" feature that the whole `extensions` suite needs, not supplement-specific. termx currently surfaces **no** properties on `extensions`-CS members (`code5.props=[]`), so the expand-good case is **blocked behind that extensions feature** regardless of supplement work. The supplement-specific slice is: also collect the supplement concepts' `propertyValues` in `mergeSupplementsIntoExpansion` (currently designations only) and merge onto members.
+
+**Order to ship:** P6b.1 (used-supplement echo) → P6b.2 (lookup designation source) → these likely flip the `lookup`/`validate` good cases. The `expand`-good cases need the extensions→property feature first (track separately).
 
 ---
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
@@ -208,7 +208,14 @@ public class ConceptSupplementService {
     Map<String, List<ResolvedSupplement>> result = new LinkedHashMap<>();
     parseRequestedSupplements(params.getUseSupplement()).forEach(requested -> {
       CodeSystem supplement = codeSystemRepository.query(new CodeSystemQueryParams().setUri(requested.uri()).limit(1)).findFirst().orElse(null);
-      if (supplement == null || StringUtils.isBlank(supplement.getBaseCodeSystem()) || !baseCodeSystems.contains(supplement.getBaseCodeSystem())) {
+      // A `useSupplement` that names a supplement the server does not host is a hard error (tx-ecosystem
+      // VALUESET_SUPPLEMENT_MISSING) — a not-found OperationOutcome, NOT a silent no-op. A supplement that
+      // exists but targets a different base code system than any being expanded is simply not applicable
+      // here, so it is skipped (not every requested supplement applies to every system in the request).
+      if (supplement == null) {
+        throw org.termx.terminology.fhir.TxIssues.notFoundException(404, "Required supplement not found: " + requested.uri());
+      }
+      if (StringUtils.isBlank(supplement.getBaseCodeSystem()) || !baseCodeSystems.contains(supplement.getBaseCodeSystem())) {
         return;
       }
       resolveSupplementVersion(supplement.getId(), requested.version())

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/SupplementMissingIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/SupplementMissingIT.groovy
@@ -1,0 +1,68 @@
+package org.termx.terminology.fhir
+
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.Resource
+import com.kodality.zmei.fhir.resource.other.Parameters
+import groovy.util.logging.Slf4j
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.valueset.ValueSetFhirImportService
+import org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation
+
+/**
+ * tx-ecosystem supplement-bad (P6): a `useSupplement` that names a supplement the server does not host
+ * must fail with a not-found OperationOutcome ("Required supplement not found: <url>"), not silently
+ * succeed. Mirrors `parameters-expand-supplement-bad`.
+ */
+@Slf4j
+@MicronautTest(transactional = true)
+class SupplementMissingIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject ValueSetFhirImportService vsImportService
+  @Inject ValueSetExpandOperation vsExpand
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importResource("extensions/codesystem-extensions.json")
+    importResource("extensions/codesystem-supplement.json")
+    importResource("extensions/valueset-extensions-all-ns.json")
+  }
+
+  def "expand-supplement-bad: unresolvable useSupplement is a not-found error, not a silent 200"() {
+    given:
+    def request = toFhir("parameters/parameters-expand-supplement-bad-request.json", Parameters.class)
+
+    when:
+    vsExpand.run(request)
+
+    then:
+    def ex = thrown(com.kodality.kefhir.core.exception.FhirException)
+    ex.getStatusCode() == 404
+    ex.getIssues().any { it.getDetails()?.getText() == "Required supplement not found: http://hl7.org/fhir/test/CodeSystem/supplement-X" }
+    // not-found tx-issue-type detail coding, per tx-ecosystem VALUESET_SUPPLEMENT_MISSING
+    ex.getIssues().any { it.getDetails()?.getCoding()?.any { c -> c.code == "not-found" } }
+  }
+
+  def importResource(String path) {
+    def resource = toFhir(path, Resource.class)
+    if (resource.resourceType == "CodeSystem") {
+      csImportService.importCodeSystem(FhirMapper.toJson(resource), resource.id)
+    }
+    if (resource.resourceType == "ValueSet") {
+      vsImportService.importValueSet(FhirMapper.toJson(resource), resource.id)
+    }
+  }
+
+  def <T extends Resource> T toFhir(String path, Class<T> clazz) {
+    def json = new String(getClass().getClassLoader().getResourceAsStream("fhir/" + path).readAllBytes())
+    json = json.replace("﻿", "")
+    json = json.replace("\$" + "instant" + "\$", "")
+    return FhirMapper.fromJson(json, clazz)
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/extensions/valueset-extensions-all-ns.json
+++ b/termx-integtest/src/test/resources/fhir/extensions/valueset-extensions-all-ns.json
@@ -1,0 +1,21 @@
+{
+  "resourceType" : "ValueSet",
+  "id" : "extensions-all-ns",
+  "url" : "http://hl7.org/fhir/test/ValueSet/extensions-all-ns",
+  "version" : "5.0.0",
+  "name" : "ExtensionsValueSetAllNS",
+  "title" : "Extensions ValueSet All No Supp",
+  "status" : "active",
+  "experimental" : false,
+  "date" : "2023-04-01",
+  "publisher" : "FHIR Project",
+  "compose" : {
+    "include" : [{
+      "system" : "http://hl7.org/fhir/test/CodeSystem/extensions",
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/test/StructureDefinition/unknown-extension-1",
+        "valueString" : "unknown extensions are ignored"
+      }]
+    }]
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/parameters/parameters-expand-supplement-bad-request.json
+++ b/termx-integtest/src/test/resources/fhir/parameters/parameters-expand-supplement-bad-request.json
@@ -1,0 +1,16 @@
+{
+  "resourceType" : "Parameters",
+  "parameter" : [{
+    "name" : "url",
+    "valueUri" : "http://hl7.org/fhir/test/ValueSet/extensions-all-ns"
+  },{
+    "name" : "excludeNested",
+    "valueBoolean" : true
+  },{
+    "name" : "useSupplement",
+    "valueCanonical" : "http://hl7.org/fhir/test/CodeSystem/supplement-X"
+  },{
+    "name" : "property",
+    "valueString" : "prop1"
+  }]
+}


### PR DESCRIPTION
## What

tx-ecosystem `supplement-bad` cases (P6): a `useSupplement` parameter that references a CodeSystem supplement the server does not host must fail with a not-found `OperationOutcome`, not silently succeed. Today termx ignores the unresolvable supplement and returns a normal 200.

## Change

`ConceptSupplementService.resolveSupplements` now throws when a requested `useSupplement` url resolves to no CodeSystem:

```
404 OperationOutcome
  severity: error
  code: not-found
  details.coding: http://hl7.org/fhir/tools/CodeSystem/tx-issue-type # not-found
  details.text: "Required supplement not found: <url>"
```

(via the existing `TxIssues.notFoundException`, matching the tx-ecosystem `VALUESET_SUPPLEMENT_MISSING` shape).

A supplement that *exists* but targets a different base code system than any being expanded remains a no-op (not applicable to this request ≠ missing).

Because resolution is shared, this covers the `$expand`, `$lookup`, `$validate-code`, `$validate-code` (coding) and `$validate-code` (codeableConcept) bad-supplement variants in one place.

## Test

`SupplementMissingIT` (testcontainers) imports the extensions CS + supplement CS + VS and asserts that the `parameters-expand-supplement-bad` request throws a 404 FhirException with the exact text and `not-found` detail coding.

## Note

This is the first slice of P6 (supplements). The `good`/`none` cases (layering the supplement's `prop1` property onto members + echoing the resolved `used-supplement` expansion parameter) are a follow-up.