### PR TITLE
feat(fhir): $lookup renders supplement designations with a source part

### DIFF
--- a/docs/fhir-tx-conformance-todo.md
+++ b/docs/fhir-tx-conformance-todo.md
@@ -209,15 +209,35 @@ Three independent gaps, in increasing cost:
 
 ---
 
-## Suggested order (by tests-per-effort, once you've answered)
+## Dependency analysis (2026-06-20) — what blocks what
 
-1. **P1+P2** (display-language) — unblocks ~25 + the display half of `version`/`validation`.
-2. **P5a** (activeOnly + inactive flag) — ~12, Java-only.
-3. **P3** (codeableConcept shapes) — ~15.
-4. **P7** (enum nested) + **P8** (VS-import) — ~10, also unblock P3 `import` cases.
-5. **P6** (supplements) + **P10** (lookup) — ~20.
-6. **P9** (HTTP codes) — ~25, in a/b/c order you pick.
-7. **P4** (version tail) — re-measure; likely mostly free after P1–P3.
-8. **P11/P12** — mop-up.
+Done so far: **P5a, P11-partial, P9a, P7 (enum abstract), P6a (bad-supplement 404), P6b.1 (used-supplement echo), P6b.2 (lookup source)**.
 
-Rough ceiling if all land: ~303 → ~470–500/599. The hard cap is the cases that genuinely need a behaviour decision (the ❓ questions) — that's why they're called out per problem.
+**Hard prerequisites (B cannot pass until A lands):**
+- **P1 (display-language) → P2, the `display` half of P7 enum-designations/definitions, the display half of `validation`, and much of P4.** Display resolution is the single biggest upstream dependency: dozens of expand/validate cases assert the echoed `display`/designations. Until display is right, those fail regardless of any other fix. P1 is the **#1 unblock** — and it is gated on your a/b/c strategy pick (still unanswered).
+- **extensions→property machinery → P6b.3 (expand-supplement-good content) AND the whole `extensions` suite.** Mapping FHIR concept extensions (`codesystem-label`, `conceptOrder`, `itemWeight`) to expansion properties is a *separate feature*; expand-good can't match until it exists. NOT supplement work.
+- **stored `used-codesystem` version-strip (versionless CS) → expand content matches across `extensions` + any versionless-CS suite.** Small, broad. The inline path already strips it; the stored path lost the "no source version" signal.
+- **P8 (VS-import inline) + P7 → P3 `import` codeableConcept cases.** Membership of an imported VS must resolve before the import-validate shapes can match.
+- **P6 supplement work → P10 (`$lookup` part shape).** Several lookup `part`-count failures are supplement-driven; **P6b.2 already did the supplement half**. P10's remaining non-supplement `part`/property-value-type shape can follow.
+
+**Cross-cutting (one fix lands rows in several suites):**
+- **P6a (bad-supplement 404) already covers the "bad supplement reference" rows inside P9** (`extensions ~4`, `validation ~3`). So P9's 4xx cluster is partly done.
+- Display (P1) and the validate-issue machinery (P2/P5/P11) share code → high regression surface; change with broad re-runs.
+
+**Independent / parallelizable (no blockers):** P9b (expand size guard), P9c (`$batch`/`$translate`), P11 remainder (deprecated/withdrawn), P5b, P12 one-offs.
+
+**Re-measure checkpoints (avoid wasted effort):**
+- **After P1 lands, re-run before touching P4.** "P4 version tail (~62)" is *mostly display/shape side-effects* — many resolve for free once P1–P3 are in. Hand-fixing P4 first burns effort on tests that fix themselves.
+- A fresh full run is also overdue now (P7/P6a/b.1/b.2 merged but unmeasured).
+
+**Recommended sequence:**
+1. **Re-measure** (confirm the merged delta; baseline is stale at 318).
+2. **P1 (display-language)** — pick a/b/c; biggest unblock, gates P2 + enum/validation/version display.
+3. **P2** (validate display) — falls out of P1's machinery.
+4. **extensions→property** + **stored used-codesystem version-strip** — unblocks the `extensions` suite + P6b.3.
+5. **P8 (VS-import)** → then **P3 import** cases.
+6. **P10** (lookup non-supplement part shape) — supplement half already done.
+7. **P9b/P9c**, **P11 remainder**, **P12** — independent mop-up, parallelizable.
+8. **Re-measure, then P4** version tail — likely mostly free.
+
+Rough ceiling unchanged (~470–500/599). The gating constraint is still the ❓ behaviour decisions (chiefly the **P1 a/b/c pick**).

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
@@ -164,11 +164,28 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
     designations.stream()
         .filter(d -> d != display && d != definition)
         .filter(d -> languageMatches(d.getLanguage(), displayLanguage))
