### PR TITLE
Count virtual concepts for external-provider code systems

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionService.java
@@ -2,6 +2,7 @@ package org.termx.terminology.terminology.codesystem.version;
 
 import com.kodality.commons.model.QueryResult;
 import jakarta.inject.Provider;
+import org.termx.core.ts.CodeSystemExternalProvider;
 import org.termx.core.ts.UcumSearchCacheInvalidator;
 import org.termx.terminology.ApiError;
 import org.termx.terminology.terminology.codesystem.CodeSystemRepository;
@@ -32,6 +33,7 @@ public class CodeSystemVersionService {
   private final Provider<ValueSetCodeSystemImpactService> valueSetCodeSystemImpactServiceProvider;
   private final CodeSystemRepository codeSystemRepository;
   private final UcumSearchCacheInvalidator ucumSearchCacheInvalidator;
+  private final List<CodeSystemExternalProvider> codeSystemProviders;
 
   @Transactional
   public void save(CodeSystemVersion version) {
@@ -57,23 +59,23 @@ public class CodeSystemVersionService {
   }
 
   public Optional<CodeSystemVersion> load(String codeSystem, String versionCode) {
-    return Optional.ofNullable(repository.load(codeSystem, versionCode));
+    return Optional.ofNullable(repository.load(codeSystem, versionCode)).map(this::decorateConceptCount);
   }
 
   public CodeSystemVersion load(Long id) {
-    return repository.load(id);
+    return decorateConceptCount(repository.load(id));
   }
 
   public CodeSystemVersion loadLastVersion(String codeSystem) {
-    return repository.loadLastVersion(codeSystem);
+    return decorateConceptCount(repository.loadLastVersion(codeSystem));
   }
 
   public CodeSystemVersion loadLastVersionByUri(String uri) {
-    return repository.loadLastVersionByUri(uri);
+    return decorateConceptCount(repository.loadLastVersionByUri(uri));
   }
 
   public CodeSystemVersion loadPreviousVersion(String codeSystem, String version) {
-    return repository.loadPreviousVersion(codeSystem, version);
+    return decorateConceptCount(repository.loadPreviousVersion(codeSystem, version));
   }
 
   public Optional<CodeSystemVersion> loadVersionByUri(String uri, String versionCode) {
@@ -81,11 +83,31 @@ public class CodeSystemVersionService {
     p.setCodeSystemUri(uri);
     p.setVersion(versionCode);
     p.setLimit(1);
-    return repository.query(p).findFirst();
+    return repository.query(p).findFirst().map(this::decorateConceptCount);
   }
 
   public QueryResult<CodeSystemVersion> query(CodeSystemVersionQueryParams params) {
-    return repository.query(params);
+    QueryResult<CodeSystemVersion> result = repository.query(params);
+    Optional.ofNullable(result.getData()).orElse(List.of()).forEach(this::decorateConceptCount);
+    return result;
+  }
+
+  /**
+   * The stored {@code conceptsTotal} counts code-system-version memberships, which is always 0 for code systems
+   * whose concepts are resolved virtually by a {@link CodeSystemExternalProvider} (e.g. UCUM). For those, take the
+   * count from the provider so the UI shows the real number of concepts instead of 0.
+   */
+  private CodeSystemVersion decorateConceptCount(CodeSystemVersion version) {
+    if (version == null || version.getCodeSystem() == null) {
+      return version;
+    }
+    codeSystemProviders.stream()
+        .map(provider -> provider.conceptCount(version.getCodeSystem()))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .findFirst()
+        .ifPresent(version::setConceptsTotal);
+    return version;
   }
 
   @Transactional

--- a/termx-core/src/main/java/org/termx/core/ts/CodeSystemExternalProvider.java
+++ b/termx-core/src/main/java/org/termx/core/ts/CodeSystemExternalProvider.java
@@ -4,6 +4,7 @@ import com.kodality.commons.model.QueryResult;
 import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.ConceptQueryParams;
 import jakarta.inject.Singleton;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @Singleton
@@ -19,4 +20,15 @@ public abstract class CodeSystemExternalProvider {
   public abstract QueryResult<Concept> searchConcepts(ConceptQueryParams params);
 
   public abstract String getCodeSystemId();
+
+  /**
+   * Total number of concepts this provider resolves for {@code codeSystem}. Providers whose concepts are
+   * virtual (resolved at runtime rather than stored as code-system-version memberships) return a value here
+   * so callers can show a meaningful count instead of the membership-based SQL count, which is always 0 for
+   * such code systems. Returns empty when this provider does not handle {@code codeSystem}, leaving the
+   * caller's stored count untouched.
+   */
+  public Optional<Integer> conceptCount(String codeSystem) {
+    return Optional.empty();
+  }
 }

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumCodeSystemProvider.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumCodeSystemProvider.java
@@ -5,6 +5,7 @@ import org.termx.core.ts.CodeSystemExternalProvider;
 import org.termx.ts.codesystem.Concept;
 import org.termx.ts.codesystem.ConceptQueryParams;
 import jakarta.inject.Singleton;
+import java.util.Optional;
 
 @Singleton
 public class UcumCodeSystemProvider extends CodeSystemExternalProvider {
@@ -24,5 +25,13 @@ public class UcumCodeSystemProvider extends CodeSystemExternalProvider {
   @Override
   public String getCodeSystemId() {
     return UCUM;
+  }
+
+  @Override
+  public Optional<Integer> conceptCount(String codeSystem) {
+    if (!UCUM.equals(codeSystem)) {
+      return Optional.empty();
+    }
+    return Optional.of(ucumConceptResolver.count());
   }
 }

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java
@@ -58,14 +58,21 @@ public class UcumConceptResolver {
         .filter(u -> matchesTextContains(u, supplementDesignations.get(u.getCode()), params.getTextContains()))
         .toList();
 
+    int total = units.size();
     int offset = Optional.ofNullable(params.getOffset()).orElse(0);
-    int limit = Optional.ofNullable(params.getLimit()).orElse(units.size());
-    if (offset >= units.size() || limit <= 0) {
-      return new QueryResult<>(List.of());
-    }
-    int to = Math.min(units.size(), offset + limit);
-    List<Concept> concepts = units.subList(offset, to).stream().map(mapper::toConcept).toList();
-    return new QueryResult<>(concepts);
+    int limit = Optional.ofNullable(params.getLimit()).orElse(total);
+    List<Concept> concepts = (offset >= total || limit <= 0)
+        ? List.of()
+        : units.subList(offset, Math.min(total, offset + limit)).stream().map(mapper::toConcept).toList();
+    // meta.total must reflect the full filtered result, not just the returned page, so the UI paging
+    // ("load more" when data.length < meta.total) works against virtual UCUM concepts.
+    QueryResult<Concept> result = new QueryResult<>(concepts);
+    result.getMeta().setTotal(total);
+    return result;
+  }
+
+  public int count() {
+    return getUnits().size();
   }
 
   public Optional<Concept> findByCode(String code) {


### PR DESCRIPTION
## Problem

Code System Version pages (e.g. `/resources/code-systems/ucum/versions/1.0.0/concepts`) show **0 concepts** for UCUM.

`conceptsTotal` is computed purely from membership rows (`entity_version_code_system_version_membership`) in `CodeSystemVersionRepository`. UCUM concepts are **virtual** — resolved at runtime by `UcumConceptResolver` via the `CodeSystemExternalProvider` mechanism and never stored as memberships — so the membership count is structurally always 0.

(Essence loading is not the cause: `UcumServiceImpl` falls back to the bundled classpath `ucum-essence.xml` at startup, so units are always available — only the count badge was wrong.)

## Changes

- **Generic count hook.** Add `Optional<Integer> conceptCount(String codeSystem)` to `CodeSystemExternalProvider` (default empty). Applies to any external-provider code system, not just UCUM.
- **UCUM override.** `UcumCodeSystemProvider.conceptCount` returns `UcumConceptResolver.count()` (the resolved, cached unit count).
- **Version decoration.** `CodeSystemVersionService` injects the provider list and decorates every version it returns (`load*` / `query`): when a provider owns the version's code system, its count overrides the membership-based `conceptsTotal`. Covers all UI surfaces (version concepts page, summary versions widget, version finder), which all route through these methods.
- **Paging fix.** `UcumConceptResolver.search` now sets `meta.total` to the full filtered count instead of the returned page size, so the concept list's "load more" (`data.length < meta.total`) works for UCUM.

No DI cycle: UCUM has no back-dependency on `CodeSystemVersionService`; LOINC/SNOMED providers defer their dependencies via `BeanProvider`.

## Verification

- `:termx-core`, `:ucum`, `:terminology` compile clean.
- `UcumExternalProviderTest` passes (forced rerun).