### PR TITLE
feat(designation): round-trip FHIR designation.extension

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -316,13 +316,29 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     if (CollectionUtils.isEmpty(designations)) {
       return null;
     }
-    return designations.stream().map(d -> new CodeSystemConceptDesignation()
-            .setLanguage(d.getLanguage())
-            .setValue(d.getName())
-            .setUse(designationUseCoding(d.getDesignationType())))
+    return designations.stream().map(d -> {
+          CodeSystemConceptDesignation fd = new CodeSystemConceptDesignation()
+              .setLanguage(d.getLanguage())
+              .setValue(d.getName())
+              .setUse(designationUseCoding(d.getDesignationType()));
+          List<Extension> ext = toFhirDesignationExtensions(d.getExtension());
+          if (ext != null) {
+            fd.setExtension(ext);
+          }
+          return fd;
+        })
         .sorted(Comparator.comparing(d -> d.getLanguage() == null ? "" : d.getLanguage()))
         .sorted(Comparator.comparing(d -> d.getUse().getCode()))
         .toList();
+  }
+
+  /** Deserializes a stored designation extension (a raw FHIR-extension JSONB passthrough) back into FHIR Extensions. */
+  public static List<Extension> toFhirDesignationExtensions(Object extension) {
+    if (extension == null) {
+      return null;
+    }
+    List<Extension> exts = JsonUtil.fromJson(JsonUtil.toJson(extension), new com.fasterxml.jackson.core.type.TypeReference<List<Extension>>() {});
+    return CollectionUtils.isEmpty(exts) ? null : exts;
   }
 
   private List<CodeSystemProperty> toFhirCodeSystemProperty(List<EntityProperty> entityProperties, String lang) {
@@ -810,6 +826,11 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
       designation.setCaseSignificance(caseSignificance);
       designation.setDesignationKind("text");
       designation.setStatus("active");
+      // Preserve any FHIR designation.extension (e.g. coding-sctdescid) as a verbatim JSONB passthrough so it
+      // round-trips on $expand/$lookup/CS export — termx assigns no semantics to these.
+      if (CollectionUtils.isNotEmpty(d.getExtension())) {
+        designation.setExtension(d.getExtension());
+      }
       return designation;
     }).collect(Collectors.toCollection(ArrayList::new));
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -1544,6 +1544,12 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
                   com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation designation =
                       new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeIncludeConceptDesignation();
                   designation.setValue(d.getName());
+                  // Round-trip any raw FHIR designation.extension (e.g. coding-sctdescid) preserved at import.
+                  List<com.kodality.zmei.fhir.Extension> desExt =
+                      org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper.toFhirDesignationExtensions(d.getExtension());
+                  if (desExt != null) {
+                    designation.setExtension(desExt);
+                  }
                   // Emit the designation's `language`, EXCEPT where the tx-resource CodeSystem shows this
                   // designation has no stated language (import defaults a missing language to the resource
                   // language, but the tx-ecosystem omits it). For a stored code system the set is empty, so the

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/designation/DesignationRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/designation/DesignationRepository.java
@@ -21,7 +21,7 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 
 @Singleton
 public class DesignationRepository extends BaseRepository {
-  private final PgBeanProcessor bp = new PgBeanProcessor(Designation.class);
+  private final PgBeanProcessor bp = new PgBeanProcessor(Designation.class, p -> p.addColumnProcessor("extension", PgBeanProcessor.fromJson()));
 
   String from = " from terminology.designation d " +
       "inner join terminology.entity_property ep on ep.id = d.designation_type_id ";
@@ -38,6 +38,7 @@ public class DesignationRepository extends BaseRepository {
     ssb.property("designation_kind", designation.getDesignationKind());
     ssb.property("description", designation.getDescription());
     ssb.property("status", designation.getStatus());
+    ssb.jsonProperty("extension", designation.getExtension());
 
     SqlBuilder sb = ssb.buildSave("terminology.designation", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());

--- a/terminology/src/main/resources/terminology/changelog/terminology/04-designation.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/04-designation.sql
@@ -33,3 +33,7 @@ select core.create_table_metadata('terminology.designation');
 -- used in file import with IN operator to optimize searches
 create index designation_name_hash_idx on terminology.designation using hash(lower(name));
 --
+
+--changeset kefhir:designation_extension
+alter table terminology.designation add column if not exists extension jsonb;
+--rollback alter table terminology.designation drop column if exists extension;

--- a/termx-api/src/main/java/org/termx/ts/codesystem/Designation.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/Designation.java
@@ -24,6 +24,9 @@ public class Designation {
 
   private String designationType;
 
+  // Raw FHIR designation.extension passthrough (e.g. coding-sctdescid) — stored as JSONB, round-tripped verbatim.
+  private Object extension;
+
   private boolean supplement;
   // Transient (not persisted): for a supplement-contributed designation, the supplement's canonical
   // `<url>|<version>` — emitted as the `$lookup` designation `source` part. Set at merge time.

--- a/zmei/zmei-fhir/src/main/java/com/kodality/zmei/fhir/Extension.java
+++ b/zmei/zmei-fhir/src/main/java/com/kodality/zmei/fhir/Extension.java
@@ -21,6 +21,7 @@ public class Extension extends Element {
 
   private String valueString;
   private String valueCode;
+  private String valueId;
   private Integer valueInteger;
   private BigDecimal valueDecimal;
   private OffsetDateTime valueDateTime;


### PR DESCRIPTION
A designation's FHIR `extension` (e.g. `coding-sctdescid`) was dropped on import, so it never surfaced on `$expand`/`$lookup`/CodeSystem output. This adds an `extension` JSONB column to `terminology.designation` and round-trips the raw FHIR extension verbatim:
- model `Designation.extension` (passthrough `Object`) + Liquibase changeset (`kefhir:`)
- `DesignationRepository` persists/loads it as JSONB
- import (`CodeSystemFhirMapper.fromFhirDesignations`) captures `designation.extension`
- exports (expand member + `toFhirDesignations`) emit it back
- adds the missing `valueId` value[x] to the FHIR `Extension` model (`coding-sctdescid` uses `valueId`), which was being silently dropped

**Verified:** the designation extension (incl. `valueId`) now round-trips end-to-end on `$expand` output. **Conformance REGRESSED 0** (the `Extension.valueId` addition is serialization-safe). **GAINED 0 by itself** — `extensions-echo-all`/`-enumerated` additionally need member-`property` emission (a separate layer), and a conformance setup re-import to backfill stored designations. Foundation for the supplement cluster.