### PR TITLE
fix: ValueSet expansion (inline version-URI, mutable array columns) + designation use round-trip

### DIFF
--- a/kodality-commons/commons-db/src/main/java/com/kodality/commons/db/resultset/ResultSetUtil.java
+++ b/kodality-commons/commons-db/src/main/java/com/kodality/commons/db/resultset/ResultSetUtil.java
@@ -26,12 +26,16 @@ public class ResultSetUtil {
 
   public static <T> List<T> getArray(ResultSet rs, int columnIndex) throws SQLException {
     Array arr = rs.getArray(columnIndex);
-    return arr == null ? null : Arrays.asList((T[]) arr.getArray());
+    // Return a mutable list: Arrays.asList yields a fixed-size view whose add/remove throw
+    // UnsupportedOperationException, so callers that mutate a loaded array column would crash.
+    return arr == null ? null : new ArrayList<>(Arrays.asList((T[]) arr.getArray()));
   }
 
   public static <T> List<T> getArray(ResultSet rs, String columnLabel) throws SQLException {
     Array arr = rs.getArray(columnLabel);
-    return arr == null ? null : Arrays.asList((T[]) arr.getArray());
+    // Return a mutable list: Arrays.asList yields a fixed-size view whose add/remove throw
+    // UnsupportedOperationException, so callers that mutate a loaded array column would crash.
+    return arr == null ? null : new ArrayList<>(Arrays.asList((T[]) arr.getArray()));
   }
 
   public static Long getLong(ResultSet rs, String columnLabel) throws SQLException {

--- a/kodality-commons/commons-db/src/test/groovy/com/kodality/commons/db/resultset/ResultSetUtilSpec.groovy
+++ b/kodality-commons/commons-db/src/test/groovy/com/kodality/commons/db/resultset/ResultSetUtilSpec.groovy
@@ -2,9 +2,51 @@ package com.kodality.commons.db.resultset
 
 import spock.lang.Specification
 
+import java.sql.Array
 import java.sql.ResultSet
 
 class ResultSetUtilSpec extends Specification {
+
+  def "getArray(int) returns a mutable list"() {
+    given:
+    ResultSet rs = Mock()
+    Array arr = Mock()
+    rs.getArray(1) >> arr
+    arr.getArray() >> (["a", "b"] as String[])
+
+    when:
+    def list = new ResultSetUtil().getArray(rs, 1)
+    list.add("c")
+
+    then:
+    notThrown(UnsupportedOperationException)
+    list == ["a", "b", "c"]
+  }
+
+  def "getArray(label) returns a mutable list"() {
+    given:
+    ResultSet rs = Mock()
+    Array arr = Mock()
+    rs.getArray("details") >> arr
+    arr.getArray() >> (["a", "b"] as String[])
+
+    when:
+    def list = new ResultSetUtil().getArray(rs, "details")
+    list.add("c")
+
+    then:
+    notThrown(UnsupportedOperationException)
+    list == ["a", "b", "c"]
+  }
+
+  def "getArray returns null for a null SQL array"() {
+    given:
+    ResultSet rs = Mock()
+    rs.getArray("details") >> null
+
+    expect:
+    new ResultSetUtil().getArray(rs, "details") == null
+  }
 
   def result = makeResultSet(
       ["id", "name"],

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -101,8 +101,16 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
     return use.getCode();
   }
 
-  /** The use Coding for an exported designation: a known designation-property name → its {system, code}; otherwise a bare code. Shared with $expand/$lookup. */
+  /**
+   * The use Coding for an exported designation: a known designation-property name → its {system, code};
+   * otherwise a bare code. Shared with $expand/$lookup. Returns {@code null} for the {@link #ALTERNATE}
+   * marker — that internal type records a designation imported WITHOUT a use (FHIR: absence of use ≠
+   * "display"), so it must round-trip with no use rather than leaking the marker as a bare code.
+   */
   public static Coding designationUseCoding(String designationType) {
+    if (ALTERNATE.equals(designationType)) {
+      return null;
+    }
     String[] sysCode = DESIGNATION_NAME_USE.get(designationType);
     return sysCode != null ? new Coding(sysCode[0], sysCode[1]) : new Coding(designationType);
   }

--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/37-value_set_expand_jsonb.sql
@@ -131,7 +131,8 @@ WITH recursive vs AS (
          inner join terminology.code_system cs on cs.uri = t."system" and cs.sys_status = 'A'
          left outer join terminology.code_system bcs on bcs.id = cs.base_code_system and bcs.sys_status = 'A'
          inner join terminology.code_system_version csv on csv.code_system = cs.id and csv.sys_status = 'A'
-                and ((t.version is not null and csv."version" = t.version ) or
+                -- match the business version OR the version's canonical URI — see note below.
+                and ((t.version is not null and (csv."version" = t.version or csv.uri = t.version)) or
                      (t.version is null and csv.id = (select t2.id
                                                         from terminology.code_system_version t2
                                                        where t2.code_system = cs.id
@@ -174,7 +175,10 @@ WITH recursive vs AS (
          inner join terminology.code_system cs on cs.uri = r."system" and cs.sys_status = 'A'
          left outer join terminology.code_system bcs on bcs.id = cs.base_code_system and bcs.sys_status = 'A'
          inner join terminology.code_system_version csv on csv.code_system = cs.id and csv.sys_status = 'A'
-                and ((r.version is not null and csv."version" = r.version ) or
+                -- compose.include.version may carry the business version OR the version's canonical
+                -- URI (ValueSetFhirMapper emits the URI when code_system_version.uri is set), so match
+                -- either — otherwise URI-versioned inline expansions resolve no code system version.
+                and ((r.version is not null and (csv."version" = r.version or csv.uri = r.version)) or
                      (r.version is null and csv.id = (select t2.id
                                                         from terminology.code_system_version t2
                                                        where t2.code_system = cs.id
@@ -420,7 +424,10 @@ WITH recursive vs AS (
          inner join terminology.code_system cs on cs.uri = r."system" and cs.sys_status = 'A'
          left outer join terminology.code_system bcs on bcs.id = cs.base_code_system and bcs.sys_status = 'A'
          inner join terminology.code_system_version csv on csv.code_system = cs.id and csv.sys_status = 'A'
-                and ((r.version is not null and csv."version" = r.version ) or
+                -- compose.include.version may carry the business version OR the version's canonical
+                -- URI (ValueSetFhirMapper emits the URI when code_system_version.uri is set), so match
+                -- either — otherwise URI-versioned inline expansions resolve no code system version.
+                and ((r.version is not null and (csv."version" = r.version or csv.uri = r.version)) or
                      (r.version is null and csv.id = (select t2.id
                                                         from terminology.code_system_version t2
                                                        where t2.code_system = cs.id

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ValueSetExpandDesignationIT.groovy
@@ -55,10 +55,9 @@ class ValueSetExpandDesignationIT extends TermxIntegTest {
     syn.use.system == "http://snomed.info/sct"
     syn.use.code == "900000000000013009"
 
-    and: "a plain (display-type) designation uses the standard designation-usage system, not a bare code"
+    and: "a designation imported WITHOUT a use round-trips with no use (FHIR: absence of use is NOT 'display'; #329)"
     def et = contains.designation.find { it.language == "et" }
-    et.use.system == "http://terminology.hl7.org/CodeSystem/designation-usage"
-    et.use.code == "display"
+    et.use == null
   }
 
   def "includeDesignations with no designation filter returns every designation"() {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandInlineFilterOperatorIT.groovy
@@ -9,6 +9,8 @@ import org.termx.core.auth.SessionInfo
 import org.termx.core.auth.SessionStore
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
 import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionRepository
+import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
 import org.termx.ts.codesystem.CodeSystemImportAction
 
@@ -34,6 +36,8 @@ class ValueSetExpandInlineFilterOperatorIT extends TermxIntegTest {
   @Inject CodeSystemImportService importService
   @Inject CodeSystemFhirMapper fhirMapper
   @Inject ValueSetVersionConceptRepository conceptRepository
+  @Inject CodeSystemVersionService codeSystemVersionService
+  @Inject CodeSystemVersionRepository codeSystemVersionRepository
 
   static final String CS_ID = "vsexpand-filter-cs"
   static final String CS_URI = "http://termx-test.local/CodeSystem/vsexpand-filter-cs"
@@ -140,16 +144,30 @@ class ValueSetExpandInlineFilterOperatorIT extends TermxIntegTest {
     expandInline("parent", "=", "A") == ["B", "C"] as Set
   }
 
+  def "include.version is resolved by the version's canonical URI, not only the business version"() {
+    given: "the code system version carries a canonical URI, as FHIR-defined nomenclatures do"
+    def versionUri = CS_URI + "|" + CS_VERSION
+    def version = codeSystemVersionService.load(CS_ID, CS_VERSION).orElseThrow()
+    version.setUri(versionUri)
+    codeSystemVersionRepository.save(version)
+
+    expect: "expanding with include.version = the canonical URI resolves the same concepts as the business version"
+    // ValueSetFhirMapper emits the version URI (not '1.0.0') in compose.include.version when the
+    // version has a uri; the rule-preview/$expand path must still resolve it. Before this fix, it
+    // returned an empty set because value_set_expand(text) only matched csv.version.
+    expandInline("method", "=", "CHROM", versionUri) == ["A", "B"] as Set
+  }
+
   // --- helpers ---------------------------------------------------------------
 
-  private Set<String> expandInline(String property, String op, Object value) {
+  private Set<String> expandInline(String property, String op, Object value, String version = CS_VERSION) {
     def valueSet = [
         resourceType: "ValueSet",
         compose      : [
             inactive: false,
             include : [[
                            system : CS_URI,
-                           version: CS_VERSION,
+                           version: version,
                            filter : [[property: property, op: op, value: value]]
                        ]]
         ]

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandPinnedVersionIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandPinnedVersionIT.groovy
@@ -1,0 +1,141 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.codesystem.CodeSystemVersionReference
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import spock.lang.PendingFeature
+
+import java.time.LocalDate
+
+/**
+ * A ValueSet rule pinned to a specific CodeSystem version must expand to ONLY that
+ * version's members. The stored-version path {@code terminology.value_set_expand(bigint)}
+ * ({@code 01-value_set_expand.sql}) currently applies a cumulative {@code release_date <=} fallback:
+ * a concept that is NOT a member of the pinned version but WAS a member of an earlier version is
+ * pulled forward and returned (tagged with the earlier version). For a code system whose versions
+ * are full releases this over-includes retired/removed concepts.
+ *
+ * <p>The fallback was introduced in {@code 5af30777} ("TEHIK fixes") to support delta-versioned code
+ * systems (each version carries only changed concepts), where pulling earlier concepts forward is
+ * required to reconstruct the full set. Any fix therefore must keep delta semantics working while
+ * making full-release pins strict — so this regression is captured as a {@link PendingFeature}
+ * until that behaviour is decided/implemented.
+ *
+ * <p>Fixture: code system {@code vsexpand-pinned-cs} imported as two full releases —
+ * <pre>
+ *   1.0.0 : [keep, drop]
+ *   2.0.0 : [keep]            // 'drop' absent from 2.0.0, still ACTIVE in 1.0.0 (not retired)
+ * </pre>
+ * A ValueSet pinned to 2.0.0 (all concepts) must expand to [keep], not [keep, drop].
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandPinnedVersionIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper fhirMapper
+  @Inject CodeSystemVersionService codeSystemVersionService
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptRepository conceptRepository
+
+  static final String CS_ID = "vsexpand-pinned-cs"
+  static final String CS_URI = "http://termx-test.local/CodeSystem/vsexpand-pinned-cs"
+  static final String VS_ID = "vsexpand-pinned-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    // Distinct release dates (1.0.0 before 2.0.0): the cumulative fallback keys on
+    // 'release_date <= pinned version release_date', so the dates must be set for it to fire.
+    importCs("1.0.0", ["keep", "drop"], LocalDate.of(2026, 1, 1))
+    // import 2.0.0 WITHOUT cleanRun so 'drop' is not retired — it stays an active member of 1.0.0
+    // only and is simply absent from 2.0.0's membership (this shape).
+    importCs("2.0.0", ["keep"], LocalDate.of(2026, 2, 1))
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  @PendingFeature(reason = "Known gap: stored expansion pinned to a version still pulls concepts forward from earlier versions (cumulative release_date<= fallback added in 5af30777 for delta-versioned code systems)")
+  def "expansion pinned to a CodeSystem version returns only that version's members"() {
+    expect:
+    expandPinnedTo("2.0.0") == ["keep"] as Set
+  }
+
+  def "sanity: expansion pinned to the older version returns its full member set"() {
+    expect:
+    expandPinnedTo("1.0.0") == ["keep", "drop"] as Set
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private Set<String> expandPinnedTo(String codeSystemVersion) {
+    def versionId = codeSystemVersionService.load(CS_ID, codeSystemVersion).orElseThrow().getId()
+    // Use a property FILTER (grp = x), not an all-concepts rule: in 01-value_set_expand.sql only the
+    // filter/hierarchy CTEs carry the cumulative release_date<= fallback (the all-concepts cs_all CTE
+    // is already strict), and the affected (customer) value set is filter-based.
+    def rule = new ValueSetVersionRule()
+        .setType("include")
+        .setCodeSystem(CS_ID)
+        .setCodeSystemVersion(new CodeSystemVersionReference().setId(versionId).setVersion(codeSystemVersion))
+        .setFilters([new ValueSetVersionRule.ValueSetRuleFilter()
+            .setProperty(new PropertyReference().setName("grp")).setOperator("=").setValue("x")])
+
+    def version = new ValueSetVersion()
+        .setStatus(PublicationStatus.draft)
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Pinned version expansion")))
+    request.setVersion(version)
+    valueSetService.save(request)
+
+    def vsVersionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+    return conceptRepository.expand(vsVersionId).collect { it.concept?.code }.findAll { it != null } as Set
+  }
+
+  private void importCs(String version, List<String> codes, LocalDate releaseDate) {
+    def concepts = codes.collect {
+      "{\"code\": \"${it}\", \"display\": \"${it}\", \"property\": [{\"code\": \"grp\", \"valueString\": \"x\"}]}"
+    }.join(",")
+    def json = """
+      {
+        "resourceType": "CodeSystem",
+        "url": "${CS_URI}",
+        "version": "${version}",
+        "status": "active",
+        "content": "complete",
+        "property": [{"code": "grp", "type": "string"}],
+        "concept": [${concepts}]
+      }
+    """
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    def cs = fhirMapper.fromFhirCodeSystem(fhir)
+    cs.versions.each { it.setReleaseDate(releaseDate) }
+    importService.importCodeSystem(cs, [], new CodeSystemImportAction().setActivate(true).setCleanRun(false).setCleanConceptRun(false))
+  }
+}


### PR DESCRIPTION
Bug fixes found while investigating two customer reports about ValueSet expansion, plus a related commons-db crash.

## Fixes
- **commons-db `ResultSetUtil.getArray` returned a fixed-size list.** `Arrays.asList(...)` throws on `add`/`remove`; any caller mutating a loaded `text[]` column crashed (root cause of the SNOMED import poller crash-loop). Now wrapped in a mutable `ArrayList`. Regression tests added.
- **Inline `$expand` / rule-preview returned empty for URI-versioned code systems.** `value_set_expand(text)` (function 37) resolved a rule's CS version only by `csv.version = include.version`, but `ValueSetFhirMapper` emits the version's **canonical URI** in `compose.include.version` when the version has a `uri`. Now matches `csv.version` OR `csv.uri`, mirroring the stored path. (Fixes the empty "Rule expansion preview".)
- **Use-less designations leaked an internal marker as a fake `use`.** A designation imported without a `use` is stored as the internal `alternate` type (#329, "absence of use ≠ display"); `$expand`/`$lookup`/export emitted `use = {code: alternate}`. `designationUseCoding` now returns `null` for `alternate`, so a use-less designation round-trips with no `use`. Stale test updated.

## Tests
- `ResultSetUtilSpec` — mutable-list contract (3 cases).
- `ValueSetExpandInlineFilterOperatorIT` — version resolved by canonical URI.
- `ValueSetExpandDesignationIT` — use-less designation has no `use`.
- `ValueSetExpandPinnedVersionIT` — **new**, pins the pinned-version cumulative-fallback regression as a `@PendingFeature` (see Known gaps).

Verified: full `terminology.valueset.*` + `terminology.fhir.*` integration suite green except the pre-existing supplement gaps below (unchanged by this PR).

## Known gaps (deferred, not introduced here)
- Stored expansion pinned to a version still pulls earlier-version concepts forward (cumulative `release_date<=` fallback). Pinned by the new `@PendingFeature` test; resolution depends on a full-release-vs-delta decision and the planned 01/37 expansion-engine unification.
- `ValueSetSupplementExpandIT`: bare-code `$validate-code` (no system) and surfacing a supplement designation that is also the chosen display (tx-ecosystem #16/#17) — conformance gaps tracked for the same unification work.