### PR TITLE
feat(expand): too-costly + circular-reference guards (tx-ecosystem 'big' suite)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TxIssues.java
@@ -117,6 +117,38 @@ public final class TxIssues {
     return new com.kodality.kefhir.core.exception.FhirException(400, issue);
   }
 
+  /**
+   * A circular {@code compose.include}/{@code exclude.valueSet} import chain: an {@code error}/{@code processing}
+   * OperationOutcome issue with the {@code tx-issue-type}/{@code vs-invalid} detail coding (tx-ecosystem
+   * {@code VALUESET_CIRCULAR_REFERENCE}). The value set cannot be expanded because resolving its imports loops.
+   */
+  public static com.kodality.kefhir.core.exception.FhirException circularReferenceException(String diagnostics) {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.PROCESSING);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept()
+        .addCoding(new org.hl7.fhir.r5.model.Coding(TX_ISSUE_TYPE, "vs-invalid", null))
+        .setText(diagnostics));
+    issue.setDiagnostics(diagnostics);
+    return new com.kodality.kefhir.core.exception.FhirException(422, issue);
+  }
+
+  /**
+   * An expansion too large to return in full (no paging requested and over the server's cost threshold): an
+   * {@code error}/{@code too-costly} OperationOutcome issue (tx-ecosystem {@code VALUESET_TOO_COSTLY}). The
+   * expected fixture carries no {@code tx-issue-type} coding — just the text — so none is attached.
+   */
+  public static com.kodality.kefhir.core.exception.FhirException tooCostlyException(String diagnostics) {
+    org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent issue =
+        new org.hl7.fhir.r5.model.OperationOutcome.OperationOutcomeIssueComponent();
+    issue.setSeverity(org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR);
+    issue.setCode(org.hl7.fhir.r5.model.OperationOutcome.IssueType.TOOCOSTLY);
+    issue.setDetails(new org.hl7.fhir.r5.model.CodeableConcept().setText(diagnostics));
+    issue.setDiagnostics(diagnostics);
+    return new com.kodality.kefhir.core.exception.FhirException(422, issue);
+  }
+
   /** No code to validate was supplied (no coding/codeableConcept/code+system/code+inferSystem) — an error
    * OperationOutcome with the reference's exact wording (note: the reference omits the closing paren). */
   public static com.kodality.kefhir.core.exception.FhirException noCodeToValidateException() {

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -257,6 +257,9 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // FHIR R5 expansion.total: post-filter, pre-pagination count. Capture HERE.
     // The mapper reads snapshot.conceptsTotal in preference to expansion.size().
     int totalAfterFilter = expandedConcepts.size();
+    // Defend against an unbounded expansion that is too large to return in full (no count requested + over the
+    // cost threshold) — 4xx too-costly, the way the reference server does. Paged requests are exempt.
+    enforceExpansionLimit(req, totalAfterFilter);
 
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)
         .orElse(req.findParameter("offset").map(ParametersParameter::getValueString).map(Integer::valueOf).orElse(null));
@@ -718,6 +721,123 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     return copy;
   }
 
