### PR TITLE
fix(fhir): reject a value set with a valueless compose filter (vs-invalid)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -74,6 +74,27 @@ public final class TxIssues {
     return new com.kodality.kefhir.core.exception.FhirException(status, issue);
   }
 
+  /**
+   * A structurally-invalid value set: an {@code invalid}-code OperationOutcome issue with the
+   * {@code tx-issue-type}/{@code vs-invalid} detail coding (tx-ecosystem {@code VS_INVALID}), carrying the
+   * offending element's location/expression. Used when the value set being operated on cannot be processed —
+   * e.g. a {@code compose.include.filter} missing its {@code value} (1..1 in R5).
+   */
+  public static com.kodality.kefhir.core.exception.FhirException vsInvalidException(int status, String text, String location) {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.INVALID);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept()
+        .addCoding(new org.hl7.fhir.r5.model.Coding(TX_ISSUE_TYPE, "vs-invalid", null))
+        .setText(text));
+    if (location != null) {
+      issue.addLocation(location);
+      issue.addExpression(location);
+    }
+    return new com.kodality.kefhir.core.exception.FhirException(status, issue);
+  }
+
   /** Formats a version list as the tx-ecosystem does: comma-separated with " or " before the last ("a, b or c"). */
   public static String presentVersionList(java.util.List<String> versions) {
     if (versions == null || versions.isEmpty()) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -698,6 +698,41 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   }
 
   /**
+   * Rejects a value set that cannot be processed because a {@code compose.include}/{@code exclude} filter is
+   * missing its {@code value} (1..1 in R5) — a 4xx {@code vs-invalid} carrying the offending filter's location,
+   * the way org.hl7.fhir.core does (tx-ecosystem {@code errors/broken-filter}). Only the operation target is
+   * checked; a malformed bundled tx-resource is tolerated on the input path.
+   */
+  private void requireValidFilters(com.kodality.zmei.fhir.resource.terminology.ValueSet vs) {
+    if (vs == null || vs.getCompose() == null) {
+      return;
+    }
+    requireValidFilters(vs.getCompose().getInclude(), "include");
+    requireValidFilters(vs.getCompose().getExclude(), "exclude");
+  }
+
+  private void requireValidFilters(
+      List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude> includes, String kind) {
+    if (includes == null) {
+      return;
+    }
+    for (int i = 0; i < includes.size(); i++) {
+      var inc = includes.get(i);
+      if (inc.getFilter() == null) {
+        continue;
+      }
+      for (int j = 0; j < inc.getFilter().size(); j++) {
+        var f = inc.getFilter().get(j);
+        if (StringUtils.isEmpty(f.getValue())) {
+          throw org.termx.terminology.fhir.TxIssues.vsInvalidException(400,
+              String.format("The system %s filter with property = %s, op = %s has no value", inc.getSystem(), f.getProperty(), f.getOp()),
+              String.format("ValueSet.compose.%s[%d].filter[%d]", kind, i, j));
+        }
+      }
+    }
+  }
+
+  /**
    * A value set that declares a REQUIRED supplement via the {@code valueset-supplement} extension must have it
    * resolvable — a bundled tx-resource CodeSystem or a stored one with that canonical url. An unresolvable
    * required supplement is a 404 not-found (tx-ecosystem {@code extensions} bad-supplement cases).
@@ -775,6 +810,11 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // to a concrete available version so the SQL expand picks the right code system version — driving
     // expansion.total and the used-codesystem parameter. A pinned version that resolves to nothing, or a
     // check-system-version mismatch, is a 4xx (the expansion can't be produced).
+    // The value set being operated on must be structurally valid: a compose filter is missing its `value`
+    // (1..1 in R5) cannot be processed — reject with a 4xx vs-invalid, the way the reference engine does
+    // (errors/broken-filter). This is the OPERATION TARGET only; a malformed *supporting* tx-resource is
+    // tolerated on the input path (see ProfileTolerantResourceValidator / #283).
+    requireValidFilters(inlineVs);
     // A value set that REQUIRES a supplement (valueset-supplement extension) must have it resolvable, else 4xx.
     requireDeclaredSupplements(inlineVs, req);
 


### PR DESCRIPTION
## What

A `compose.include`/`exclude` filter that is missing its `value` (1..1 in R5) makes the value set un-processable. `$expand` and `$validate-code` now reject the **operation target** with a **4xx `vs-invalid`** OperationOutcome — *"The system X filter with property = P, op = O has no value"*, located at the offending `ValueSet.compose.include[i].filter[j]` — the way `org.hl7.fhir.core` does, instead of silently expanding to nothing and returning 200.

## Scope / safety

- **Operation target only.** A malformed *supporting* tx-resource bundled with the request stays tolerated on the input path (`ProfileTolerantResourceValidator`, #283). The `errors` suite bundles the `broken-filter` VS on every request, so this distinction is what keeps the other `errors` tests green.
- **One check point.** The check lives in `expandInline`, which `$validate-code` also drives internally, so both operations are covered by a single guard placed before any expansion work.

## Result

tx-ecosystem conformance **386 → 389 / 599**, flipping exactly:

- `errors/broken-filter-expand`
- `errors/broken-filter-validate`
- `errors/broken-filter2-validate`

**Zero regressions** — verified by a full test-level pass/fail diff of the TestReport before/after.