### PR TITLE
fix(fhir): reject unresolvable useSupplement and malformed displayLanguage in $validate-code

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -95,6 +95,21 @@ public final class TxIssues {
     return new com.kodality.kefhir.core.exception.FhirException(status, issue);
   }
 
+  /**
+   * A malformed {@code displayLanguage} request parameter: a {@code processing}-code OperationOutcome issue with
+   * the {@code tx-issue-type}/{@code invalid-display} detail coding (tx-ecosystem {@code validation-wrong-de-en-bad}).
+   */
+  public static com.kodality.kefhir.core.exception.FhirException invalidDisplayLanguageException(String displayLanguage) {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.PROCESSING);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept()
+        .addCoding(new org.hl7.fhir.r5.model.Coding(TX_ISSUE_TYPE, "invalid-display", null))
+        .setText("Invalid displayLanguage: '" + displayLanguage + "'"));
+    return new com.kodality.kefhir.core.exception.FhirException(400, issue);
+  }
+
   /** Formats a version list as the tx-ecosystem does: comma-separated with " or " before the last ("a, b or c"). */
   public static String presentVersionList(java.util.List<String> versions) {
     if (versions == null || versions.isEmpty()) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -45,6 +45,7 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   private final ValueSetVersionConceptService valueSetVersionConceptService;
   private final ConceptService conceptService;
   private final ValueSetExpandOperation expandOperation;
+  private final org.termx.terminology.terminology.codesystem.CodeSystemService codeSystemService;
 
   public String getResourceType() {
     return ResourceType.ValueSet.name();
@@ -73,6 +74,13 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   }
 
   public Parameters run(Parameters req) {
+    // A `useSupplement` that names a code system supplement which can't be resolved — neither bundled as a
+    // tx-resource nor stored — is a hard 404, the same way $expand rejects an unresolvable required supplement
+    // (tx-ecosystem parameters/validate-supplement-bad). Checked up front, before resolving the value set.
+    requireResolvableSupplements(req);
+    // A structurally-malformed displayLanguage (e.g. a bare '-') is rejected up front with a 400 processing
+    // error, the way the reference engine does (tx-ecosystem validation-wrong-de-en-bad).
+    requireValidDisplayLanguage(req);
     String rawUrl = req.findParameter("url")
         .map(pp -> pp.getValueUrl() != null ? pp.getValueUrl() : pp.getValueUri() != null ? pp.getValueUri() : pp.getValueString())
         .orElse(null);
@@ -144,6 +152,60 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
   }
 
   private record CsConcept(boolean found, String display, boolean inactive, String status) {
+  }
+
+  /**
+   * Every {@code useSupplement} the request names must be resolvable to a CodeSystem supplement — either one
+   * bundled as a {@code tx-resource} on the request or one stored with that canonical url. An unresolvable
+   * supplement is a 404 not-found (mirrors {@code ValueSetExpandOperation.requireDeclaredSupplements}).
+   */
+  private void requireResolvableSupplements(Parameters req) {
+    if (req == null || req.getParameter() == null) {
+      return;
+    }
+    for (ParametersParameter p : req.getParameter()) {
+      if (!"useSupplement".equals(p.getName())) {
+        continue;
+      }
+      String ref = p.getValueCanonical() != null ? p.getValueCanonical()
+          : p.getValueUri() != null ? p.getValueUri() : p.getValueString();
+      if (StringUtils.isEmpty(ref)) {
+        continue;
+      }
+      String url = ref.contains("|") ? ref.substring(0, ref.indexOf('|')) : ref;
+      boolean txPresent = req.getParameter().stream()
+          .filter(pp -> "tx-resource".equals(pp.getName()))
+          .map(ParametersParameter::getResource)
+          .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+          .map(r -> ((com.kodality.zmei.fhir.resource.terminology.CodeSystem) r).getUrl())
+          .anyMatch(url::equals);
+      boolean storedPresent = txPresent || codeSystemService.query(
+          new org.termx.ts.codesystem.CodeSystemQueryParams().setUri(url).limit(1)).findFirst().isPresent();
+      if (!storedPresent) {
+        throw org.termx.terminology.fhir.TxIssues.notFoundException(404, "Required supplement not found: " + ref);
+      }
+    }
+  }
+
+  /** A single well-formed BCP-47 language range: a primary subtag (or `*`) plus optional `-`-joined subtags. */
+  private static final java.util.regex.Pattern LANGUAGE_RANGE = java.util.regex.Pattern.compile("\\*|[A-Za-z]{1,8}(-[A-Za-z0-9]{1,8})*");
+
+  /**
+   * Reject a structurally-malformed {@code displayLanguage} (a comma-separated BCP-47 range list, each range
+   * optionally carrying a {@code ;q=} weight) with a 400 — e.g. a bare {@code '-'} that is not a language tag.
+   */
+  private void requireValidDisplayLanguage(Parameters req) {
+    String dl = req.findParameter("displayLanguage")
+        .map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).orElse(null);
+    if (StringUtils.isEmpty(dl)) {
+      return;
+    }
+    for (String part : dl.split(",")) {
+      String tag = part.split(";")[0].trim();
+      if (!tag.isEmpty() && !LANGUAGE_RANGE.matcher(tag).matches()) {
+        throw org.termx.terminology.fhir.TxIssues.invalidDisplayLanguageException(dl);
+      }
+    }
   }
 
   private static final String STANDARDS_STATUS_URL = "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status";


### PR DESCRIPTION
## Problem

`$validate-code` accepted two malformed inputs that the reference engine rejects with a 4xx, returning 200 instead:

1. A `useSupplement` parameter naming a code system supplement that resolves to nothing — neither bundled as a `tx-resource` nor stored.
2. A structurally-malformed `displayLanguage` (e.g. a bare `-`, which is not a BCP-47 language tag).

## Fix

`ValueSetValidateCodeOperation.run` now validates both up front:

- **`requireResolvableSupplements`** — each `useSupplement` must resolve to a bundled tx-resource CodeSystem or a stored one with that canonical url; otherwise a 404 `not-found` "Required supplement not found: `<url>`". This mirrors the unresolvable-required-supplement check `$expand` already applies (`requireDeclaredSupplements`).
- **`requireValidDisplayLanguage`** — `displayLanguage` is parsed as a comma-separated BCP-47 range list (each range optionally carrying a `;q=` weight); a range whose tag is neither `*` nor a well-formed language tag yields a 400 `processing` OperationOutcome with the `tx-issue-type/invalid-display` coding and text "Invalid displayLanguage: '`<value>`'".

## Verification

`validator_cli.jar txTests` full 599-test diff before/after:

- **Gained 2**: `parameters/parameters-validate-supplement-bad`, `language2/validation-wrong-de-en-bad`.
- **Regressed 0**.