### PR TITLE
fix(validate-code): a coding whose system is a value set → invalid-data

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -1725,6 +1725,18 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       // TWO issues — not-in-vs at `code` plus not-found at `system` (system url UNquoted here) — and the system is
       // reported via x-unknown-system. The message lists the not-found first, then the not-in-vs.
       String notInVs = String.format("The provided code '%s#%s' was not found in the value set '%s'", system, code, vsCanonical);
+      if (!txResourceValueSets(req, system).isEmpty()) {
+        // The "system" is actually a known VALUE SET canonical, not a code system: an invalid-data error at the
+        // system (no not-found, no x-unknown-system), plus the not-in-vs at the code.
+        String vsRef = String.format("The Coding references a value set, not a code system ('%s')", system);
+        parameters.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+            org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "not-in-vs", notInVs, codeLoc),
+            org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "invalid-data", vsRef, systemLoc))));
+        parameters.addParameter(new ParametersParameter("message").setValueString(vsRef + "; " + notInVs));
+        parameters.addParameter(new ParametersParameter("result").setValueBoolean(false));
+        parameters.addParameter(new ParametersParameter("system").setValueUri(system));
+        return parameters;
+      }
       String notFound = String.format("A definition for CodeSystem %s could not be found, so the code cannot be validated", system);
       parameters.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
           org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "not-in-vs", notInVs, codeLoc),


### PR DESCRIPTION
When a coding's `system` resolves to a known **value set** canonical (a bundled tx-resource value set) rather than a code system, the reference reports an `invalid-data` error — "The Coding references a value set, not a code system ('…')" at `Coding.system` — plus the `not-in-vs` at the code. termx was treating it as an unknown code system (`not-found` + `x-unknown-system`). `unknownSystem` now detects the value-set case.

Gains `validation/validation-simple-coding-bad-system2`, no regressions across the full tx-ecosystem suite (the two inactive tests shown as regressed in the local diff are #348's, not yet on main).