### PR TITLE
fix(validate-code): a system-less Coding fails instead of inferring its system

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -1425,7 +1425,23 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
           }
           if (!requestedProperties.isEmpty()) {
             List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty> props =
-                ValueSetFhirMapper.toFhirContainsProperties(concept.getPropertyValues(), requestedProperties::contains, displayLanguage);
+                new java.util.ArrayList<>(
+                    ValueSetFhirMapper.toFhirContainsProperties(concept.getPropertyValues(), requestedProperties::contains, displayLanguage));
+            // `definition` is stored as an implicit designation (type "definition"), not an EntityPropertyValue, so
+            // toFhirContainsProperties cannot see it. When the request asks for the `definition` property, surface it
+            // from that designation as a definition property (mirroring how the CodeSystem mapper special-cases the
+            // status concept field). The definition designation is already excluded from the designation array above.
+            if (requestedProperties.contains("definition")
+                && props.stream().noneMatch(p -> "definition".equals(p.getCode()))
+                && concept.getAdditionalDesignations() != null) {
+              concept.getAdditionalDesignations().stream()
+                  .filter(d -> "definition".equals(d.getDesignationType()) && StringUtils.isNotEmpty(d.getName()))
+                  .map(d -> d.getName())
+                  .findFirst()
+                  .ifPresent(def -> props.add(
+                      new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty()
+                          .setCode("definition").setValueString(def)));
+            }
             if (!props.isEmpty()) {
               contain.setProperty(props);
             }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -1014,6 +1014,29 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         .findFirst().orElse(null);
 
     String vsCanonical = inlineVs.getUrl() + (inlineVs.getVersion() != null ? "|" + inlineVs.getVersion() : "");
+    // A Coding/CodeableConcept supplied WITHOUT a system has no defined meaning and cannot be validated: the
+    // reference server does NOT infer the system from the value set (that would silently validate a bare code),
+    // it fails with a not-in-vs error at the code plus a no-system warning. A bare `code` param (system implied
+    // by a single-system value set) is unaffected — this only fires when a coding/codeableConcept was given.
+    boolean inferSystemReq = req.findParameter("inferSystem")
+        .map(p -> Boolean.TRUE.equals(p.getValueBoolean()) || "true".equals(p.getValueString())).orElse(false);
+    boolean codingWithoutSystem = system == null && !inferSystemReq
+        && (req.findParameter("coding").isPresent() || req.findParameter("codeableConcept").isPresent());
+    if (codingWithoutSystem) {
+      boolean cc = req.findParameter("codeableConcept").isPresent();
+      String codeLoc = cc ? "CodeableConcept.coding[0].code" : "Coding.code";
+      String codingLoc = cc ? "CodeableConcept.coding[0]" : "Coding";
+      String notInVs = String.format("The provided code '#%s' was not found in the value set '%s'", code, vsCanonical);
+      String noSystem = "Coding has no system. A code with no system has no defined meaning, and it cannot be validated. A system should be provided";
+      Parameters ns = new Parameters();
+      ns.addParameter(new ParametersParameter("code").setValueCode(code));
+      ns.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+          org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "not-in-vs", notInVs, codeLoc),
+          org.termx.terminology.fhir.TxIssues.issue("warning", "invalid", "invalid-data", noSystem, codingLoc))));
+      ns.addParameter(new ParametersParameter("message").setValueString(noSystem + "; " + notInVs));
+      ns.addParameter(new ParametersParameter("result").setValueBoolean(false));
+      return ns;
+    }
     // inferSystem with no system supplied: the code's system is inferred from the value set's expansion. If the
     // code appears under MORE THAN ONE code system, the system is ambiguous — the reference engine returns
     // result=false with a `cannot-infer` error (plus the standard not-in-vs), naming the candidate systems,


### PR DESCRIPTION
A `Coding` (or `CodeableConcept`) supplied **without a system** has no defined meaning and cannot be validated. termx inferred the system from the value set's expansion, matched the bare code, and returned `result=true`. The reference server instead returns `result=false` with two issues:
- `error` / `code-invalid` / `not-in-vs` at `Coding.code` — "The provided code '#code' was not found in the value set …";
- `warning` / `invalid` / `invalid-data` at `Coding` — "Coding has no system. A code with no system has no defined meaning …".

A bare `code` parameter (system implied by a single-system value set) is unaffected — this fires only when a coding/codeableConcept without a system was given and `inferSystem` was not requested.

Gains `validation/validation-simple-coding-no-system`, no regressions across the full tx-ecosystem suite.