### PR TITLE
fix(validate): batch-validate error envelope + invalid-display on a not-in-VS code

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/BatchValidateCodeSupport.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/BatchValidateCodeSupport.java
@@ -34,17 +34,41 @@ public final class BatchValidateCodeSupport {
       // params come first so findParameter resolves them ahead of the shared defaults.
       shared.forEach(in::addParameter);
 
-      Parameters result;
       try {
-        result = validateCode.apply(in);
+        resp.addParameter(new ParametersParameter(VALIDATION).setResource(validateCode.apply(in)));
       } catch (FhirException e) {
-        result = new Parameters()
-            .addParameter(new ParametersParameter("result").setValueBoolean(false))
-            .addParameter(new ParametersParameter("message").setValueString(e.getMessage()));
+        // A hard error (e.g. no code to validate at all) is returned as an OperationOutcome for that entry — the
+        // reference embeds the error outcome, not a Parameters result.
+        resp.addParameter(new ParametersParameter(VALIDATION).setResource(toOperationOutcome(e)));
       }
-      resp.addParameter(new ParametersParameter(VALIDATION).setResource(result));
     }
     return resp;
+  }
+
+  private static com.kodality.zmei.fhir.resource.other.OperationOutcome toOperationOutcome(FhirException e) {
+    java.util.List<org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent> riList =
+        e.getIssues() != null ? e.getIssues() : java.util.List.of();
+    java.util.List<com.kodality.zmei.fhir.resource.other.OperationOutcome.OperationOutcomeIssue> issues = riList.stream()
+        .map(ri -> {
+          var cc = new com.kodality.zmei.fhir.datatypes.CodeableConcept()
+              .setText(ri.getDetails() != null ? ri.getDetails().getText() : e.getMessage());
+          if (ri.getDetails() != null && !ri.getDetails().getCoding().isEmpty()) {
+            cc.setCoding(ri.getDetails().getCoding().stream()
+                .map(c -> new com.kodality.zmei.fhir.datatypes.Coding(c.getSystem(), c.getCode())).toList());
+          }
+          return new com.kodality.zmei.fhir.resource.other.OperationOutcome.OperationOutcomeIssue()
+              .setSeverity(ri.getSeverity() != null ? ri.getSeverity().toCode() : "error")
+              .setCode(ri.getCode() != null ? ri.getCode().toCode() : "invalid")
+              .setDetails(cc);
+        }).toList();
+    if (issues.isEmpty()) {
+      issues = java.util.List.of(new com.kodality.zmei.fhir.resource.other.OperationOutcome.OperationOutcomeIssue()
+          .setSeverity("error").setCode("invalid")
+          .setDetails(new com.kodality.zmei.fhir.datatypes.CodeableConcept().setText(e.getMessage())));
+    }
+    com.kodality.zmei.fhir.resource.other.OperationOutcome oo = new com.kodality.zmei.fhir.resource.other.OperationOutcome();
+    oo.setIssue(issues);
+    return oo;
   }
 
   /** Each validation's input is a nested Parameters resource; tolerate the part-based shape as a fallback. */

--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -117,6 +117,18 @@ public final class TxIssues {
     return new com.kodality.kefhir.core.exception.FhirException(400, issue);
   }
 
