### PR TITLE
fix(validate): second code-comment for a retired/deprecated not-in-VS code

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -1367,9 +1367,17 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         String codeComment = String.format("The concept '%s' has a status of inactive and its use should be reviewed", code);
         nfIssues.add(0, org.termx.terminology.fhir.TxIssues.issue("error", "business-rule", "code-rule", codeRule));
         nfIssues.add(org.termx.terminology.fhir.TxIssues.issue("warning", "business-rule", "code-comment", codeComment));
-        // The message joins the inactive texts ahead of the not-in-vs text (code-comment, then code-rule, then
+        // A concept with a specific non-active status (retired/deprecated) carries a SECOND code-comment naming
+        // that status, in addition to the generic "inactive" one — mirroring the reference's inactive envelope.
+        String specificStatus = csConcept.status();
+        String statusComment = specificStatus != null && !"inactive".equals(specificStatus)
+            ? String.format("The concept '%s' has a status of %s and its use should be reviewed", code, specificStatus) : null;
+        if (statusComment != null) {
+          nfIssues.add(org.termx.terminology.fhir.TxIssues.issue("warning", "business-rule", "code-comment", statusComment));
+        }
+        // The message joins the inactive texts ahead of the not-in-vs text (code-comment(s), then code-rule, then
         // the existing not-in-vs message) — the reference's order for an inactive code excluded by activeOnly.
-        message = codeComment + "; " + codeRule + "; " + message;
+        message = codeComment + "; " + (statusComment != null ? statusComment + "; " : "") + codeRule + "; " + message;
       }
       if (!ccInput) {
         resp.addParameter(new ParametersParameter("code").setValueCode(code));


### PR DESCRIPTION
When a code is valid in its code system but **inactive** and excluded from the value set (the not-in-vs + "valid but not active" envelope), the reference emits **two** `code-comment` warnings: the generic "has a status of inactive" plus a specific one naming the status (e.g. "has a status of retired"). termx emitted only the generic one.

The specific-status comment is now added from the already-resolved tx-resource concept's status word (`csConcept.status()`), with the message join updated to match.

**Conformance: GAINED `inactive/inactive-3a-validate`, REGRESSED 0.**