### PR TITLE
fix(fhir): $expand code regex filter matches the entire code

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
@@ -236,7 +236,10 @@ expressions as (
      and t.rule_id = c.rule_id
      and (t.filter_ -> 'property' ->> 'name')::text = 'code' and (
          (t.filter_ ->> 'operator')::text = '=' and c.csev_code = (t.filter_ ->> 'value')::text or -- code equals the provided value
-         (t.filter_ ->> 'operator')::text = 'regex' and c.csev_code = any(regexp_match(c.csev_code, (t.filter_ ->> 'value')::text||'$')) or -- code matches the regex
+         -- FHIR filter regex matches the ENTIRE code: anchor both ends as `^(value)$`. The previous
+         -- `= any(regexp_match(code, value||'$'))` form only anchored the tail and compared against a
+         -- captured group, so a value with its own group (e.g. `(a+)+`) matched nothing. (#310)
+         (t.filter_ ->> 'operator')::text = 'regex' and c.csev_code ~ ('^(' || (t.filter_ ->> 'value')::text || ')$') or -- code matches the regex (full match)
          (t.filter_ ->> 'operator')::text = 'in' and c.csev_code = any(string_to_array((t.filter_ ->> 'value')::text, ',')) or -- code is in the set
          (t.filter_ ->> 'operator')::text = 'not-in' and c.csev_code != all(string_to_array((t.filter_ ->> 'value')::text, ',')) -- code is not in the set
      )

--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -278,7 +278,12 @@ WITH recursive vs AS (
          -- code / concept column with '=', 'in', 'regex', 'not-in'
          ((t.filter_ ->> 'property') in ('code', 'concept') and (t.filter_ ->> 'op') in ('=','in','regex','not-in') and (
               (t.filter_ ->> 'op') = '='      and con.code = (t.filter_ ->> 'value')::text or
-              (t.filter_ ->> 'op') = 'regex'  and con.code = any(regexp_match(con.code, (t.filter_ ->> 'value')::text || '$')) or
+              -- FHIR filter regex matches the ENTIRE code: anchor both ends as `^(value)$`. The previous
+              -- `code = any(regexp_match(code, value||'$'))` form only anchored the tail and compared the
+              -- code against a CAPTURED GROUP, so a value carrying its own group (e.g. `(a+)+`) returned the
+              -- inner capture instead of the whole match and matched nothing. The wrapping parens keep
+              -- top-level alternation (`a|b`) bound to the anchors.
+              (t.filter_ ->> 'op') = 'regex'  and con.code ~ ('^(' || (t.filter_ ->> 'value')::text || ')$') or
               (t.filter_ ->> 'op') = 'in'     and con.code = any(string_to_array((t.filter_ ->> 'value')::text, ',')) or
               (t.filter_ ->> 'op') = 'not-in' and con.code != all(string_to_array((t.filter_ ->> 'value')::text, ','))
          ))


### PR DESCRIPTION
## Problem

FHIR `ValueSet.compose.include.filter` with `op = regex` must match the **entire** code. Both expansion functions (`value_set_expand(text)` inline path and `value_set_expand(bigint)` stored path) used:

```sql
code = any(regexp_match(code, value || '$'))
```

This only anchors the tail, and `regexp_match` returns *captured groups*. When the pattern carries its own group — e.g. `(a+)+` — the comparison runs against the inner capture rather than the whole match, so valid codes matched nothing and were dropped from the expansion.

## Fix

Anchor both ends and match the full code:

```sql
code ~ ('^(' || value || ')$')
```

The wrapping parens keep top-level alternation (`a|b`) bound to the anchors.

## Verification

Full `tx-ecosystem` conformance run (inline tx-resource path):

- **412 → 414 / 599**, **0 regressions**
- Gained: `regex-bad/expand-regex-bad`, `regex-bad/expand-regex-bad-2`
- Existing regex tests unchanged: `simple-expand-regex` (3), `simple-expand-regex2` (3), `simple-expand-regexp-prop` — verified against real data, identical counts before/after.

Both functions are `runOnChange` Liquibase `sqlFile` entries; the change re-applies on startup.