+  // --- big/* cost & cycle guards (tx-ecosystem 'big' suite) -------------------------------------------------
+
+  /** Max depth of nested value-set imports before the chain is treated as circular (backstop for the path check). */
+  private static final int MAX_IMPORT_DEPTH = 20;
+  /** Default cap on an unbounded expansion's size before it is rejected as too-costly; the
+   *  {@code X-TOO-COSTLY-THRESHOLD} request header (used by the tx-ecosystem 'big' suite) overrides it. */
+  private static final int DEFAULT_EXPANSION_LIMIT = 10_000;
+
+  /**
+   * Rejects a value set whose {@code compose.include}/{@code exclude.valueSet} imports form a cycle, before the
+   * expansion engine silently skips the re-import and returns a wrong 200. Walks the import graph resolving each
+   * ref through the same sources the expand uses (a contained resource, then a bundled tx-resource), tracking the
+   * current ancestor path; a ref already on the path — or a chain deeper than {@link #MAX_IMPORT_DEPTH} — is a
+   * {@code VALUESET_CIRCULAR_REFERENCE} 4xx.
+   */
+  private void checkImportCycle(com.kodality.zmei.fhir.resource.terminology.ValueSet vs, Parameters req) {
+    java.util.LinkedHashSet<String> path = new java.util.LinkedHashSet<>();
+    if (vs != null && vs.getUrl() != null) {
+      path.add(vs.getUrl() + (vs.getVersion() != null ? "|" + vs.getVersion() : ""));
+    }
+    walkImportCycle(vs, req, path, 1);
+  }
+
+  private void walkImportCycle(com.kodality.zmei.fhir.resource.terminology.ValueSet vs, Parameters req,
+      java.util.LinkedHashSet<String> path, int depth) {
+    if (vs == null || vs.getCompose() == null) {
+      return;
+    }
+    if (depth > MAX_IMPORT_DEPTH) {
+      throw org.termx.terminology.fhir.TxIssues.circularReferenceException(
+          "Value set import chain exceeds the maximum depth of " + MAX_IMPORT_DEPTH + " via [" + String.join(", ", path) + "]");
+    }
+    // include AND exclude valueSet refs both participate in a cycle (big-circle-2 excludes big-circle-1).
+    List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude> groups = new java.util.ArrayList<>();
+    if (vs.getCompose().getInclude() != null) {
+      groups.addAll(vs.getCompose().getInclude());
+    }
+    if (vs.getCompose().getExclude() != null) {
+      groups.addAll(vs.getCompose().getExclude());
+    }
+    for (var g : groups) {
+      if (g.getValueSet() == null) {
+        continue;
+      }
+      for (String ref : g.getValueSet()) {
+        if (StringUtils.isEmpty(ref)) {
+          continue;
+        }
+        com.kodality.zmei.fhir.resource.terminology.ValueSet imported = resolveValueSetRef(ref, req, vs);
+        // Key the path by the resolved canonical (url|version) so the same value set reached by url and by
+        // versioned ref collapses to one node; fall back to the raw ref when it resolves to no bundled resource.
+        String key = imported != null && imported.getUrl() != null
+            ? imported.getUrl() + (imported.getVersion() != null ? "|" + imported.getVersion() : "")
+            : ref;
+        if (!path.add(key)) {
+          throw org.termx.terminology.fhir.TxIssues.circularReferenceException(
+              "Cyclic reference detected resolving " + key + " via [" + String.join(", ", path) + "]");
+        }
+        walkImportCycle(imported, req, path, depth + 1);
+        path.remove(key);
+      }
+    }
+  }
+
+  /** Resolves a {@code compose.*.valueSet} ref for cycle-walking: a contained {@code #id}, then a bundled
+   *  tx-resource (pinned version, else latest). Returns null when only a stored snapshot exists (no compose to
+   *  recurse into — the stored expand path owns those), which simply ends that branch of the walk. */
+  private com.kodality.zmei.fhir.resource.terminology.ValueSet resolveValueSetRef(
+      String ref, Parameters req, com.kodality.zmei.fhir.resource.terminology.ValueSet contextVs) {
+    if (ref.startsWith("#")) {
+      String id = ref.substring(1);
+      return java.util.Optional.ofNullable(contextVs.getContained()).orElse(List.of()).stream()
+          .filter(r -> r instanceof com.kodality.zmei.fhir.resource.terminology.ValueSet)
+          .map(r -> (com.kodality.zmei.fhir.resource.terminology.ValueSet) r)
+          .filter(cvs -> id.equals(cvs.getId()))
+          .findFirst().orElse(null);
+    }
+    int pipe = ref.indexOf('|');
+    String refUrl = pipe >= 0 ? ref.substring(0, pipe) : ref;
+    String refVersion = pipe >= 0 ? ref.substring(pipe + 1) : null;
+    return txResourceValueSets(req, refUrl).stream()
+        .filter(vs -> refVersion == null || refVersion.equals(vs.getVersion()))
+        .max(java.util.Comparator.comparing(com.kodality.zmei.fhir.resource.terminology.ValueSet::getVersion,
+            java.util.Comparator.nullsFirst(ValueSetExpandOperation::compareVersions)))
+        .orElse(null);
+  }
+
+  /** Throws a {@code too-costly} 4xx when an unbounded expansion ({@code count} absent) exceeds the threshold. A
+   *  paged request (any {@code count}) is exempt — the client is windowing, not asking for the whole set. */
+  private static void enforceExpansionLimit(Parameters req, int total) {
+    if (req != null && req.findParameter("count").isPresent()) {
+      return;
+    }
+    int limit = tooCostlyThreshold();
+    if (total > limit) {
+      throw org.termx.terminology.fhir.TxIssues.tooCostlyException(
+          "The value set expansion has " + total + " concepts, which exceeds the maximum of " + limit
+              + "; the expansion is too costly to return in full (use the count/offset paging parameters)");
+    }
+  }
+
+  /** The cost threshold for an unbounded expansion: the {@code X-TOO-COSTLY-THRESHOLD} request header when present
+   *  (the tx-ecosystem 'big' suite sets it to make the limit deterministic), else {@link #DEFAULT_EXPANSION_LIMIT}. */
+  private static int tooCostlyThreshold() {
+    String header = io.micronaut.http.context.ServerRequestContext.currentRequest()
+        .map(r -> r.getHeaders().get("X-TOO-COSTLY-THRESHOLD"))
+        .filter(StringUtils::isNotEmpty).orElse(null);
+    if (header != null) {
+      try {
+        return Integer.parseInt(header.trim());
+      } catch (NumberFormatException ignore) {
+        // malformed header — fall through to the default
+      }
+    }
+    return DEFAULT_EXPANSION_LIMIT;
+  }
+
   /**
    * P8 — resolve {@code compose.include[].valueSet} (imported value sets). The SQL expand only handles
    * {@code system}/{@code concept}/{@code filter}; an imported value set is expanded here (recursively, from the
@@ -1101,6 +1221,9 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     requireValidFilters(inlineVs);
     // A value set that REQUIRES a supplement (valueset-supplement extension) must have it resolvable, else 4xx.
     requireDeclaredSupplements(inlineVs, req);
+    // A circular compose.include/exclude.valueSet import chain can't be expanded — resolveImportedValueSets below
+    // would silently skip the re-import and return a wrong 200, so detect the cycle up front and 4xx instead.
+    checkImportCycle(inlineVs, req);
 
     // P8: flatten any compose.include[].valueSet (imported value sets) into system+concept includes first.
     List<String> usedValueSets = new java.util.ArrayList<>();
@@ -1256,6 +1379,9 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     // pagination — so the response reflects the full set size and clients can
     // paginate without re-issuing a `count=0` discovery probe.
     int totalAfterFilter = expandedConcepts.size();
+    // Defend against an unbounded expansion too large to return in full (no count + over the cost threshold) —
+    // 4xx too-costly, mirroring the stored path. Paged requests are exempt.
+    enforceExpansionLimit(req, totalAfterFilter);
 
     // Apply paging
     Integer offset = req == null ? null : req.findParameter("offset").map(ParametersParameter::getValueInteger)

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -830,6 +830,96 @@ class ValueSetExpandOperationTest extends Specification {
 
 
   // ---------------------------------------------------------------------------
+  // big/* cost & cycle guards (tx-ecosystem 'big' suite)
+  //
+  // A value set whose compose.include/exclude.valueSet imports form a cycle, or
+  // an unbounded expansion that exceeds the cost threshold, must abort with a
+  // 4xx OperationOutcome (circular-reference / too-costly) instead of looping or
+  // returning a giant 200.
+  // ---------------------------------------------------------------------------
+
+  def "expand of a value set with a circular import chain is a 4xx circular-reference error"() {
+    given:
+    // big-circle-1 imports big-circle-2; big-circle-2 excludes big-circle-1 -> cycle. Both are bundled as
+    // tx-resources (as the validator does at runtime), so the import refs resolve and the cycle is detectable.
+    def bc1 = composeVs("http://hl7.org/fhir/test/ValueSet/big-circle-1",
+        "http://hl7.org/fhir/test/ValueSet/big-circle-2", null)
+    def bc2 = composeVs("http://hl7.org/fhir/test/ValueSet/big-circle-2",
+        null, "http://hl7.org/fhir/test/ValueSet/big-circle-1")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(bc1))
+        .addParameter(new Parameters.ParametersParameter("tx-resource").setResource(bc1))
+        .addParameter(new Parameters.ParametersParameter("tx-resource").setResource(bc2))
+
+    when:
+    operation.run(req)
+
+    then:
+    def e = thrown(FhirException)
+    e.statusCode == 422
+    e.issues[0].severity == org.hl7.fhir.r5.model.OperationOutcome.IssueSeverity.ERROR
+    e.issues[0].code == org.hl7.fhir.r5.model.OperationOutcome.IssueType.PROCESSING
+    e.issues[0].details.coding[0].code == "vs-invalid"
+  }
+
+  def "unbounded expand over the cost threshold is a 4xx too-costly error"() {
+    given:
+    conceptSupplementService.mergeSupplementsIntoExpansion(_, _) >> []
+    // 10001 members > the default 10000 limit, and no count param -> unbounded -> too-costly.
+    valueSetVersionConceptRepository.expandFromJson(_) >> (0..10000).collect { concept(it) }
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+
+    when:
+    operation.run(req)
+
+    then:
+    def e = thrown(FhirException)
+    e.statusCode == 422
+    e.issues[0].code == org.hl7.fhir.r5.model.OperationOutcome.IssueType.TOOCOSTLY
+  }
+
+  def "paged expand over the cost threshold returns the page, not too-costly"() {
+    given:
+    conceptSupplementService.mergeSupplementsIntoExpansion(_, _) >> []
+    valueSetVersionConceptRepository.expandFromJson(_) >> (0..10000).collect { concept(it) }
+    def inlineVs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    inlineVs.setUrl("http://example.org/inline")
+    inlineVs.setStatus("active")
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("valueSet").setResource(inlineVs))
+        .addParameter(new Parameters.ParametersParameter("count").setValueInteger(50))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 50
+    result.expansion.total == 10001
+  }
+
+  /** A zmei ValueSet whose compose imports/excludes another value set by url (for cycle tests). */
+  private static com.kodality.zmei.fhir.resource.terminology.ValueSet composeVs(String url, String includeRef, String excludeRef) {
+    def vs = new com.kodality.zmei.fhir.resource.terminology.ValueSet()
+    vs.setUrl(url)
+    vs.setVersion("5.0.0")
+    vs.setStatus("active")
+    def compose = new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetCompose()
+    if (includeRef != null) {
+      compose.setInclude([new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude().setValueSet([includeRef])])
+    }
+    if (excludeRef != null) {
+      compose.setExclude([new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetComposeInclude().setValueSet([excludeRef])])
+    }
+    vs.setCompose(compose)
+    return vs
+  }
+
+
+  // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Implements the two protective error modes the tx-ecosystem `big` suite requires of `$expand`/`$validate-code`, returning a 4xx `OperationOutcome` instead of a giant 200 or a wrong result.