-        .forEach(d -> resp.addParameter(new ParametersParameter("designation")
-            .addPart(new ParametersParameter("use").setValueCoding(
-                org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(d.getDesignationType())))
-            .addPart(new ParametersParameter("value").setValueString(d.getName()))
-            .addPart(new ParametersParameter("language").setValueString(d.getLanguage()))));
+        .forEach(d -> {
+          ParametersParameter designation = new ParametersParameter("designation")
+              .addPart(new ParametersParameter("language").setValueString(d.getLanguage()));
+          // A supplement-contributed designation carries a `source` part (the supplement's canonical
+          // url|version) instead of a `use` coding — it identifies which supplement defined it.
+          if (StringUtils.isNotBlank(d.getSupplementSource())) {
+            designation.addPart(new ParametersParameter("source").setValueCanonical(d.getSupplementSource()));
+          } else {
+            designation.addPart(new ParametersParameter("use").setValueCoding(
+                org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.designationUseCoding(d.getDesignationType())));
+          }
+          designation.addPart(new ParametersParameter("value").setValueString(d.getName()));
+          resp.addParameter(designation);
+        });
+
+    // Report the supplements that actually contributed designations as `used-supplement` parameters
+    // (resolved canonical url|version), matching the tx-ecosystem $lookup-with-useSupplement shape.
+    designations.stream()
+        .map(Designation::getSupplementSource)
+        .filter(StringUtils::isNotBlank)
+        .distinct()
+        .forEach(src -> resp.addParameter(new ParametersParameter().setName("used-supplement").setValueCanonical(src)));
 
     Map<String, String> propertyDescriptions = cs == null || cs.getProperties() == null ? Map.of() :
         cs.getProperties().stream().filter(p -> p.getName() != null && p.getDescription() != null && !p.getDescription().isEmpty())

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
@@ -163,9 +163,10 @@ public class ConceptSupplementService {
     supplements.forEach(supplement -> loadSupplementConcepts(supplement.id(), baseCodeSystem, codes, supplement.version(), params).forEach(concept -> {
       // Include ALL supplement designations regardless of displayLanguage (it only selects the display) —
       // see mergeSupplementsIntoExpansion.
+      String source = new UsedSupplement(supplement.url(), supplement.version()).asCanonical();
       List<Designation> designations = concept.getVersions() == null ? List.of() : concept.getVersions().stream()
           .flatMap(v -> Optional.ofNullable(v.getDesignations()).orElse(List.of()).stream())
-          .map(d -> d.setSupplement(true))
+          .map(d -> d.setSupplement(true).setSupplementSource(source))
           .toList();
       if (CollectionUtils.isNotEmpty(designations)) {
         supplementDesignations.computeIfAbsent(concept.getCode(), key -> new ArrayList<>()).addAll(designations);

--- a/termx-api/src/main/java/org/termx/ts/codesystem/Designation.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/Designation.java
@@ -25,4 +25,7 @@ public class Designation {
   private String designationType;
 
   private boolean supplement;
+  // Transient (not persisted): for a supplement-contributed designation, the supplement's canonical
+  // `<url>|<version>` — emitted as the `$lookup` designation `source` part. Set at merge time.
+  private String supplementSource;
 }

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/LookupSupplementSourceIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/LookupSupplementSourceIT.groovy
@@ -1,0 +1,69 @@
+package org.termx.terminology.fhir
+
+import com.kodality.kefhir.structure.api.ResourceContent
+import com.kodality.zmei.fhir.FhirMapper
+import com.kodality.zmei.fhir.resource.Resource
+import com.kodality.zmei.fhir.resource.other.Parameters
+import groovy.util.logging.Slf4j
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.fhir.codesystem.operations.CodeSystemLookupOperation
+
+/**
+ * tx-ecosystem lookup-supplement-good (P6b.2): a $lookup with useSupplement layers the supplement's
+ * designation (nl "ectenoot") rendered with a `source` part = <supplement>|<version>, and reports the
+ * applied supplement as a `used-supplement` parameter. Mirrors `parameters-lookup-supplement-good`.
+ */
+@Slf4j
+@MicronautTest(transactional = true)
+class LookupSupplementSourceIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImportService
+  @Inject CodeSystemLookupOperation lookup
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importResource("extensions/codesystem-extensions.json")
+    importResource("extensions/codesystem-supplement.json")
+  }
+
+  def "lookup useSupplement: nl designation carries source part + used-supplement param"() {
+    given:
+    def reqJson = readJson("parameters/parameters-lookup-supplement-good-request.json")
+
+    when:
+    def respContent = lookup.run(new ResourceContent(reqJson, "json"))
+    Parameters resp = FhirMapper.fromJson(respContent.getValue(), Parameters.class)
+    def designations = resp.getParameter().findAll { it.name == "designation" }
+    def nl = designations.find { dg -> dg.part.any { it.name == "language" && it.valueString == "nl" } }
+    def nlSource = nl?.part?.find { it.name == "source" }?.valueCanonical
+    def nlValue = nl?.part?.find { it.name == "value" }?.valueString
+    def nlHasUse = nl?.part?.any { it.name == "use" }
+    def usedSupplement = resp.getParameter().find { it.name == "used-supplement" }?.valueCanonical
+
+    then:
+    log.info("LOOKUP-SUPP nlValue={} nlSource={} nlHasUse={} usedSupplement={}", nlValue, nlSource, nlHasUse, usedSupplement)
+    nlValue == "ectenoot"
+    nlSource == "http://hl7.org/fhir/test/CodeSystem/supplement|0.1.1"
+    !nlHasUse
+    usedSupplement == "http://hl7.org/fhir/test/CodeSystem/supplement|0.1.1"
+  }
+
+  def importResource(String path) {
+    def json = readJson(path)
+    def res = FhirMapper.fromJson(json, Resource.class)
+    if (res.resourceType == "CodeSystem") {
+      csImportService.importCodeSystem(json, res.id)
+    }
+  }
+
+  def readJson(String path) {
+    def json = new String(getClass().getClassLoader().getResourceAsStream("fhir/" + path).readAllBytes())
+    return json.replace("﻿", "").replace("\$" + "instant" + "\$", "")
+  }
+}

--- a/termx-integtest/src/test/resources/fhir/parameters/parameters-lookup-supplement-good-request.json
+++ b/termx-integtest/src/test/resources/fhir/parameters/parameters-lookup-supplement-good-request.json
@@ -1,0 +1,13 @@
+{
+  "resourceType" : "Parameters",
+  "parameter" : [{
+    "name" : "system",
+    "valueUri" : "http://hl7.org/fhir/test/CodeSystem/extensions"
+  },{
+    "name" : "code",
+    "valueCode" : "code1"
+  },{
+    "name" : "useSupplement",
+    "valueCanonical" : "http://hl7.org/fhir/test/CodeSystem/supplement"
+  }]
+}


### PR DESCRIPTION
## What

P6b.2 — the tx-ecosystem `lookup-supplement-good` case. A `$lookup` with `useSupplement` layers the supplement's designation onto the base concept, but termx rendered it like any base designation (a `use` coding, no provenance) and never reported the supplement. The reference engine expects:

- each supplement-contributed designation to carry a `source` part = the supplement's canonical `url|version` (instead of a `use`)
- a `used-supplement` parameter on the response

## Change

- `Designation` gains a transient `supplementSource` (`<url>|<version>`), set in `ConceptSupplementService` when a designation is marked `supplement=true`.
- `CodeSystemLookupOperation` emits a `source` part for supplement designations (and omits `use`), plus one `used-supplement` parameter per applied supplement.

## Test

`LookupSupplementSourceIT` asserts the `nl "ectenoot"` designation carries `source = …/supplement|0.1.1` with no `use`, and the response has `used-supplement = …/supplement|0.1.1`. Regression-checked against `CodeSystemLookupSupplementIT`, the UCUM lookup test, and the supplement expand/missing ITs — all green.