### PR TITLE
fix(fhir): $expand filter-as-uri + used-codesystem on empty expansions

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -455,18 +455,26 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
 
     return param.getParameter().stream()
         .filter(p -> !EXPANSION_SELECTION_PARAMETERS.contains(p.getName()))
-        .map(p -> new ValueSetExpansionParameter().setName(p.getName())
-        .setValueString(p.getValueString())
-        .setValueBoolean(p.getValueBoolean())
-        .setValueInteger(p.getValueInteger())
-        .setValueDecimal(p.getValueDecimal())
-        // expansion.parameter.value is a uri (not url/canonical), so fold those in — otherwise a
-        // request param like `url` carried as valueUrl/valueCanonical produced an expansion.parameter
-        // with a name but no value, which is invalid FHIR and crashes strict clients (e.g. the validator).
-        .setValueUri(p.getValueUri() != null ? p.getValueUri() : p.getValueUrl() != null ? p.getValueUrl() : p.getValueCanonical())
-        .setValueCode(p.getValueCode())
-        .setValueDateTime(p.getValueDateTime())
-    ).filter(ValueSetFhirMapper::hasValue).toList();
+        .map(p -> {
+          // The $expand `filter` parameter is a string (the text to match); a request that supplied it as a
+          // uri/code is echoed back as a string, the way the reference engine does (the `search` cases).
+          if ("filter".equals(p.getName())) {
+            String filterValue = p.getValueString() != null ? p.getValueString()
+                : p.getValueUri() != null ? p.getValueUri() : p.getValueCode() != null ? p.getValueCode() : p.getValueUrl();
+            return new ValueSetExpansionParameter().setName(p.getName()).setValueString(filterValue);
+          }
+          return new ValueSetExpansionParameter().setName(p.getName())
+              .setValueString(p.getValueString())
+              .setValueBoolean(p.getValueBoolean())
+              .setValueInteger(p.getValueInteger())
+              .setValueDecimal(p.getValueDecimal())
+              // expansion.parameter.value is a uri (not url/canonical), so fold those in — otherwise a
+              // request param like `url` carried as valueUrl/valueCanonical produced an expansion.parameter
+              // with a name but no value, which is invalid FHIR and crashes strict clients (e.g. the validator).
+              .setValueUri(p.getValueUri() != null ? p.getValueUri() : p.getValueUrl() != null ? p.getValueUrl() : p.getValueCanonical())
+              .setValueCode(p.getValueCode())
+              .setValueDateTime(p.getValueDateTime());
+        }).filter(ValueSetFhirMapper::hasValue).toList();
   }
 
   /** A FHIR expansion.parameter MUST have a value — drop any that ended up valueless rather than emit invalid output. */

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -855,7 +855,8 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // the stored-VS path semantics. Filters affect `expansion.total`;
     // pagination does not.
     String textFilter = req == null ? null : req.findParameter("filter")
-        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+        .map(pp -> pp.getValueString() != null ? pp.getValueString()
+            : pp.getValueCode() != null ? pp.getValueCode() : pp.getValueUri()).orElse(null);
     if (textFilter != null && !textFilter.isBlank()) {
       String needle = textFilter.toLowerCase();
       expandedConcepts = expandedConcepts.stream().filter(c -> {
@@ -1622,7 +1623,8 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     ValueSetVersion stubVersion = new ValueSetVersion();
 
     String textFilter = req == null ? null : req.findParameter("filter")
-        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+        .map(pp -> pp.getValueString() != null ? pp.getValueString()
+            : pp.getValueCode() != null ? pp.getValueCode() : pp.getValueUri()).orElse(null);
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
     Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)
@@ -1741,7 +1743,8 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         .orElse(req.findParameter("defaultLanguage").map(ParametersParameter::getValueCode)
         .orElse(req.findParameter("defaultLanguage").map(ParametersParameter::getValueString).orElse(null))));
     String textFilter = req == null ? null : req.findParameter("filter")
-        .map(pp -> pp.getValueString() != null ? pp.getValueString() : pp.getValueCode()).orElse(null);
+        .map(pp -> pp.getValueString() != null ? pp.getValueString()
+            : pp.getValueCode() != null ? pp.getValueCode() : pp.getValueUri()).orElse(null);
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
     Integer count = req == null ? null : req.findParameter("count").map(ParametersParameter::getValueInteger)

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -951,6 +951,21 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // used-codesystem entries — same shape as the stored-snapshot path (reuses the mapper helper).
     List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter> expansionParameters =
         ValueSetFhirMapper.expansionParameters(req, expandedConcepts);
+    // used-codesystem is normally derived from the expanded members. When a filter excludes every member the
+    // expansion is empty, but the code system(s) the value set drew from were still "used" — so derive
+    // used-codesystem from the resolved compose includes instead (the reference engine reports it on an empty
+    // search result). Only when none was derived from members, so a non-empty expansion is unaffected.
+    if (expansionParameters.stream().noneMatch(pp -> "used-codesystem".equals(pp.getName()))
+        && inlineVs.getCompose() != null && inlineVs.getCompose().getInclude() != null) {
+      java.util.LinkedHashSet<String> includeSystems = new java.util.LinkedHashSet<>();
+      for (var inc : inlineVs.getCompose().getInclude()) {
+        if (inc.getSystem() != null) {
+          includeSystems.add(inc.getSystem() + (inc.getVersion() != null ? "|" + inc.getVersion() : ""));
+        }
+      }
+      includeSystems.forEach(s -> expansionParameters.add(
+          new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter().setName("used-codesystem").setValueUri(s)));
+    }
     // Derived used-supplement params (resolved url|version) for supplements applied to this inline expansion.
     usedSupplements.forEach(s -> expansionParameters.add(new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter()
         .setName("used-supplement").setValueUri(s.asCanonical())));


### PR DESCRIPTION
## What

Two related `$expand` shape fixes (together they complete the `search` suite):

1. **`filter` parameter supplied as a uri** — the FHIR `filter` is a *string*. termx echoed it into `expansion.parameter` as `valueUri` (should be `valueString`) AND read the free-text member filter only from `valueString`/`valueCode`, so a uri-supplied filter wasn't applied (the expansion returned all members). Both now read `valueUri`.
2. **used-codesystem on an empty expansion** — `used-codesystem` was derived only from the expanded members, so a filter that excluded every member produced an expansion with **no** `used-codesystem`. The code systems the value set drew from were still used — derive it from the resolved compose includes when none came from members (narrowly gated to the empty case).

## Result

tx-ecosystem conformance **402 → 409 / 599** (with #308), flipping **all six `search/search-{all,filter,enum}-{yes,no}`** plus **`exclude/exclude-all`**, **zero regressions** (full TestReport diff).