### PR TITLE
fix(expand): guard against empty inline-VS compose dropped by NON_EMPTY round-trip

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -678,6 +678,12 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     }
     com.kodality.zmei.fhir.resource.terminology.ValueSet copy = FhirMapper.fromJson(
         FhirMapper.toJson(inlineVs), com.kodality.zmei.fhir.resource.terminology.ValueSet.class);
+    // The JSON round-trip serializes with Include.NON_EMPTY, which drops an empty compose/include (e.g. an
+    // include list that is non-null-but-empty, or whose entries are all empty objects) — so copy.getCompose()
+    // can be null here even though inlineVs.getCompose() passed the guard above. Nothing concrete to resolve.
+    if (copy.getCompose() == null || copy.getCompose().getInclude() == null) {
+      return inlineVs;
+    }
     for (var inc : copy.getCompose().getInclude()) {
       String system = inc.getSystem();
       if (system == null) {

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -87,6 +87,9 @@ class ValueSetExpandOperationTest extends Specification {
       capturedSnapshot = args[3] as ValueSetSnapshot
       return new com.kodality.zmei.fhir.resource.terminology.ValueSet()
     }
+    // The inline-VS path always consults the supplement service and then iterates the result; give the mock an
+    // explicit empty result so the suite doesn't depend on the framework's default for a generic List return.
+    conceptSupplementService.mergeSupplementsIntoExpansion(_, _) >> []
   }
 
   def cleanup() {
@@ -359,6 +362,34 @@ class ValueSetExpandOperationTest extends Specification {
     result.expansion.contains.size() == 10
     result.expansion.contains[0].code == "code_0"
     result.expansion.contains[9].code == "code_9"
+  }
+
+  def "inline-VS expand with an empty include does not NPE (compose dropped by NON_EMPTY round-trip)"() {
+    // Regression: resolveIncludeVersions null-checks inlineVs.getCompose()/getInclude(),
+    // then deep-copies the value set via a FhirMapper JSON round-trip and loops over
+    // copy.getCompose().getInclude(). FhirMapper serializes with Include.NON_EMPTY, which
+    // strips an empty compose/include — a non-null-but-empty include list (the shape Jackson
+    // deserializes `"include":[]` into) collapses the whole compose to nothing, so
+    // copy.getCompose() comes back null and the loop threw an NPE, surfaced to the client as
+    // "exception during profile validation: null". The fix returns the untouched original when
+    // the round-trip drops the compose — there is nothing concrete to resolve.
+    given:
+    valueSetVersionConceptRepository.expandFromJson(_) >> []
+
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    inlineVs.setCompose(new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetCompose()
+        .setInclude([] as List))
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    noExceptionThrown()
+    result.expansion.contains == null || result.expansion.contains.isEmpty()
   }
 
   def "inline-VS expand with offset=2 count=3 returns slice starting at offset"() {


### PR DESCRIPTION
## Problem

`$validate-code` / `$expand` against an inline value set whose `compose` collapses to empty crashes with an NPE, surfaced to the client as `exception during profile validation: null`:

```
java.lang.NullPointerException: Cannot invoke "...ValueSet$ValueSetCompose.getInclude()" because the return value of "...ValueSet.getCompose()" is null
  at ValueSetExpandOperation.resolveIncludeVersions(ValueSetExpandOperation.java:681)
  at ValueSetExpandOperation.expandInline(ValueSetExpandOperation.java:1132)
  ...
```

## Root cause

`resolveIncludeVersions` null-checks `inlineVs.getCompose()`/`getInclude()`, then deep-copies the value set through a `FhirMapper` JSON round-trip and iterates `copy.getCompose().getInclude()`. `FhirMapper` serializes with `Include.NON_EMPTY`, which strips an empty `compose`/`include` — a non-null-but-empty include list, or include entries that are all empty objects (e.g. `include:[{}]`, `include:[{"concept":[]}]`). So `copy.getCompose()` can be `null` even though the original passed the guard.

## Fix

Guard `copy` after the round-trip and return the untouched original when the compose collapsed to empty — there is nothing concrete to resolve. Pure defensive guard: prior behavior on these inputs was a crash, so it cannot regress any passing case.