### PR TITLE
fix(cs-validate-code): inactive concept + inactive designation envelopes

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -305,8 +305,30 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
       result.addParameter(new ParametersParameter("message").setValueString(note));
       result.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
           org.termx.terminology.fhir.TxIssues.issue("warning", "business-rule", "code-comment", note))));
+    } else if (display != null && conceptDisplay != null && !display.equals(conceptDisplay) && designationInactive(concept, display)) {
+      // The supplied display is a valid designation but a non-active one (its standards-status is withdrawn/
+      // deprecated): result stays true, but a display-comment warning notes it is no longer a correct display and
+      // points at the active display.
+      String note = String.format("'%s' is no longer considered a correct display for code '%s' (status = deprecated). The correct display is one of \"%s\".",
+          display, code, conceptDisplay);
+      // A display-comment carries no separate `message` parameter (unlike the code-comment envelope above).
+      result.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+          org.termx.terminology.fhir.TxIssues.issue("warning", "invalid", "display-comment", note))));
     }
     return result;
+  }
+
+  /** True when the supplied display matches a designation of the inline concept that carries a non-active standards-status. */
+  private static boolean designationInactive(com.kodality.zmei.fhir.resource.terminology.CodeSystem.CodeSystemConcept concept, String display) {
+    if (concept == null || concept.getDesignation() == null) {
+      return false;
+    }
+    return concept.getDesignation().stream()
+        .filter(d -> display.equals(d.getValue()) && d.getExtension() != null)
+        .flatMap(d -> d.getExtension().stream())
+        .filter(e -> "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status".equals(e.getUrl()))
+        .map(com.kodality.zmei.fhir.Extension::getValueCode)
+        .anyMatch(v -> List.of("deprecated", "withdrawn", "retired").contains(v));
   }
 
   /**

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -296,7 +296,43 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     if (StringUtils.isNotEmpty(conceptDisplay)) {
       result.addParameter(new ParametersParameter("display").setValueString(conceptDisplay));
     }
+    // A valid but non-active (deprecated/retired/inactive) concept stays result=true, but echoes its `status` and
+    // a code-comment warning advising review — the reference server's inactive-concept envelope.
+    String status = conceptStatus(concept);
+    if (status != null && List.of("deprecated", "retired", "inactive").contains(status)) {
+      String note = String.format("The concept '%s' is %s and its use should be reviewed", code, status);
+      result.addParameter(new ParametersParameter("status").setValueCode(status));
+      result.addParameter(new ParametersParameter("message").setValueString(note));
+      result.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+          org.termx.terminology.fhir.TxIssues.issue("warning", "business-rule", "code-comment", note))));
+    }
     return result;
+  }
+
+  /**
+   * The non-active status (deprecated/retired/inactive) of an inline CodeSystem concept — from a {@code status}
+   * concept property or the {@code structuredefinition-standards-status} extension — or null.
+   */
+  private static String conceptStatus(com.kodality.zmei.fhir.resource.terminology.CodeSystem.CodeSystemConcept concept) {
+    if (concept == null) {
+      return null;
+    }
+    if (concept.getProperty() != null) {
+      String fromProperty = concept.getProperty().stream()
+          .filter(pr -> "status".equals(pr.getCode()))
+          .map(com.kodality.zmei.fhir.resource.terminology.CodeSystem.CodeSystemConceptProperty::getValueCode)
+          .filter(java.util.Objects::nonNull).findFirst().orElse(null);
+      if (fromProperty != null) {
+        return fromProperty;
+      }
+    }
+    if (concept.getExtension() != null) {
+      return concept.getExtension().stream()
+          .filter(e -> "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status".equals(e.getUrl()))
+          .map(com.kodality.zmei.fhir.Extension::getValueCode)
+          .filter(java.util.Objects::nonNull).findFirst().orElse(null);
+    }
+    return null;
   }
 
   /** Depth-first search of the inline concept hierarchy by code. */


### PR DESCRIPTION
Two related fixes to inline CodeSystem `$validate-code`, both `result=true` with an added envelope, exposed by the `extensions` suite:

1. **Inactive concept** (`validate-code-inactive`) — a deprecated/retired/inactive concept echoes a `status` parameter, a `message`, and a `code-comment` warning advising review. Status comes from a `status` concept property **or** the `structuredefinition-standards-status` extension (`code5` is marked deprecated via that extension, not a property).
2. **Inactive designation** (`validate-code-inactive-display`) — when the supplied display matches a designation whose standards-status is withdrawn/deprecated/retired (`code2`'s "2nd Code"), a `display-comment` warning notes the display is no longer correct and points at the active display (no separate `message` parameter here, unlike the code-comment case).

Gains `extensions/validate-code-inactive` and `extensions/validate-code-inactive-display`, no regressions across the full tx-ecosystem suite.