### PR TITLE
fix(fhir): VS-scoped concept deprecation in $validate-code + $expand

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -420,6 +420,7 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
   }
 
   private static final String STANDARDS_STATUS_URL = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status";
+  private static final String VALUESET_DEPRECATED_URL = "http://hl7.org/fhir/StructureDefinition/valueset-deprecated";
 
   /** The tx-resource CodeSystem whose canonical url matches {@code system}. */
   private static com.kodality.zmei.fhir.resource.terminology.CodeSystem txCodeSystem(Parameters req, String system) {
@@ -1045,6 +1046,31 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
             ? c.getConcept().getCodeSystemVersions().stream().findFirst().orElse(null) : null)
         .filter(java.util.Objects::nonNull).distinct().count() > 1;
 
+    // VS-scoped concept deprecation: the value set's compose can mark an enumerated concept as deprecated via a
+    // valueset-deprecated / standards-status extension on the include.concept (the concept itself may be active in
+    // its code system — this is a value-set-level annotation). The expand SQL drops compose-level extensions, so
+    // rebuild a (system|code → extensions) map from the source compose and echo those extensions onto the matching
+    // expansion.contains entry.
+    java.util.Map<String, List<com.kodality.zmei.fhir.Extension>> composeConceptDeprecation = new java.util.HashMap<>();
+    if (inlineVs.getCompose() != null && inlineVs.getCompose().getInclude() != null) {
+      for (var inc : inlineVs.getCompose().getInclude()) {
+        if (inc.getConcept() == null) {
+          continue;
+        }
+        for (var cc : inc.getConcept()) {
+          if (cc.getCode() == null || cc.getExtension() == null) {
+            continue;
+          }
+          List<com.kodality.zmei.fhir.Extension> deps = cc.getExtension().stream()
+              .filter(e -> VALUESET_DEPRECATED_URL.equals(e.getUrl()) || STANDARDS_STATUS_URL.equals(e.getUrl()))
+              .toList();
+          if (!deps.isEmpty()) {
+            composeConceptDeprecation.put((inc.getSystem() != null ? inc.getSystem() : "") + "|" + cc.getCode(), deps);
+          }
+        }
+      }
+    }
+
     // Map concepts to expansion contains
     List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContains> contains =
         expandedConcepts.stream().map(concept -> {
@@ -1068,6 +1094,11 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
           if (isAbstractMember(concept)
               || (concept.getConcept() != null && txAbstractCodes.contains(concept.getConcept().getCodeSystemUri() + "|" + concept.getConcept().getCode()))) {
             contain.setAbstractField(true);
+          }
+          // Echo any VS-scoped deprecation extensions the source compose stated for this member.
+          List<com.kodality.zmei.fhir.Extension> depExts = composeConceptDeprecation.get(contain.getSystem() + "|" + contain.getCode());
+          if (depExts != null) {
+            depExts.forEach(contain::addExtension);
           }
           if (includeDesignations && concept.getAdditionalDesignations() != null) {
             List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation> designations =

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -147,6 +147,38 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   }
 
   private static final String STANDARDS_STATUS_URL = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status";
+  private static final String VALUESET_DEPRECATED_URL = "http://hl7.org/fhir/StructureDefinition/valueset-deprecated";
+
+  /**
+   * True when the value set's own compose marks the matched concept as deprecated — either a
+   * {@code valueset-deprecated = true} extension or a {@code standards-status = deprecated} extension on the
+   * {@code compose.include.concept} entry. This is a value-set-scoped deprecation (the concept may be perfectly
+   * active in its code system), so it yields a warning, not an inactive flag.
+   */
+  private static boolean vsConceptDeprecated(com.kodality.zmei.fhir.resource.terminology.ValueSet vs, String system, String code) {
+    if (vs == null || vs.getCompose() == null || vs.getCompose().getInclude() == null || code == null) {
+      return false;
+    }
+    for (var inc : vs.getCompose().getInclude()) {
+      if (inc.getConcept() == null || (system != null && inc.getSystem() != null && !system.equals(inc.getSystem()))) {
+        continue;
+      }
+      for (var c : inc.getConcept()) {
+        if (!code.equals(c.getCode())) {
+          continue;
+        }
+        var deprecatedExt = c.getExtensions(VALUESET_DEPRECATED_URL);
+        if (deprecatedExt != null && deprecatedExt.anyMatch(e -> "true".equals(e.getValueCode()) || Boolean.TRUE.equals(e.getValueBoolean()))) {
+          return true;
+        }
+        var standardsExt = c.getExtensions(STANDARDS_STATUS_URL);
+        if (standardsExt != null && standardsExt.anyMatch(e -> "deprecated".equals(e.getValueCode()))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   /** The tx-resource CodeSystem whose canonical url matches {@code system}. */
   private static com.kodality.zmei.fhir.resource.terminology.CodeSystem txCodeSystemResource(Parameters req, String system) {
@@ -890,6 +922,17 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     if (vsStatus != null) {
       issues.add(org.termx.terminology.fhir.TxIssues.issue("information", "business-rule", "status-check",
           String.format("Reference to %s ValueSet %s%s", vsStatus, inlineVs.getUrl(), inlineVs.getVersion() != null ? "|" + inlineVs.getVersion() : "")));
+    }
+    // A concept marked deprecated by the value set's own compose (valueset-deprecated / standards-status=deprecated
+    // on the include.concept) is still valid, but its use should be reviewed — emit a code-comment warning.
+    if (inlineVs != null && vsConceptDeprecated(inlineVs, match.getSystem() != null ? match.getSystem() : system, match.getCode())) {
+      String depLoc = req.findParameter("codeableConcept").isPresent() ? "CodeableConcept.coding[0].code"
+          : req.findParameter("coding").isPresent() ? "Coding.code" : "code";
+      issues.add(org.termx.terminology.fhir.TxIssues.issue("warning", "business-rule", "code-comment",
+          String.format("The presence of the concept '%s' in the system '%s' in the value set %s%s is marked with a status of deprecated and its use should be reviewed",
+              match.getCode(), match.getSystem() != null ? match.getSystem() : system, inlineVs.getUrl(),
+              inlineVs.getVersion() != null ? "|" + inlineVs.getVersion() : ""),
+          depLoc));
     }
     resp.addParameter(new ParametersParameter("result").setValueBoolean(displayValid && !vr.hasError()));
     resp.addParameter(new ParametersParameter("code").setValueCode(match.getCode()));


### PR DESCRIPTION
## Problem

A value set's `compose` can mark an enumerated concept as deprecated via a `valueset-deprecated` (`valueCode=true`) or `structuredefinition-standards-status` (`valueCode=deprecated`) extension on the `include.concept` entry. The concept may still be perfectly active in its own code system — this is a value-set-level annotation. termx ignored these extensions in both operations.

## Fix

- **`$validate-code`**: when the matched code carries such an extension, emit a `warning`/`business-rule` (tx-issue-type `code-comment`) issue: *"The presence of the concept 'X' in the system 'S' in the value set V|ver is marked with a status of deprecated and its use should be reviewed"*. Result stays `true`.
- **`$expand`**: echo the deprecation extensions onto the matching `expansion.contains` entry. The inline expand SQL drops compose-level extensions, so the map is rebuilt from the source compose (keyed by `system|code`).

## Verification

Full `tx-ecosystem` conformance run, diffed against the prior run with identical methodology:

- **+3, 0 regressions, 0 missing**
- Gained: `deprecated/vs-deprecation` (expand echo), `deprecated/deprecating-validate`, `deprecated/deprecating-validate-2` (validate warning)

Independent of PRs #310 / #311 (different code paths); stacks cleanly to 419/599 with all three.