### PR TITLE
fix(fhir): resolve compose value-set imports from stored value sets

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -660,8 +660,45 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
                 java.util.Comparator.nullsFirst(ValueSetExpandOperation::compareVersions)))
             .orElse(null);
         if (imported == null) {
-          throw org.termx.terminology.fhir.TxIssues.notFoundException(404,
-              "Unable to resolve the value set import " + refUrl + (refVersion != null ? "|" + refVersion : ""));
+          // Not bundled inline as a tx-resource — fall back to a value set the server already stores under this
+          // canonical (a compose may import a standard/registered value set, e.g. the FHIR administrative-gender
+          // value set, that the request doesn't re-send). Expand the stored version through the snapshot path and
+          // fold its members in, so a mixed include/exclude that references a stored import resolves instead of 404ing.
+          ValueSetQueryParams storedParams = new ValueSetQueryParams();
+          storedParams.setUri(refUrl);
+          storedParams.setLimit(1);
+          storedParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
+          ValueSet storedVs = valueSetService.query(storedParams).findFirst().orElse(null);
+          ValueSetVersion storedVersion = null;
+          if (storedVs != null) {
+            if (refVersion != null) {
+              ValueSetVersionQueryParams svParams = new ValueSetVersionQueryParams();
+              svParams.setValueSet(storedVs.getId());
+              svParams.setVersion(refVersion);
+              svParams.setLimit(1);
+              storedVersion = valueSetVersionService.query(svParams).findFirst().orElse(null);
+            } else {
+              storedVersion = valueSetVersionService.loadLastVersion(storedVs.getId());
+            }
+          }
+          if (storedVersion == null) {
+            throw org.termx.terminology.fhir.TxIssues.notFoundException(404,
+                "Unable to resolve the value set import " + refUrl + (refVersion != null ? "|" + refVersion : ""));
+          }
+          usedValueSets.add(refUrl + (storedVersion.getVersion() != null ? "|" + storedVersion.getVersion() : ""));
+          if (!visited.add(refUrl + "|" + (storedVersion.getVersion() == null ? "" : storedVersion.getVersion()))) {
+            continue; // already expanded on this path — guard against import cycles
+          }
+          for (ValueSetVersionConcept m : valueSetVersionConceptService.expand(storedVs.getId(), storedVersion.getVersion(), "en", false).getExpansion()) {
+            if (m.getConcept() == null || m.getConcept().getCode() == null) {
+              continue;
+            }
+            String sys = m.getConcept().getCodeSystemUri() != null ? m.getConcept().getCodeSystemUri() : m.getConcept().getBaseCodeSystemUri();
+            if (sys != null) {
+              bySystem.computeIfAbsent(sys, k -> new java.util.LinkedHashSet<>()).add(m.getConcept().getCode());
+            }
+          }
+          continue;
         }
         // Report the resolved imported value set as a `used-valueset` expansion parameter (url|version).
         usedValueSets.add(refUrl + (imported.getVersion() != null ? "|" + imported.getVersion() : ""));


### PR DESCRIPTION
## Problem

`$expand` of a value set whose compose imports another value set by canonical (`compose.include.valueSet`) only resolved the import from `tx-resource` resources bundled in the request. When the import wasn't bundled, it threw **404** — *"Unable to resolve the value set import …"* — even when the server already **stores** that value set.

Real-world impact: any compose that imports a registered/standard value set (e.g. the FHIR `administrative-gender` value set) fails to expand unless the client re-sends the imported VS inline.

## Fix

In `resolveImportedValueSets`, when the import isn't found among tx-resources, fall back to the **stored** value set: look it up by canonical (honouring a pinned `|version`, else the latest version), expand it through the snapshot path, and fold its members in by code system — mirroring the tx-resource branch (reports `used-valueset`, guards against import cycles).

## Verification

Full `tx-ecosystem` conformance run: **0 regressions, 0 missing** (419/599 unchanged). The three `exclude` tests this unblocks from a hard 404 (`exclude-gender`, `exclude-gender2`, `include-combo`) now expand the correct **set** of codes but still differ from the reference on `expansion.contains` **ordering** — HAPI's expansion ordering is intricate and underspecified (e.g. one fixture wants alphabetical order, another wants import order), so that's deliberately left for separate work. This PR is a correctness fix for the 404 itself, which is a genuine defect independent of the suite.