### PR TITLE
fix(validate): 200 (not 400) for a relative or supplement Coding.system

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java
@@ -76,6 +76,10 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
         .map(pp -> StringUtils.firstNonBlank(pp.getValueUrl(), pp.getValueCanonical(), pp.getValueUri(), pp.getValueString()))
         .or(() -> req.findParameter("system")
             .map(pp -> StringUtils.firstNonBlank(pp.getValueUrl(), pp.getValueCanonical(), pp.getValueUri(), pp.getValueString())))
+        // A url-less $validate-code infers the code system from the supplied coding / codeableConcept system, so a
+        // coding naming (say) a supplement code system resolves to that CS and degrades to a 200 invalid-data rather
+        // than a 400 "url parameter required".
+        .or(() -> codingSystem(req))
         .orElse(null);
 
     // tx-resource / inline: validate against a CodeSystem supplied inline (the FHIR validator passes the
@@ -213,6 +217,20 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
   }
 
   /** Finds a CodeSystem supplied inline via a tx-resource parameter whose url matches the requested url. */
+  /** The code system url named by the request's {@code coding} / {@code codeableConcept} system — the fallback
+   *  source of the system for a url-less {@code $validate-code}. */
+  private static java.util.Optional<String> codingSystem(Parameters req) {
+    var coding = req.findParameter("coding").map(ParametersParameter::getValueCoding).orElse(null);
+    if (coding != null && StringUtils.isNotEmpty(coding.getSystem())) {
+      return java.util.Optional.of(coding.getSystem());
+    }
+    var cc = req.findParameter("codeableConcept").map(ParametersParameter::getValueCodeableConcept).orElse(null);
+    if (cc != null && cc.getCoding() != null) {
+      return cc.getCoding().stream().map(c -> c.getSystem()).filter(StringUtils::isNotEmpty).findFirst();
+    }
+    return java.util.Optional.empty();
+  }
+
   private static com.kodality.zmei.fhir.resource.terminology.CodeSystem findTxResourceCodeSystem(Parameters req, String url) {
     if (req.getParameter() == null || url == null) {
       return null;
@@ -249,6 +267,24 @@ public class CodeSystemValidateCodeOperation implements InstanceOperationDefinit
     }
     if (code == null) {
       throw new FhirException(400, IssueType.INVALID, "code, coding or codeableConcept parameter required");
+    }
+
+    // A supplement code system is not a usable Coding.system: the reference degrades to a 200 result=false with an
+    // invalid-data issue, not a 400. (A url-less validate naming a supplement resolves to the bundled supplement CS.)
+    if ("supplement".equals(inlineCs.getContent())) {
+      String csRef = inlineCs.getUrl() + (StringUtils.isNotEmpty(inlineCs.getVersion()) ? "|" + inlineCs.getVersion() : "");
+      String message = "CodeSystem " + csRef + " is a supplement, so can't be used as a value in Coding.system";
+      String systemLoc = req.findParameter("codeableConcept").isPresent() ? "CodeableConcept.coding[0].system" : "Coding.system";
+      Parameters supplement = new Parameters()
+          .addParameter(new ParametersParameter("result").setValueBoolean(false))
+          .addParameter(new ParametersParameter("code").setValueCode(code));
+      if (StringUtils.isNotEmpty(inlineCs.getUrl())) {
+        supplement.addParameter(new ParametersParameter("system").setValueUri(inlineCs.getUrl()));
+      }
+      supplement.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+          org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "invalid-data", message, systemLoc))));
+      supplement.addParameter(new ParametersParameter("message").setValueString(message));
+      return supplement;
     }
 
     String finalCode = code;

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -672,6 +672,12 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     return req.findParameter("coding").isPresent() ? "Coding.system" : "system";
   }
 
