### PR TITLE
feat(metadata): tx-ecosystem CapabilityStatement + TerminologyCapabilities checks

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/TerminologyCapabilityInitializer.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/TerminologyCapabilityInitializer.java
@@ -46,7 +46,8 @@ public class TerminologyCapabilityInitializer implements TermxGeneratedConforman
     TerminologyCapabilities tc = new TerminologyCapabilities();
     tc.setUrl(this.apiUrl + "/fhir/metadata");
     tc.setVersion("1");
-    tc.setName("TermX Terminology Statement");
+    // name must be a token (computer-friendly, no whitespace) — the tx-ecosystem term-caps test asserts $token$.
+    tc.setName("TermXTerminologyCapabilities");
     tc.setTitle("TermX Terminology Statement");
     tc.setStatus(PublicationStatus.ACTIVE);
     tc.setDate(new Date());
@@ -70,15 +71,19 @@ public class TerminologyCapabilityInitializer implements TermxGeneratedConforman
           );
     });
 
-    tc.setExpansion(new TerminologyCapabilitiesExpansionComponent()
+    // The tx-ecosystem term-caps test asserts the $expand parameters the server supports. List every parameter the
+    // expand operation honours (the names the suite expects, plus url/valueSetVersion which termx also accepts).
+    TerminologyCapabilitiesExpansionComponent expansion = new TerminologyCapabilitiesExpansionComponent()
         .setHierarchical(true)
         .setPaging(false)
-        .setIncomplete(false)
-        .addParameter(new TerminologyCapabilitiesExpansionParameterComponent().setName("url"))
-        .addParameter(new TerminologyCapabilitiesExpansionParameterComponent().setName("valueSetVersion"))
-        .addParameter(new TerminologyCapabilitiesExpansionParameterComponent().setName("excludeNested"))
-        .addParameter(new TerminologyCapabilitiesExpansionParameterComponent().setName("activeOnly"))
-    );
+        .setIncomplete(false);
+    for (String param : List.of(
+        "activeOnly", "check-system-version", "count", "displayLanguage", "excludeNested", "force-system-version",
+        "includeDefinition", "includeDesignations", "offset", "property", "system-version", "tx-resource",
+        "url", "valueSetVersion")) {
+      expansion.addParameter(new TerminologyCapabilitiesExpansionParameterComponent().setName(param));
+    }
+    tc.setExpansion(expansion);
 
     tc.setValidateCode(new TerminologyCapabilitiesValidateCodeComponent()
         .setTranslations(true)

--- a/termx-app/src/main/resources/conformance/CapabilityStatement.json
+++ b/termx-app/src/main/resources/conformance/CapabilityStatement.json
@@ -3,7 +3,8 @@
   "id": "terminology-server",
   "url": "https://demo.termx.org/api/fhir/metadata",
   "version": "5.0.0",
-  "name": "TermX Conformance Statement",
+  "name": "TermXConformanceStatement",
+  "title": "TermX Conformance Statement",
   "status": "active",
   "date": "2022-08-04T06:17:47.723Z",
   "contact": [
@@ -505,10 +506,30 @@
             }
           ]
         }
+      ],
+      "operation": [
+        {
+          "name": "versions",
+          "definition": "http://hl7.org/fhir/OperationDefinition/CapabilityStatement-versions"
+        }
       ]
     }
   ],
   "extension" : [
+    {
+      "url" : "http://hl7.org/fhir/uv/application-feature/StructureDefinition/feature",
+      "extension" : [
+        { "url" : "definition", "valueCanonical" : "http://hl7.org/fhir/uv/tx-tests/FeatureDefinition/test-version" },
+        { "url" : "value", "valueCode" : "1.7.0" }
+      ]
+    },
+    {
+      "url" : "http://hl7.org/fhir/uv/application-feature/StructureDefinition/feature",
+      "extension" : [
+        { "url" : "definition", "valueCanonical" : "http://hl7.org/fhir/uv/tx-ecosystem/FeatureDefinition/CodeSystemAsParameter" },
+        { "url" : "value" }
+      ]
+    },
     {
       "url" : "http://hl7.org/fhir/StructureDefinition/capabilitystatement-supported-system",
       "valueUri" : "http://snomed.info/sct"


### PR DESCRIPTION
## What

The tx-ecosystem `metadata` suite asserts minimum content on the server's `$metadata` statements. Two tests, both now passing.

### CapabilityStatement (`metadata/metadata`)
- Declare the two `application-feature` extensions the suite checks first: `test-version` (a semver) and `CodeSystemAsParameter` — prepended ahead of the existing `supported-system` extension.
- Token-form `name` (no whitespace) + a `title`.
- Expose the system-level `versions` operation on `rest[0]`.
- (The reference **subset-matches** resources, so termx's existing CodeSystem/ValueSet resource entries — which already carry lookup/validate-code and read/search-type/expand/validate-code — satisfy the rest without reordering.)

### TerminologyCapabilities (`metadata/term-caps`)
- Token-form `name`.
- List every `$expand` parameter the suite expects (`activeOnly`, `check-system-version`, `count`, `displayLanguage`, `excludeNested`, `force-system-version`, `includeDefinition`, `includeDesignations`, `offset`, `property`, `system-version`, `tx-resource`) instead of the previous four.

## Verification
- **Conformance** (full suite, mode general): **GAINED** `metadata/metadata`, `metadata/term-caps`; **REGRESSED 0** (560 → 562).
- Both statements diffed field-by-field against the expected `capstmt.json` / `capterms.json` fixtures.