### PR TITLE
fix(fhir): translate against inline (tx-resource) ConceptMaps in $translate

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapTranslateOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/operations/ConceptMapTranslateOperation.java
@@ -60,6 +60,12 @@ public class ConceptMapTranslateOperation implements InstanceOperationDefinition
     String url = req.findParameter("url").
           map(c -> c.getValueString() != null ? c.getValueString() : c.getValueUrl()).orElse(null);
     if (url == null) {
+      // Inline tx-resource path: the conformance validator bundles the ConceptMap(s) as tx-resource and selects
+      // the map by source/target system rather than a url. Translate against the inline definition (guest-safe).
+      List<com.kodality.zmei.fhir.resource.terminology.ConceptMap> txCms = txResourceConceptMaps(req);
+      if (!txCms.isEmpty()) {
+        return new ResourceContent(FhirMapper.toJson(translateInline(txCms, req)), "json");
+      }
       throw new FhirException(400, IssueType.INVALID, "url parameter required");
     }
     String conceptMapVersion = req.findParameter("conceptMapVersion").
@@ -166,5 +172,119 @@ public class ConceptMapTranslateOperation implements InstanceOperationDefinition
     return p;
   }
 
+  /** ConceptMaps supplied inline via tx-resource params. */
+  private static List<com.kodality.zmei.fhir.resource.terminology.ConceptMap> txResourceConceptMaps(Parameters req) {
+    if (req == null || req.getParameter() == null) {
+      return List.of();
+    }
+    return req.getParameter().stream()
+        .filter(p -> "tx-resource".equals(p.getName()))
+        .map(ParametersParameter::getResource)
+        .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.ConceptMap)
+        .map(r -> (com.kodality.zmei.fhir.resource.terminology.ConceptMap) r)
+        .toList();
+  }
+
+  /**
+   * Translate a source/target code against inline (tx-resource) ConceptMaps, the way the conformance validator
+   * invokes {@code POST /ConceptMap/$translate} with the map bundled and no url. Forward (a source code is given)
+   * walks each group's elements to its targets; reverse (only a target code is given) walks targets back to the
+   * source element. Response parts are alphabetical (concept, equivalence, originMap, relationship, source).
+   */
+  private Parameters translateInline(List<com.kodality.zmei.fhir.resource.terminology.ConceptMap> cms, Parameters req) {
+    String sourceCode = req.findParameter("sourceCode").map(c -> c.getValueCode() != null ? c.getValueCode() : c.getValueString()).orElse(null);
+    String targetCode = req.findParameter("targetCode").map(c -> c.getValueCode() != null ? c.getValueCode() : c.getValueString()).orElse(null);
+    String sourceSystem = uriParam(req, "sourceSystem", "system");
+    String targetSystem = uriParam(req, "targetSystem");
+    if (req.findParameter("sourceCoding").isPresent()) {
+      Coding c = req.findParameter("sourceCoding").map(ParametersParameter::getValueCoding).orElse(null);
+      sourceCode = c == null ? null : c.getCode();
+      sourceSystem = c == null ? null : c.getSystem();
+    }
+    if (req.findParameter("targetCoding").isPresent()) {
+      Coding c = req.findParameter("targetCoding").map(ParametersParameter::getValueCoding).orElse(null);
+      targetCode = c == null ? null : c.getCode();
+      targetSystem = c == null ? null : c.getSystem();
+    }
+    if (sourceCode == null && targetCode == null) {
+      throw new FhirException(400, IssueType.INVALID,
+          "One (and only one) of the in parameters (sourceCode, sourceCoding, sourceCodeableConcept, targetCode, "
+              + "targetCoding, or targetCodeableConcept) SHALL be provided, to identify the code that is to be translated.");
+    }
+    boolean reverse = sourceCode == null;
+    List<ParametersParameter> matches = new java.util.ArrayList<>();
+    for (com.kodality.zmei.fhir.resource.terminology.ConceptMap cm : cms) {
+      String originMap = cm.getUrl() == null ? null : cm.getUrl() + (cm.getVersion() != null ? "|" + cm.getVersion() : "");
+      for (var group : Optional.ofNullable(cm.getGroup()).orElse(List.of())) {
+        if (sourceSystem != null && group.getSource() != null && !sourceSystem.equals(group.getSource())) {
+          continue;
+        }
+        if (targetSystem != null && group.getTarget() != null && !targetSystem.equals(group.getTarget())) {
+          continue;
+        }
+        for (var element : Optional.ofNullable(group.getElement()).orElse(List.of())) {
+          if (!reverse && !sourceCode.equals(element.getCode())) {
+            continue;
+          }
+          for (var target : Optional.ofNullable(element.getTarget()).orElse(List.of())) {
+            if (reverse && !targetCode.equals(target.getCode())) {
+              continue;
+            }
+            matches.add(buildMatch(group.getTarget(), target.getCode(), target.getRelationship(), originMap,
+                reverse ? group.getSource() : null, reverse ? element.getCode() : null));
+          }
+        }
+      }
+    }
+    Parameters out = new Parameters();
+    out.addParameter(new ParametersParameter("result").setValueBoolean(!matches.isEmpty()));
+    matches.forEach(out::addParameter);
+    return out;
+  }
+
+  /** A {@code match} parameter; parts emitted alphabetically: concept, equivalence, originMap, relationship, source. */
+  private static ParametersParameter buildMatch(String targetSystem, String targetCode, String relationship,
+                                                String originMap, String sourceSystem, String sourceCode) {
+    ParametersParameter match = new ParametersParameter("match");
+    match.addPart(new ParametersParameter("concept").setValueCoding(new Coding(targetSystem, targetCode)));
+    String equivalence = relationship == null ? null : equivalence(relationship);
+    if (equivalence != null) {
+      match.addPart(new ParametersParameter("equivalence").setValueCode(equivalence));
+    }
+    if (originMap != null) {
+      match.addPart(new ParametersParameter("originMap").setValueCanonical(originMap));
+    }
+    if (relationship != null) {
+      match.addPart(new ParametersParameter("relationship").setValueCode(relationship));
+    }
+    if (sourceSystem != null && sourceCode != null) {
+      match.addPart(new ParametersParameter("source").setValueCoding(new Coding(sourceSystem, sourceCode)));
+    }
+    return match;
+  }
+
+  /** Map an R5 ConceptMap {@code relationship} to the legacy R4 {@code equivalence} code (null when no mapping). */
+  private static String equivalence(String relationship) {
+    return switch (relationship) {
+      case "equivalent" -> "equivalent";
+      case "source-is-narrower-than-target" -> "narrower";
+      case "source-is-broader-than-target" -> "wider";
+      case "related-to" -> "relatedto";
+      case "not-related-to" -> "disjoint";
+      default -> null;
+    };
+  }
+
+  private static String uriParam(Parameters req, String... names) {
+    for (String name : names) {
+      String v = req.findParameter(name)
+          .map(c -> c.getValueUri() != null ? c.getValueUri() : c.getValueUrl() != null ? c.getValueUrl() : c.getValueString())
+          .orElse(null);
+      if (v != null) {
+        return v;
+      }
+    }
+    return null;
+  }
 
 }