+  /** A Coding.system is a relative/local reference when it carries no URI scheme (e.g. "Location1" vs
+   *  "http://…" or "urn:…") — FHIR requires an absolute reference, so the reference reports it as invalid-data. */
+  private static boolean isRelativeSystem(String system) {
+    return system != null && !system.matches("[a-zA-Z][a-zA-Z0-9+.\\-]*:.*");
+  }
+
   /**
    * The "Valid display is …" clause of the invalid-display message, mirroring org.hl7.fhir.core. The valid
    * displays are the member's primary display (tagged with the code system's language) plus its designations
@@ -1809,6 +1815,23 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       parameters.addParameter(new ParametersParameter("result").setValueBoolean(false));
       parameters.addParameter(new ParametersParameter("system").setValueUri(system));
       parameters.addParameter(new ParametersParameter("x-caused-by-unknown-system").setValueCanonical(system));
+    } else if (isRelativeSystem(system)) {
+      // A relative/local Coding.system (e.g. "Location1", not an absolute URI). The reference returns 200 with
+      // THREE issues — not-in-vs at the code, an invalid-data "must be an absolute reference" at the system, and
+      // not-found (system QUOTED) at the system — plus x-unknown-system. (The request-layer validator tolerates the
+      // relative system on a $validate-code input so this graceful envelope can be produced; see
+      // ProfileTolerantResourceValidator.) The message lists not-found, then the relative error, then not-in-vs.
+      String notInVs = String.format("The provided code '%s#%s' was not found in the value set '%s'", system, code, vsCanonical);
+      String relative = "Coding.system must be an absolute reference, not a local reference";
+      String notFound = String.format("A definition for CodeSystem '%s' could not be found, so the code cannot be validated", system);
+      parameters.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+          org.termx.terminology.fhir.TxIssues.issue("error", "code-invalid", "not-in-vs", notInVs, codeLoc),
+          org.termx.terminology.fhir.TxIssues.issue("error", "invalid", "invalid-data", relative, systemLoc),
+          org.termx.terminology.fhir.TxIssues.issue("error", "not-found", "not-found", notFound, systemLoc))));
+      parameters.addParameter(new ParametersParameter("message").setValueString(notFound + "; " + relative + "; " + notInVs));
+      parameters.addParameter(new ParametersParameter("result").setValueBoolean(false));
+      parameters.addParameter(new ParametersParameter("system").setValueUri(system));
+      parameters.addParameter(new ParametersParameter("x-unknown-system").setValueCanonical(system));
     } else {
       // The unknown system is NOT one the value set includes: the code is additionally not in the value set, so
       // TWO issues — not-in-vs at `code` plus not-found at `system` (system url UNquoted here) — and the system is

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperationTest.groovy
@@ -89,6 +89,34 @@ class CodeSystemValidateCodeOperationTest extends Specification {
     !bool(resp, "result")
   }
 
+  def "a coding naming a supplement code system degrades to a 200 invalid-data, not a 400"() {
+    // A url-less $validate-code whose coding.system is a (bundled) supplement code system must not 400 ('url
+    // parameter required' / supplement rejected) — the reference returns 200 result=false with an invalid-data issue.
+    given:
+    def supplement = new com.kodality.zmei.fhir.resource.terminology.CodeSystem()
+    supplement.setUrl("http://hl7.org/fhir/test/CodeSystem/supplement")
+    supplement.setVersion("0.1.1")
+    supplement.setContent("supplement")
+    def req = new Parameters()
+        .addParameter(new ParametersParameter("coding").setValueCoding(
+            new com.kodality.zmei.fhir.datatypes.Coding("http://hl7.org/fhir/test/CodeSystem/supplement", "code1")))
+        .addParameter(new ParametersParameter("tx-resource").setResource(supplement))
+
+    when:
+    def resp = parse(operation.run(new ResourceContent(FhirMapper.toJson(req), "json")))
+
+    then:
+    !bool(resp, "result")
+    resp.findParameter("code").get().valueCode == "code1"
+    resp.findParameter("system").get().valueUri == "http://hl7.org/fhir/test/CodeSystem/supplement"
+    def oo = resp.findParameter("issues").get().resource as com.kodality.zmei.fhir.resource.other.OperationOutcome
+    oo.issue.size() == 1
+    oo.issue[0].code == "invalid"
+    oo.issue[0].details.coding[0].code == "invalid-data"
+    oo.issue[0].details.text.contains("is a supplement, so can't be used as a value in Coding.system")
+    oo.issue[0].location == ["Coding.system"]
+  }
+
   private ResourceContent invoke(Map<String, String> params) {
     Parameters req = new Parameters()
     params.each { k, v -> req.addParameter(new ParametersParameter(k).setValueString(v)) }

--- a/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
+++ b/termx-app/src/main/java/org/termx/fhir/ProfileTolerantResourceValidator.java
@@ -60,6 +60,16 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
       "CODESYSTEM_CS_NO_VS_SUPPLEMENT1",
       "CODESYSTEM_CS_NO_VS_SUPPLEMENT2");
 
+  // A relative/local Coding.system in a $validate-code (or $expand) operation INPUT is a data issue the operation
+  // reports gracefully (a 200 with an invalid-data issue + x-unknown-system), NOT a request-structure 400 — the
+  // reference tx server returns 200. So tolerate it on operation inputs only; a stored resource SAVE with a local
+  // reference is still rejected. Matched by message-id, with a text fallback in case the validator omits the id.
+  private static final String RELATIVE_SYSTEM_MESSAGE = "Coding.system must be an absolute reference, not a local reference";
+
+  private static boolean isToleratedOperationInputMessage(SingleValidationMessage m) {
+    return "Terminology_TX_System_Relative".equals(m.getMessageId()) || RELATIVE_SYSTEM_MESSAGE.equals(m.getMessage());
+  }
+
   @Inject
   private ResourceFormatService resourceFormatService;
   @Inject
@@ -116,6 +126,7 @@ public class ProfileTolerantResourceValidator extends ResourceBeforeSaveIntercep
           .filter(m -> isError(m.getSeverity()))
           .filter(m -> !isUncheckedProfile(m))
           .filter(m -> !TOLERATED_BEST_PRACTICE_MESSAGE_IDS.contains(m.getMessageId()))
+          .filter(m -> !(operationInput && isToleratedOperationInputMessage(m)))
           .filter(m -> !(operationInput && isInsideParameterResource(m.getLocationString())))
           .collect(toList());
       if (!errors.isEmpty()) {


### PR DESCRIPTION
## What

Two `$validate-code` inputs the reference tx server returns **200** for, but termx rejected with a **400** at the request layer.

### relative `Coding.system` (`validation-simple-coding-bad-system-local`)
A coding like `{system: "Location1", code: "code1"}` — "Location1" is a relative/local reference. The HAPI instance validator run on the operation input raised *"Coding.system must be an absolute reference, not a local reference"* and 400'd before the operation ran.
- **Request layer**: tolerate that one message on operation **inputs only** (a stored-resource save with a local reference is still rejected).
- **Operation**: `unknownSystem` now emits the reference's three-issue envelope for a relative system — `not-in-vs` at the code, `invalid-data` (must be an absolute reference) at the system, `not-found` (system quoted) at the system — plus `result=false`, `system`, `x-unknown-system`.

### url-less supplement (`validate-coding-bad-supplement-url`)
A `CodeSystem/$validate-code` with just a coding whose system is a supplement code system. termx 400'd with *"url parameter required"*.
- Infer the system from the `coding`/`codeableConcept` (no `url` needed).
- When the resolved CS is `content=supplement`, degrade to **200** `result=false` with an `invalid-data` issue (*"… is a supplement, so can't be used as a value in Coding.system"*).

## Verification
- **Conformance** (full suite, mode general): **GAINED** `validation-simple-coding-bad-system-local`, `validate-coding-bad-supplement-url`; **REGRESSED 0** (560 → 562).
- **Live smoke** with harness-bundled tx-resources: both exact-match the expected fixtures (3-issue envelope / invalid-data).
- **Unit test** (`CodeSystemValidateCodeOperationTest`): the supplement case.