### PR TITLE
fix(expand): designation filter excludes definitions and matches language exactly

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java
@@ -342,8 +342,9 @@ public class ValueSetFhirMapper extends BaseFhirMapper {
       if (system != null && !LANGUAGE_SYSTEMS.contains(system)) {
         return code != null && code.equals(d.getDesignationType());
       }
-      boolean languageMatch = d.getLanguage() != null && code != null
-          && (d.getLanguage().equals(code) || d.getLanguage().startsWith(code + "-"));
+      // A designation `language` filter matches the language EXACTLY — `de` selects `de` but NOT `de-CH` (the
+      // reference treats a regional variant as a distinct language for the designation filter).
+      boolean languageMatch = d.getLanguage() != null && code != null && d.getLanguage().equals(code);
       return languageMatch || (code != null && code.equals(d.getDesignationType()));
     });
   }

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -1400,11 +1400,11 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
             List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation> designations =
                 concept.getAdditionalDesignations().stream()
                 .filter(d -> ValueSetFhirMapper.designationMatchesFilter(d, designationFilter))
-                // The designation repeating the member's display is already removed (applyDisplayLanguage drops
-                // it by value); the definition is surfaced as a definition property, not a designation. With no
-                // explicit `designation` filter, drop only the definition — the remaining alternate-language
-                // designations are kept. An explicit filter returns exactly what was asked for.
-                .filter(d -> !designationFilter.isEmpty() || !"definition".equals(d.getDesignationType()))
+                // The designation repeating the member's display is already removed (applyDisplayLanguage drops it
+                // by value); the definition is surfaced as a definition property, never a designation, so it is
+                // dropped from the designation array even when a `designation` language filter would otherwise
+                // match it (a definition is not a linguistic designation).
+                .filter(d -> !"definition".equals(d.getDesignationType()))
                 .map(d -> {
                   com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation designation =
                       new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation();


### PR DESCRIPTION
Two fixes to the `$expand` `designation` filter (`includeDesignations` + `designation` params), exposed by `language/language-echo-en-designations`:

1. The **definition** is surfaced as a `definition` property, never a designation — so it's dropped from the designation array even when a `designation` language filter (e.g. `urn:ietf:bcp:47|de`) would otherwise match it by language. Previously it was kept whenever any filter was present.
2. A designation **language filter matches the language exactly** — `de` selects `de` but not `de-CH`. The reference treats a regional variant as a distinct language for this filter; termx was matching the variant via a `startsWith(code + "-")` prefix rule.

Gains `language/language-echo-en-designations`, no regressions across the full tx-ecosystem suite.