### PR TITLE
fix(import): a use-less FHIR designation is not a display

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -57,7 +57,12 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
   private final CodeSystemRelatedArtifactService relatedArtifactService;
   private static final String DISPLAY = "display";
   private static final String DEFINITION = "definition";
-  private static final Set<String> IMPLICIT_PROPERTY_DEFINITIONS = Set.of(DISPLAY, DEFINITION);
+  // A use-less FHIR designation that is NOT the concept's display is stored under this designation-property type
+  // (FHIR: designation.use is optional, and its absence does NOT mean "display"). Implicit so it is always defined
+  // (designations of this type would otherwise be dropped, having no matching property) yet not re-emitted as a
+  // property definition on export.
+  private static final String ALTERNATE = "alternate";
+  private static final Set<String> IMPLICIT_PROPERTY_DEFINITIONS = Set.of(DISPLAY, DEFINITION, ALTERNATE);
   private static final String SNOMED_URL = "http://snomed.info/sct";
   // Well-known designation `use` codings (keyed by `system#code`) ↔ the termx defined designation-property
   // name. Mapping a use to its known name lets a designation link to the shared defined property (by name)
@@ -784,9 +789,22 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     if (c.getDesignation() == null) {
       c.setDesignation(new ArrayList<>());
     }
+    // A FHIR designation with no `use` is NOT a display (FHIR: use is optional, absence ≠ display). It becomes an
+    // `alternate` designation so it does not compete with the concept's real display — EXCEPT when the concept has
+    // no display of its own, where the FIRST use-less designation becomes the display (so the concept still has a
+    // display name). A designation WITH a use keeps its resolved type.
+    boolean[] displayTaken = {StringUtils.isNotEmpty(c.getDisplay())};
     List<Designation> designations = c.getDesignation().stream().map(d -> {
       Designation designation = new Designation();
-      designation.setDesignationType(designationUseName(d.getUse()));
+      if (d.getUse() != null && d.getUse().getCode() != null) {
+        designation.setDesignationType(designationUseName(d.getUse()));
+      } else if (!displayTaken[0]) {
+        designation.setDesignationType(DISPLAY);
+        designation.setPreferred(true);
+        displayTaken[0] = true;
+      } else {
+        designation.setDesignationType(ALTERNATE);
+      }
       designation.setName(d.getValue());
       designation.setLanguage(d.getLanguage() == null ? Language.en : d.getLanguage());
       designation.setCaseSignificance(caseSignificance);


### PR DESCRIPTION
## Problem

When importing a FHIR CodeSystem, `CodeSystemFhirMapper.fromFhirDesignations` mapped a concept `designation` with **no `use`** to the termx `display` designation type (`designationUseName(null)` → `"display"`). Per FHIR, `designation.use` is optional and its **absence does not mean "display"** — so an imported concept's language designations all became `display`-type and competed with the concept's real display in `$expand`.

Concretely: the FHIR R5 `publication-status#active` concept (display `"Active"`, plus use-less `nl` "actief" / `ru` "активный" designations) expanded as **`"actief"`** instead of `"Active"` (`$lookup` was correct via `preferred`; only the expand display selection picked a foreign-language `display`-typed designation).

## Fix

In `fromFhirDesignations`, a use-less designation now maps to a new **implicit `alternate`** designation property instead of `display`, so it no longer competes with the concept's display. **Exception:** when the concept declares no display of its own, the **first** use-less designation becomes the display (preferred) so the concept still has a display name. Designations carrying a `use` are unchanged.

`alternate` is added to the implicit designation properties so these designations resolve to a defined property (otherwise `prepareEntityVersionDesignations` drops a designation whose type matches no property), and — like `display`/`definition` — it is not re-emitted as a property definition on export.

## Verification

- Unit tests pass: `CodeSystemImportServiceTest` (3), `ConceptExportServiceTest` (8), `ConceptContentSignatureTest` (20) — 0 failures.
- Manual, fresh import of `publication-status`: `$lookup` display `"Active"`, the `nl`/`ru` designations now carry `use={code: alternate}`; **`$expand` returns `"Active"`** (was `"actief"`).
- Case (a), a concept with no display + two use-less designations: the first becomes the display (`"First Label"`), the second becomes `alternate`.

This is the foundational correctness fix behind the FHIR-core import work (it unblocks the `exclude`/`contained` conformance imports once core terminology is loaded + the public-canonical import resolution lands).