### PR TITLE
fix(fhir): display-language with no display in the requested language (validate-code + expand)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -1448,7 +1448,12 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
         // Among language-matching candidates, prefer (in order) an EXACT language match over a region-subtag
         // match (`de` over `de-CH`), and the concept's PRIMARY display value over an alternate same-language
         // designation. Scored: exact-language = 2, primary-display value = 1.
-        chosen = all.values().stream().filter(d -> languageMatches(d.getLanguage(), eff))
+        // A `definition`-use designation is NOT a display name (FHIR), so it must never be chosen as the
+        // display — e.g. a `de` definition must not surface as the `de` display, which would otherwise leave a
+        // requested-language definition masquerading as the display (the reference keeps the default display).
+        chosen = all.values().stream()
+            .filter(d -> !"definition".equals(d.getDesignationType()))
+            .filter(d -> languageMatches(d.getLanguage(), eff))
             .max(java.util.Comparator.comparingInt(d ->
                 (eff.equalsIgnoreCase(d.getLanguage()) ? 2 : 0)
                     + (d.getName() != null && d.getName().equals(primaryDisplay) ? 1 : 0)))


### PR DESCRIPTION
## Problem

When `displayLanguage` is requested but the matched concept has **no valid display in that language** (only e.g. a `definition`, or designations in other languages), termx mis-handled both the display it returned and the display validation:

1. `$expand` picked the requested-language **definition** as the member display (a definition is not a display name).
2. `$validate-code` returned that alternate/definition display, and treated a provided default-language display as either fully-valid (no notice) or a hard error — instead of *valid-with-warning*.

## Fix

**$expand** (`applyDisplayLanguage`): exclude `definition`-use designations from the display candidates, so a concept with only a `de` definition keeps its default display rather than surfacing the definition as the `de` display.

**$validate-code**: when a `displayLanguage` is requested but the concept has no valid display in it (designations read reliably from the tx-resource CodeSystem; definitions don't count), keep the concept's **primary (default-language) display** and judge the provided display against the default language:
- valid for the default language → result stays **true** with an *information* invalid-display notice: *"There are no valid display names found for the code X for language(s) 'L'. The display is 'Y' which is a valid display for the default language"*;
- matches nothing → the usual **error** (*"Wrong Display Name … Default display is 'Z'"*).

Guarded to a **known** default language that differs from the request — when the requested language *does* have its own display, the branch is skipped, so a foreign-language display under a satisfied request stays an error (the deliberate prior behavior is preserved).

## Verification

Full `tx-ecosystem` conformance run, diffed against the 419 baseline with identical methodology: **+6, 0 regressions, 0 missing** → **425/599**.

Gained: `validation/simple-{code,coding}-{good,bad}-language-none` (4) + `language2/validation-right-{de-en,de-ende-N}` (2). Verified no regressions across the `language` / `language2` / `validation` suites (the over-trigger that an earlier iteration caused on `*-good-language` was fixed by reading designations from the CS and excluding definitions).