### PR TITLE
fix(fhir): cannot-infer when inferSystem code is ambiguous across systems

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -661,6 +661,32 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         .findFirst().orElse(null);
 
     String vsCanonical = inlineVs.getUrl() + (inlineVs.getVersion() != null ? "|" + inlineVs.getVersion() : "");
+    // inferSystem with no system supplied: the code's system is inferred from the value set's expansion. If the
+    // code appears under MORE THAN ONE code system, the system is ambiguous — the reference engine returns
+    // result=false with a `cannot-infer` error (plus the standard not-in-vs), naming the candidate systems,
+    // rather than silently picking one. A unique match keeps the normal success path (the `implied` cases).
+    boolean inferSystem = req.findParameter("inferSystem")
+        .map(p -> Boolean.TRUE.equals(p.getValueBoolean()) || "true".equals(p.getValueString())).orElse(false);
+    if (inferSystem && system == null) {
+      java.util.List<String> matchSystems = Optional.ofNullable(expanded.getExpansion())
+          .map(com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansion::getContains).orElse(List.of()).stream()
+          .filter(c -> finalCode.equals(c.getCode())).map(c -> c.getSystem())
+          .filter(java.util.Objects::nonNull).distinct().sorted().toList();
+      if (matchSystems.size() > 1) {
+        String notInVs = String.format("The provided code '#%s' was not found in the value set '%s'", code, vsCanonical);
+        String cannotInfer = String.format(
+            "The System URI could not be determined for the code '%s' in the ValueSet '%s': value set expansion has multiple matches: [%s]",
+            code, vsCanonical, String.join(", ", matchSystems));
+        Parameters ambiguous = new Parameters();
+        ambiguous.addParameter(new ParametersParameter("code").setValueCode(code));
+        ambiguous.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+            org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "not-in-vs", notInVs, "code"),
+            org.termx.terminology.fhir.TxIssues.issue("error", "not-found", "cannot-infer", cannotInfer, "code"))));
+        ambiguous.addParameter(new ParametersParameter("message").setValueString(cannotInfer + "; " + notInVs));
+        ambiguous.addParameter(new ParametersParameter("result").setValueBoolean(false));
+        return ambiguous;
+      }
+    }
     Parameters resp = new Parameters();
     if (match == null) {
       // Unknown code system: when the code's system has no resolvable definition at all — no member in the


### PR DESCRIPTION
## What

With `inferSystem` set and no `system` supplied, `$validate-code` infers the code's system from the value set's expansion. When the code appears under **more than one** code system the system is **ambiguous** — the reference engine returns `result=false` with a `not-found`/`cannot-infer` error naming the candidate systems (alongside the standard `not-in-vs`), rather than silently picking one. termx took the first match and reported `result=true`.

## Scope

Gated narrowly: `inferSystem` set, **no** `system` given, **and** the code resolves to >1 distinct system in the expansion. A unique inferred match keeps the normal success path (the `validation` `implied-good`/`implied-bad-code` cases, which already pass, are unaffected).

## Result

tx-ecosystem conformance **393 → 394 / 599**, flipping **`errors/combination-bad`**, **zero regressions** (full TestReport diff vs the post-#303 baseline).

Builds on #303 (which made the `combination` value set's `simple1`/`simple2` members resolvable in the first place).