+  /** No code to validate was supplied (no coding/codeableConcept/code+system/code+inferSystem) — an error
+   * OperationOutcome with the reference's exact wording (note: the reference omits the closing paren). */
+  public static com.kodality.kefhir.core.exception.FhirException noCodeToValidateException() {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.INVALID);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept()
+        .setText("Unable to find code to validate (looked for coding | codeableConcept | code+system | code+inferSystem in parameters"));
+    return new com.kodality.kefhir.core.exception.FhirException(400, issue);
+  }
+
   /** Formats a version list as the tx-ecosystem does: comma-separated with " or " before the last ("a, b or c"). */
   public static String presentVersionList(java.util.List<String> versions) {
     if (versions == null || versions.isEmpty()) {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -81,6 +81,14 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     // A structurally-malformed displayLanguage (e.g. a bare '-') is rejected up front with a 400 processing
     // error, the way the reference engine does (tx-ecosystem validation-wrong-de-en-bad).
     requireValidDisplayLanguage(req);
+    // No code to validate at all (no coding / codeableConcept / code+system / code+inferSystem) is an error, not a
+    // normal Parameters result — the reference returns an OperationOutcome (tx-ecosystem batch-validate-bad[1]).
+    boolean inferSystemReq = req.findParameter("inferSystem")
+        .map(p -> Boolean.TRUE.equals(p.getValueBoolean()) || "true".equals(p.getValueString())).orElse(false);
+    if (req.findParameter("coding").isEmpty() && req.findParameter("codeableConcept").isEmpty()
+        && !(req.findParameter("code").isPresent() && (req.findParameter("system").isPresent() || inferSystemReq))) {
+      throw org.termx.terminology.fhir.TxIssues.noCodeToValidateException();
+    }
     String rawUrl = req.findParameter("url")
         .map(pp -> pp.getValueUrl() != null ? pp.getValueUrl() : pp.getValueUri() != null ? pp.getValueUri() : pp.getValueString())
         .orElse(null);
@@ -681,7 +689,9 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       displays.put(match.getDisplay(), csLang);
     }
     Optional.ofNullable(match.getDesignation()).orElse(List.of()).forEach(d -> {
-      if (d.getValue() != null) {
+      // Only language-tagged designations are offered as alternative valid displays — a language-less designation
+      // (e.g. an alternate code with no stated language) is not a display choice the reference enumerates.
+      if (d.getValue() != null && d.getLanguage() != null) {
         displays.putIfAbsent(d.getValue(), d.getLanguage());
       }
     });
@@ -1397,6 +1407,19 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
         // The message joins the inactive texts ahead of the not-in-vs text (code-comment(s), then code-rule, then
         // the existing not-in-vs message) — the reference's order for an inactive code excluded by activeOnly.
         message = codeComment + "; " + (statusComment != null ? statusComment + "; " : "") + codeRule + "; " + message;
+      }
+      // A code valid in the code system but excluded from the value set, supplied WITH a wrong display, also gets an
+      // invalid-display warning — the reference validates the display against the code system even when the code is
+      // not a value-set member.
+      if (StringUtils.isNotEmpty(display) && csConcept.found() && csConcept.display() != null
+          && !inactiveConcept && !display.equals(csConcept.display())) {
+        String csLang = Optional.ofNullable(txCodeSystemResource(req, system))
+            .map(com.kodality.zmei.fhir.resource.terminology.CodeSystem::getLanguage).orElse(null);
+        String reqStr = StringUtils.isEmpty(displayLanguage) ? "--" : displayLanguage;
+        String wrongDisplay = String.format("Wrong Display Name '%s' for %s#%s. Valid display is '%s'%s (for the language(s) '%s')",
+            display, system, code, csConcept.display(), csLang != null ? " (" + csLang + ")" : "", reqStr);
+        nfIssues.add(org.termx.terminology.fhir.TxIssues.issue("warning", "invalid", "invalid-display", wrongDisplay, displayLocation(req)));
+        message = message + "; " + wrongDisplay;
       }
       if (!ccInput) {
         resp.addParameter(new ParametersParameter("code").setValueCode(code));


### PR DESCRIPTION
Five fixes that together green the `batch-validate-bad` envelope (each was exposed only after the previous one landed):
1. a **language-less designation** is no longer offered as a valid display choice in the "Valid display is …" clause (a single-display concept now reads as one, not "one of 2 choices")
2. **no code to validate** at all (no coding / codeableConcept / code+system / code+inferSystem) is an `OperationOutcome` error, not a `Parameters` result
3. a `$batch-validate-code` entry that **errors** now embeds that `OperationOutcome` (built from the exception's issues), not a `Parameters` result+message
4. a code **valid in the code system but excluded from the value set**, supplied with a wrong display, also carries an `invalid-display` warning (the reference validates the display against the CS even for a non-member)
5. the `message` appends that wrong-display text after the not-in-vs text

**Conformance: GAINED `batch/batch-validate-bad`, REGRESSED 0.**