### PR TITLE
fix(validate-code): scope display validation by the value set's stated language

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -959,6 +959,12 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       }
     }
     String displayLanguage = req.findParameter("displayLanguage").map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).orElse(null);
+    // With no explicit displayLanguage parameter, the value set's own stated language scopes display validation:
+    // a supplied display in another language (e.g. a German designation under an `en` value set) is then an
+    // invalid-display error, not a lenient any-language match. (The `validation-*-bad-language-vslang` case.)
+    if (displayLanguage == null && StringUtils.isNotEmpty(inlineVs.getLanguage())) {
+      displayLanguage = inlineVs.getLanguage();
+    }
     String code = req.findParameter("code").map(p -> p.getValueCode() != null ? p.getValueCode() : p.getValueString()).orElse(null);
     String system = findSystem(req);
     String display = req.findParameter("display").map(ParametersParameter::getValueString).orElse(null);


### PR DESCRIPTION
When `$validate-code` is called with **no** `displayLanguage` parameter, the value set's own resource `language` now scopes display validation. A supplied display in a different language (e.g. the German designation "Anzeige 1" under an `en` value set) becomes an `error` / `invalid-display` with `result=false`, instead of a lenient any-language match (`information`, `result=true`) — matching the reference server. termx's language-scoped display-validation logic already existed; it just wasn't being fed the value set's language.

Gains `validation/validation-simple-coding-bad-language-vslang`, no regressions across the full tx-ecosystem suite.

The sibling cases `-bad-language-vs` (language in `compose.extension` valueset-expansion-parameter, not modelled by the FHIR layer) and `-bad-language-header` (language in the `Accept-Language` HTTP header) need separate plumbing and are tracked in the notes.