### PR TITLE
fix(expand): apply a bundled supplement and graft its designations

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -393,14 +393,22 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     if (req == null || req.getParameter() == null) {
       return null;
     }
-    String joined = req.getParameter().stream()
+    java.util.stream.Stream<String> explicit = req.getParameter().stream()
         .filter(p -> "useSupplement".equals(p.getName()))
+        .map(p -> p.getValueCanonical() != null ? p.getValueCanonical()
+            : p.getValueUri() != null ? p.getValueUri()
+                : p.getValueUrl() != null ? p.getValueUrl() : p.getValueString());
+    // Auto-apply a BUNDLED supplement: a tx-resource CodeSystem with content=supplement is applied to the
+    // expansion even without an explicit useSupplement (the reference does this). A supplement for a code system
+    // not in the expansion contributes nothing (no member matches), so this is safe.
+    java.util.stream.Stream<String> bundled = req.getParameter().stream()
+        .filter(p -> "tx-resource".equals(p.getName()) && p.getResource() instanceof com.kodality.zmei.fhir.resource.terminology.CodeSystem cs
+            && "supplement".equals(cs.getContent()) && cs.getUrl() != null)
         .map(p -> {
-          String v = p.getValueCanonical() != null ? p.getValueCanonical()
-              : p.getValueUri() != null ? p.getValueUri()
-              : p.getValueUrl() != null ? p.getValueUrl() : p.getValueString();
-          return v;
-        })
+          com.kodality.zmei.fhir.resource.terminology.CodeSystem cs = (com.kodality.zmei.fhir.resource.terminology.CodeSystem) p.getResource();
+          return cs.getUrl() + (StringUtils.isNotEmpty(cs.getVersion()) ? "|" + cs.getVersion() : "");
+        });
+    String joined = java.util.stream.Stream.concat(explicit, bundled)
         .filter(StringUtils::isNotEmpty)
         .distinct()
         .collect(java.util.stream.Collectors.joining(","));

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java
@@ -191,8 +191,12 @@ public class ConceptSupplementService {
     // The membership query filters permitted code systems on BOTH the entity's code system (the base) and the
     // version's code system (the supplement); a null (unrestricted) list matches NOTHING, so pass both
     // explicitly when unrestricted. A restricted caller's grants are honored as-is.
+    // The base and the supplement being applied are always readable here — they were resolved as the supplements
+    // to apply, so include them in the permitted set (union with the caller's grants) even when the caller's
+    // CS_READ grants do not list the supplement (e.g. a bundled tx-resource supplement the guest can't otherwise read).
     versionParams.setPermittedCodeSystems(params.getPermittedCodeSystems() != null
-        ? params.getPermittedCodeSystems()
+        ? java.util.stream.Stream.concat(params.getPermittedCodeSystems().stream(),
+            java.util.stream.Stream.of(baseCodeSystem, supplementCodeSystem)).distinct().toList()
         : List.of(baseCodeSystem, supplementCodeSystem));
     versionParams.all();
 


### PR DESCRIPTION
Two fixes so a **bundled** code system supplement (a tx-resource `content=supplement`) is applied to the expansion, as the reference server does:

1. **Auto-apply** a bundled supplement even without an explicit `useSupplement` (a supplement for a code system not in the expansion matches no member, so it's safe).
2. **Make it readable when grafting** — `loadSupplementConcepts` now includes the base + supplement code systems in the permitted set, so a bundled supplement the caller has no `CS_READ` grant for still contributes its designations.

Together these make a bundled supplement's designations graft onto the members (`used-supplement` emitted, e.g. the `extensions` CS's `supplement` now adds `nl 'ectenoot'` to `code1`).

**Foundation, 0 conformance gain yet, REGRESSED 0.** The `extensions`/`parameters` supplement tests each hit a further orthogonal layer (notably designation `extension` propagation — termx's `Designation` model carries no extensions; plus property counts and the bad-supplement-url 400). Documented in the notes; this is the prerequisite those build on.