### PR TITLE
fix(fhir): inline $expand reports used-codesystem with resolved version

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -966,6 +966,29 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       includeSystems.forEach(s -> expansionParameters.add(
           new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter().setName("used-codesystem").setValueUri(s)));
     }
+    // The reference engine reports used-codesystem as `system|version` whenever the code system has a
+    // version. The inline expand SQL does not carry the resolved CS version onto its members, and the
+    // empty-expansion compose fallback above only knows the version the include pinned (often none), so
+    // both can emit a bare `system`. Backfill the version from the request's tx-resource CodeSystems:
+    // a versionless code system (no version on its tx-resource) stays bare, and a system that resolves
+    // to more than one distinct version is left untouched (ambiguous).
+    java.util.Map<String, java.util.Set<String>> txResourceVersions = new java.util.HashMap<>();
+    if (req != null && req.getParameter() != null) {
+      for (ParametersParameter p : req.getParameter()) {
+        if ("tx-resource".equals(p.getName()) && p.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem cs
+            && cs.getUrl() != null && StringUtils.isNotEmpty(cs.getVersion())) {
+          txResourceVersions.computeIfAbsent(cs.getUrl(), k -> new java.util.HashSet<>()).add(cs.getVersion());
+        }
+      }
+    }
+    expansionParameters.stream()
+        .filter(pp -> "used-codesystem".equals(pp.getName()) && pp.getValueUri() != null && !pp.getValueUri().contains("|"))
+        .forEach(pp -> {
+          java.util.Set<String> versions = txResourceVersions.get(pp.getValueUri());
+          if (versions != null && versions.size() == 1) {
+            pp.setValueUri(pp.getValueUri() + "|" + versions.iterator().next());
+          }
+        });
     // Derived used-supplement params (resolved url|version) for supplements applied to this inline expansion.
     usedSupplements.forEach(s -> expansionParameters.add(new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionParameter()
         .setName("used-supplement").setValueUri(s.asCanonical())));


### PR DESCRIPTION
## Problem

The reference engine reports the `used-codesystem` expansion parameter as `system|version` whenever the code system has a version. termx's inline path (`$expand` of a tx-resource value set) could emit a bare `system`:

- the inline expand SQL (`value_set_expand(text)`) does not carry the resolved code-system version onto its members, so the member-derived `used-codesystem` lost the version;
- the empty-expansion compose fallback only knew the version the `include` pinned — often none (e.g. a filter that matches nothing on a versioned CS).

## Fix

After the `used-codesystem` entries are assembled, backfill the version from the request's `tx-resource` CodeSystems:

- a **versionless** code system (no version on its tx-resource) stays bare — e.g. `extensions`, `big`, `en-multi`;
- a system resolving to **more than one** distinct version is left untouched (ambiguous);
- otherwise the single resolved version is appended → `system|version`.

Centralized in `ValueSetExpandOperation` (inline path only); the stored-snapshot path is unchanged.

## Verification

Full `tx-ecosystem` conformance run (inline tx-resource path), measured against the 412 baseline with identical methodology:

- **+2, 0 regressions**
- Gained: `simple-cases/simple-expand-all-count`, `notSelectable/notSelectable-prop-trueUC`
- The 49 expected version-less `used-codesystem` values (extensions/big/en-multi/…) verified to stay bare — survey of all suite fixtures: 216 expect `system|version`, 49 expect bare, split exactly on whether the CS declares a version.