### PR TITLE
fix(fhir): make ValueSet $batch-validate-code reachable (kefhir R5.12)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ commonsVersion=1-SNAPSHOT
 commonsMicronautVersion=4.5-SNAPSHOT
 jacksonVersion=2.17.1
 zmeiVersion=R5-SNAPSHOT
-kefhirVersion=R5.11
+kefhirVersion=R5.12
 testcontainersVersion=1.21.4
 
 # change micronaut.openapi.server.context.path for local dev

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetBatchValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetBatchValidateCodeOperation.java
@@ -4,17 +4,18 @@ import com.kodality.kefhir.core.api.resource.TypeOperationDefinition;
 import com.kodality.kefhir.structure.api.ResourceContent;
 import com.kodality.zmei.fhir.FhirMapper;
 import com.kodality.zmei.fhir.resource.other.Parameters;
-import io.micronaut.context.annotation.Factory;
+import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import org.hl7.fhir.r4.model.ResourceType;
 import org.termx.terminology.fhir.BatchValidateCodeSupport;
 
 /**
- * FHIR ValueSet {@code $batch-validate-code}: validates many codes against value sets in one request,
- * delegating each {@code validation} item to {@link ValueSetValidateCodeOperation} (so inline tx-resource
- * value sets, designations, displays etc. behave identically to the single-code operation).
+ * FHIR ValueSet {@code $batch-validate-code}: validates many codes against value sets in one request, delegating
+ * each {@code validation} item to {@link ValueSetValidateCodeOperation} (so inline tx-resource value sets,
+ * designations, displays etc. behave identically to the single-code operation). The HL7 validator posts the batch
+ * to {@code POST /ValueSet/$batch-validate-code}.
  */
-@Factory
+@Singleton
 @RequiredArgsConstructor
 public class ValueSetBatchValidateCodeOperation implements TypeOperationDefinition {
   private final ValueSetValidateCodeOperation validateCodeOperation;


### PR DESCRIPTION
## Problem

termx already had a `$batch-validate-code` handler (`ValueSetBatchValidateCodeOperation`), but it was **never reachable**: kefhir only routed operations declared in the CapabilityStatement, so `POST /ValueSet/$batch-validate-code` returned **400 'not defined in capability statement'**. The tx-ecosystem `batch/*` tests therefore failed on the response code.

## Change

- Depends on **kefhir R5.12** ([termx-health/kefhir#12](https://github.com/termx-health/kefhir/pull/12)), which auto-exposes any operation that has an implementation bean.
- Mark the batch operation `@Singleton` (was `@Factory`, which did not register it as a discoverable `TypeOperationDefinition` bean).
- Bump `kefhirVersion` → **R5.12**.

## Verification

Full `tx-ecosystem` conformance run vs the 468 baseline: **+1, 0 regressions → 469/599**. `batch/batch-validate` now passes; `batch/batch-validate-bad` reaches the server (200) and remains on a single-item display-message content nuance (separate from the batch mechanism).

> ⚠️ Requires kefhir#12 to merge and publish R5.12 to GitHub Packages before this builds in CI.