### PR TITLE
fix(fhir): 404 when validate-code names an unresolvable value set

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -135,7 +135,10 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       if (version != null) {
         throw valueSetNotResolvable(url, version);
       }
-      return error("valueset version not found");
+      // An unresolvable value set canonical (not inline, not stored) is a hard 404 not-found per the
+      // tx-ecosystem, not a 200 with result=false.
+      throw org.termx.terminology.fhir.TxIssues.notFoundException(404,
+          String.format("A definition for the value Set '%s' could not be found", url));
     }
     return run(vsVersion, req);
   }


### PR DESCRIPTION
## What

`$validate-code` with a `url` that resolves to **neither** an inline `tx-resource` **nor** stored content (and no `valueSetVersion` pinned) was returning a 200 with a `"valueset version not found"` message. The tx-ecosystem expects a hard **404 not-found** `OperationOutcome` — the same shape termx already produces for an unresolvable *pinned* `valueSetVersion`.

## Impact

tx-ecosystem conformance: **371 → 374 / 599**, no regressions. Flips `validation/validation-simple-{code,coding,codeableconcept}-bad-valueSet`.

## Scope

One line in `ValueSetValidateCodeOperation.run` — replaces the 200 `error(...)` fall-through with `TxIssues.notFoundException(404, …)`.