### PR TITLE
fix(expand): resolve a transitive ValueSet import without the caller's VS_READ filter

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -785,7 +785,11 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
           ValueSetQueryParams storedParams = new ValueSetQueryParams();
           storedParams.setUri(refUrl);
           storedParams.setLimit(1);
-          storedParams.setPermittedIds(SessionStore.require().getPermittedResourceIds(Privilege.VS_READ));
+          // No VS_READ filter here: this is a TRANSITIVE import resolved inside an expansion the caller already
+          // initiated, not a direct read. A compose routinely imports standard/registered value sets (e.g. the
+          // FHIR core administrative-gender value set) that the caller has no explicit grant for; the reference
+          // tx server resolves them, and the import surfaces only as expansion members. Filtering by the caller's
+          // permitted ids here 404s every such import (the import's content is never exposed as a readable resource).
           ValueSet storedVs = valueSetService.query(storedParams).findFirst().orElse(null);
           ValueSetVersion storedVersion = null;
           if (storedVs != null) {


### PR DESCRIPTION
A compose that imports a standard/registered value set — e.g. the FHIR core `administrative-gender` value set — returned **404** ("Unable to resolve the value set import …") for an unauthenticated caller. The stored-import lookup filtered by the caller's `VS_READ`-permitted ids, which a guest does not hold for the core value sets (they *are* loaded in the DB — this was a permission gap, not a data gap).

A transitive import resolved **inside** an expansion the caller already initiated is not a direct read: its content surfaces only as expansion members, and the reference tx server resolves such imports. The fix drops the permitted-id filter on that one lookup. Direct `$expand` of a value set still goes through normal url resolution, so this doesn't widen direct read access.

**Conformance: GAINED `exclude/exclude-gender` (was 404), REGRESSED 0** (measured off main; the version vs1wb deltas in local testing are [#353](https://github.com/termx-health/termx-server/pull/353) not yet merged into this branch). It also unblocks `exclude-gender2`, `exclude-combo`, and `include-combo` past the 404 — they now hit secondary `used-codesystem`/`total` diffs handled separately.