### PR TITLE
fix(fhir): order multi-version overload expansion by code then version desc

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -1106,6 +1106,28 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // An enumerated value set (explicit compose.include.concept list) is a flat selection, not a view of the
     // code system hierarchy — it is never nested, even with excludeNested=false.
     boolean enumerated = !expandedConcepts.isEmpty() && expandedConcepts.stream().allMatch(ValueSetVersionConcept::isEnumerated);
+    // Multi-version "overload": when a code system is included at more than one version, the reference engine
+    // orders the expansion by code ascending then version descending (code1@2.0.0, code1@1.0.0, code2@2.0.0, …),
+    // not by include order. Scope this narrowly — only a NON-enumerated expansion that actually spans more than
+    // one version — so an enumerated value set keeps its definition order and a single-version expansion (the
+    // overwhelming majority) is untouched.
+    long distinctVersions = contains.stream()
+        .map(com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains::getVersion)
+        .filter(java.util.Objects::nonNull).distinct().count();
+    if (!enumerated && distinctVersions > 1) {
+      List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains> ordered = new java.util.ArrayList<>(contains);
+      ordered.sort((a, b) -> {
+        int byCode = java.util.Comparator.nullsLast(String::compareTo).compare(a.getCode(), b.getCode());
+        if (byCode != 0) {
+          return byCode;
+        }
+        if (a.getVersion() == null || b.getVersion() == null) {
+          return java.util.Comparator.nullsLast(String::compareTo).compare(b.getVersion(), a.getVersion());
+        }
+        return compareVersions(b.getVersion(), a.getVersion()); // version descending within a code
+      });
+      contains = ordered;
+    }
     boolean nestHierarchy = !enumerated && req != null && req.findParameter("excludeNested").isPresent()
         && req.findParameter("excludeNested")
             .map(p -> !(Boolean.TRUE.equals(p.getValueBoolean()) || "true".equals(p.getValueString()))).orElse(false);


### PR DESCRIPTION
## What

When a code system is included at more than one **explicit** version, the reference engine orders the expansion **by code ascending then version descending** (`code1@2.0.0, code1@1.0.0, code2@2.0.0, …`), not by include order. termx's inline expand kept the SQL/include order, so each member's `version` landed at the wrong index (the `overload` suite's `contains[i].version` diffs).

## Scope / safety

The reorder is gated narrowly — applied **only** to a **non-enumerated** expansion that **actually spans more than one version**:

- An **enumerated** value set keeps its definition order (HAPI preserves it; re-sorting would regress those).
- A **single-version** expansion (the overwhelming majority) is untouched — no member has a sibling at another version, so the gate is false.

## Result

tx-ecosystem conformance **389 → 392 / 599**, flipping:

- `overload/expand-all`
- `overload/expand-all-versioned`
- `overload/expand-all-sysver`

**Zero regressions** — verified by a full test-level pass/fail diff of the TestReport before/after.

`overload/expand-mixed` is intentionally left: its second include is *versionless* (resolves to the latest), and HAPI orders that case version-*ascending* — a different implementation artifact not worth special-casing.