### PR DESCRIPTION
## Problem

`ConceptMap/$translate` only resolved **stored** MapSets through the caller's `MS_READ` privileges, and the type-level `POST /ConceptMap/$translate` required a `url` parameter. The conformance validator bundles the ConceptMap as a `tx-resource`, identifies it by source/target system (no `url`), and runs as a guest — so every call 404'd on "url parameter required".

## Fix

Add an inline path to `run(ResourceContent)`: when no `url` is given but tx-resource ConceptMaps are bundled, translate against the inline definition (guest-safe, mirroring the inline `$validate-code`/`$expand` paths).

- **Forward** (a source code given): match `group.source == sourceSystem`, find `element.code == sourceCode`, emit each target.
- **Reverse** (only a target code given): match `group.target == targetSystem`, find `element.target.code == targetCode`, emit the matched target plus a `source` coding for the element.
- Reads the `sourceSystem`/`targetSystem` parameters the operation declares (the prior code read `system`).
- Match parts emitted alphabetically: `concept`, `equivalence`, `originMap`, `relationship`, `source`; `originMap` is `<url>|<version>`; the legacy R4 `equivalence` is mapped from the R5 `relationship`.

## Verification

`validator_cli.jar txTests` full 599-test diff vs merged main:

- **Gained 2**: `translate/translate-1`, `translate/translate-reverse`.
- **Regressed 0**.