### PR TITLE
fix(validate): honor system-version default when a ValueSet pins an unknown CS version

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -800,6 +800,17 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     String echo = csVersion != null ? csVersion
         : codingVersion != null && available.contains(codingVersion) ? codingVersion
         : available.stream().max(ValueSetValidateCodeOperation::compareVersions).orElse(null);
+    // When the ValueSet pins an unknown code system version (e.g. version|1 with only 1.0.0/1.2.0 present),
+    // a default `system-version` (or `check-system-version`) selects which REAL version drives the echoed
+    // `version` + the member display — version|1 unknown with system-version=...|1.0.0 echoes 1.0.0, not the
+    // latest. A forced version is already applied above; with no default/check the echo stays the latest.
+    if (includeVersionNotFound) {
+      String def = overrideVersion(req, "system-version", system);
+      String fallback = def != null ? concretize(def, available) : check != null ? concretize(check, available) : null;
+      if (fallback != null) {
+        echo = fallback;
+      }
+    }
     // The `message` concatenates the ERROR issue texts (warnings/info excluded) in issue order,
     // joined with "; " — mirrors org.hl7.fhir.core's combined validation message.
     String message = issues.stream().filter(i -> "error".equals(i.getSeverity()))


### PR DESCRIPTION
When a stored ValueSet pins a code system version that does not exist (e.g. `version-w-bad` pins `version|1` with only `1.0.0`/`1.2.0` present), the code cannot be confirmed in the value set — `x-caused-by-unknown-system = version|1`, `result=false` — but the echoed `version` and the member `display` are resolved against a *real* version.

termx echoed the **latest** (1.2.0). The reference resolves against the supplied default `system-version` (or `check-system-version`): `version|1` unknown with `system-version=...|1.0.0` echoes **1.0.0**. With no default/check the latest is kept (unchanged behaviour), and a forced version still wins.

The fix is scoped to the pinned-unknown case (`includeVersionNotFound`) in `resolveVersion`, so versionless and resolvable-version paths are untouched.

**Conformance: 545 → 549 (GAINED 4, REGRESSED 0).** Flips the `code`/`coding` × `vnn` × `default`/`check` version tests; `codeableconcept` (no top-level version param), `v10`, plain, and `-force` already passed.