### too-costly (`big-echo-no-limit`)
An **unbounded** `$expand` (no `count`) whose post-filter total exceeds a threshold → `error`/`too-costly`. The threshold is the `X-TOO-COSTLY-THRESHOLD` request header when present (the suite sets it to 1000 to make the limit deterministic regardless of the server's real ceiling), else a generous default (10000). **Paged** requests (any `count`) are exempt, so `big-echo-zero-fifty`/`-fifty-fifty` still page normally. Applied on both the stored-snapshot and inline expand paths.

### circular-reference (`big-circle-bang`, `big-circle-validate`)
`big-circle-1` imports `big-circle-2`, which **excludes** `big-circle-1` → a cycle. The import resolver previously skipped the re-import silently and returned a wrong 200. A pre-expansion walk over the import graph (resolving `compose.include`/`exclude.valueSet` refs through the same contained/tx-resource sources the expand uses, with a path-based cycle detector + a depth backstop of 20) now returns `error`/`processing`/`vs-invalid`. Covers both operations, which route through `expandInline`.

## Verification

- **Conformance** (full suite, mode general): **GAINED** `big-circle-bang`, `big-circle-validate`, `big-echo-no-limit`; **REGRESSED 0** (560 → 563).
- **Live smoke** against the dev server: unbounded `big` + header → 422 too-costly; `count=50` → 200 / 50-of-2000; circular expand & validate → 422 processing/vs-invalid.
- **Unit tests** (`ValueSetExpandOperationTest`): circular import → 422/processing/vs-invalid; unbounded-over-limit → 422/too-costly; paged-over-limit → returns the page.