### PR TITLE
fix(expand): an enumerated code is flagged enumerated regardless of display

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -463,7 +463,10 @@ codes as (
     where type='exclude'
 )
 select t.obj, to_jsonb(ec.display), ec.designation::jsonb, ec.order_nr,
-       case when ec.code is not null and ec.display is not null then true else false end
+       -- A code is "enumerated" when it comes from an explicit compose.include.concept entry, regardless of whether
+       -- that entry carried a display (the display is resolved later) — mirrors 01-value_set_expand. Without this an
+       -- enumerated value set that lists bare codes is mis-flagged non-enumerated and gets wrongly hierarchy-nested.
+       case when ec.code is not null then true else false end
   from codes t left outer join exact_concepts ec on t.code = ec.code
  order by ec.order_nr;
 


### PR DESCRIPTION
## Problem

The JSONB `terminology.value_set_expand` function flagged an expansion member `enumerated` only when its explicit `compose.include.concept` entry carried **both** a code **and** a display:

```sql
case when ec.code is not null and ec.display is not null then true else false end
```

But `exact_concepts.display` is the **compose entry's** display, and an enumerated value set usually lists bare codes (no display), so its members were mis-flagged `enumerated = false`. `$expand` then treated the value set as a hierarchy view and, with `excludeNested=false`, **nested** the members under their code-system parents (e.g. `code2a`/`code2b` under `code2`) — but an enumerated value set is a flat selection and must not be nested.

## Fix

Drop the `and ec.display is not null` condition — a member is enumerated whenever it comes from an explicit concept entry (`ec.code is not null`), regardless of display. This matches the non-JSONB `01-value_set_expand` function, which already does `case when ec.csev_code is not null then true else false end`. The function changeset is `runOnChange="true"`, so it re-applies on startup.

## Verification

`validator_cli.jar txTests` full-suite diff before/after (same validator):

- **Gained 5**: `parameters/parameters-expand-enum-{hierarchy,inactive,designations,definitions,property}`.
- **Regressed 0**.