### PR TITLE
fix(expand): surface concept definition as a definition property

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -1425,7 +1425,23 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
           }
           if (!requestedProperties.isEmpty()) {
             List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty> props =
-                ValueSetFhirMapper.toFhirContainsProperties(concept.getPropertyValues(), requestedProperties::contains, displayLanguage);
+                new java.util.ArrayList<>(
+                    ValueSetFhirMapper.toFhirContainsProperties(concept.getPropertyValues(), requestedProperties::contains, displayLanguage));
+            // `definition` is stored as an implicit designation (type "definition"), not an EntityPropertyValue, so
+            // toFhirContainsProperties cannot see it. When the request asks for the `definition` property, surface it
+            // from that designation as a definition property (mirroring how the CodeSystem mapper special-cases the
+            // status concept field). The definition designation is already excluded from the designation array above.
+            if (requestedProperties.contains("definition")
+                && props.stream().noneMatch(p -> "definition".equals(p.getCode()))
+                && concept.getAdditionalDesignations() != null) {
+              concept.getAdditionalDesignations().stream()
+                  .filter(d -> "definition".equals(d.getDesignationType()) && StringUtils.isNotEmpty(d.getName()))
+                  .map(d -> d.getName())
+                  .findFirst()
+                  .ifPresent(def -> props.add(
+                      new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty()
+                          .setCode("definition").setValueString(def)));
+            }
             if (!props.isEmpty()) {
               contain.setProperty(props);
             }


### PR DESCRIPTION
When `$expand` is asked for the `definition` property (`property=definition`), termx returned no property at all on the expanded concepts.

**Cause:** termx stores a concept's definition as an *implicit designation* (type `definition`), not as an `EntityPropertyValue`. The property-assembly path only reads property values via `toFhirContainsProperties`, so the definition was invisible to it. The definition designation was already being excluded from the `designation` array with a comment promising it would surface "as a definition property" — but that emission was never implemented.

**Fix:** when `definition` is among the requested properties, source the value from the concept's definition designation and emit it as a `{code: "definition", valueString: …}` property — mirroring how the `status` concept field is special-cased in the CodeSystem mapper.

Gains 3 tx-ecosystem conformance tests (`parameters-expand-{all,enum,isa}-definitions2`), no regressions.