### PR TITLE
ValueSet expansion unification — strict per-version + engine-parity gate

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
+++ b/terminology/src/main/resources/terminology/changelog/terminology/functions/01-value_set_expand.sql
@@ -55,15 +55,7 @@ exact_concepts as (
          left outer join terminology.entity_version_code_system_version_membership evcsvm
                  on evcsvm.sys_status = 'A'
                 and csev.id = evcsvm.code_system_entity_version_id
-                and (evcsvm.code_system_version_id = t.code_system_version_id
-                      or evcsvm.code_system_version_id in (
-                          select csv2.id
-                            from terminology.code_system_version csv2
-                           where csv2.code_system = t.code_system
-                             and csv2.sys_status = 'A'
-                             and csv2.release_date <= (select csv3.release_date
-                                                         from terminology.code_system_version csv3
-                                                        where csv3.id = t.code_system_version_id)))
+                and evcsvm.code_system_version_id = t.code_system_version_id -- strict: pinned version expands to exactly its own members (no cumulative carry-forward; FHIR has no cross-version delta semantics)
    where (evcsvm.id is not null or cs.content = 'not-present')
      and not exists (
          select 1
@@ -100,15 +92,7 @@ expressions as (
            inner join terminology.entity_version_code_system_version_membership evcsvm
                    on evcsvm.sys_status = 'A'
                   and csev.id = evcsvm.code_system_entity_version_id
-                  and (evcsvm.code_system_version_id = t.code_system_version_id
-                        or evcsvm.code_system_version_id in (
-                            select csv2.id
-                              from terminology.code_system_version csv2
-                             where csv2.code_system = t.code_system
-                               and csv2.sys_status = 'A'
-                               and csv2.release_date <= (select csv3.release_date
-                                                           from terminology.code_system_version csv3
-                                                          where csv3.id = t.code_system_version_id)))
+                  and evcsvm.code_system_version_id = t.code_system_version_id -- strict: pinned version expands to exactly its own members (no cumulative carry-forward; FHIR has no cross-version delta semantics)
            inner join terminology.code_system_version csv
                    on csv.id = evcsvm.code_system_version_id and csv.sys_status = 'A'
      where (t.filter_ ->> 'operator')::text = any(array['is-a','descendent-of', 'child-of', 'is-not-a', 'descendent-leaf'])
@@ -148,15 +132,7 @@ expressions as (
            inner join terminology.entity_version_code_system_version_membership evcsvm
                    on evcsvm.sys_status = 'A'
                   and csev.id = evcsvm.code_system_entity_version_id
-                  and (evcsvm.code_system_version_id = t.code_system_version_id
-                        or evcsvm.code_system_version_id in (
-                            select csv2.id
-                              from terminology.code_system_version csv2
-                             where csv2.code_system = t.code_system
-                               and csv2.sys_status = 'A'
-                               and csv2.release_date <= (select csv3.release_date
-                                                           from terminology.code_system_version csv3
-                                                          where csv3.id = t.code_system_version_id)))
+                  and evcsvm.code_system_version_id = t.code_system_version_id -- strict: pinned version expands to exactly its own members (no cumulative carry-forward; FHIR has no cross-version delta semantics)
            inner join terminology.code_system_version csv
                    on csv.id = evcsvm.code_system_version_id and csv.sys_status = 'A'
      where (t.filter_ ->> 'operator')::text = 'generalizes'
@@ -205,15 +181,7 @@ expressions as (
            inner join terminology.entity_version_code_system_version_membership evcsvm
                    on evcsvm.sys_status = 'A'
                   and csev.id = evcsvm.code_system_entity_version_id
-                  and (evcsvm.code_system_version_id = t.code_system_version_id
-                        or evcsvm.code_system_version_id in (
-                            select csv2.id
-                              from terminology.code_system_version csv2
-                             where csv2.code_system = t.code_system
-                               and csv2.sys_status = 'A'
-                               and csv2.release_date <= (select csv3.release_date
-                                                           from terminology.code_system_version csv3
-                                                          where csv3.id = t.code_system_version_id)))
+                  and evcsvm.code_system_version_id = t.code_system_version_id -- strict: pinned version expands to exactly its own members (no cumulative carry-forward; FHIR has no cross-version delta semantics)
            inner join terminology.code_system_version csv
                    on csv.id = evcsvm.code_system_version_id and csv.sys_status = 'A'
      where t.filters is not null

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandEngineParityIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandEngineParityIT.groovy
@@ -1,0 +1,141 @@
+package org.termx.terminology.valueset
+
+import com.kodality.commons.model.LocalizedName
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirMapper
+import org.termx.terminology.fhir.valueset.ValueSetFhirMapper
+import org.termx.terminology.terminology.codesystem.CodeSystemImportService
+import org.termx.terminology.terminology.valueset.ValueSetService
+import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptRepository
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.codesystem.CodeSystemImportAction
+import org.termx.ts.property.PropertyReference
+import org.termx.ts.valueset.ValueSet
+import org.termx.ts.valueset.ValueSetTransactionRequest
+import org.termx.ts.valueset.ValueSetVersion
+import org.termx.ts.valueset.ValueSetVersionConcept
+import org.termx.ts.valueset.ValueSetVersionRuleSet
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
+import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule.ValueSetRuleFilter
+import spock.lang.Unroll
+
+/**
+ * Engine-parity gate for the planned 01/37 expansion unification. The two SQL engines —
+ * {@code value_set_expand(bigint)} (stored, fn01, via {@link ValueSetVersionConceptRepository#expand})
+ * and {@code value_set_expand(text)} (inline, fn37, via {@link ValueSetVersionConceptRepository#expandFromJson})
+ * — must return the SAME concept set for the same value-set definition. This expands one stored version
+ * through BOTH paths (fn37 is fed the FHIR JSON produced by {@link ValueSetFhirMapper#toFhir}) and asserts
+ * equality, so any future divergence (or the eventual single-engine swap) is caught here.
+ *
+ * <p>Fixture {@code cs-hierarchy.json}: A(method=CHROM), B(method=CHROM)→A, C→A, D→B, X (separate root).
+ */
+@MicronautTest(transactional = true)
+class ValueSetExpandEngineParityIT extends TermxIntegTest {
+  @Inject CodeSystemImportService importService
+  @Inject CodeSystemFhirMapper csFhirMapper
+  @Inject ValueSetFhirMapper vsFhirMapper
+  @Inject ValueSetService valueSetService
+  @Inject ValueSetVersionService valueSetVersionService
+  @Inject ValueSetVersionConceptRepository conceptRepository
+
+  static final String CS_ID = "vsexpand-filter-cs"
+  static final String CS_URI = "http://termx-test.local/CodeSystem/vsexpand-filter-cs"
+  static final String VS_ID = "vsexpand-parity-vs"
+  static final String VS_VERSION = "1.0.0"
+
+  void setup() {
+    def sessionInfo = new SessionInfo()
+    sessionInfo.privileges = ['*.*.*']
+    SessionStore.setLocal(sessionInfo)
+    importHierarchyCs()
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  @Unroll
+  def "fn01 (stored) and fn37 (inline) agree for #name"() {
+    when:
+    def both = expandBothWays(rule)
+
+    then: "the two engines return the same concept set, and it matches the expected set"
+    both.stored == expected as Set
+    both.inline == both.stored
+
+    where:
+    name                    | rule                                                              || expected
+    "all concepts"          | allConcepts()                                                     || ["A", "B", "C", "D", "X"]
+    "exact concepts"        | exactConcepts("A", "C")                                           || ["A", "C"]
+    "property = (string)"   | filtered(filter("method", "=", "CHROM"))                          || ["A", "B"]
+    "code in"               | filtered(filter("code", "in", "B,C"))                             || ["B", "C"]
+    "concept is-a"          | filtered(filter("concept", "is-a", "A"))                          || ["A", "B", "C", "D"]
+    "concept descendent-of" | filtered(filter("concept", "descendent-of", "A"))                 || ["B", "C", "D"]
+  }
+
+  // --- helpers ---------------------------------------------------------------
+
+  private Map expandBothWays(ValueSetVersionRule rule) {
+    def version = new ValueSetVersion()
+        .setStatus(PublicationStatus.draft)
+        .setPreferredLanguage("en")
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule]))
+    version.setValueSet(VS_ID)
+    version.setVersion(VS_VERSION)
+
+    def vs = new ValueSet().setId(VS_ID).setUri("http://termx-test.local/ValueSet/" + VS_ID)
+        .setTitle(new LocalizedName().add("en", "Engine parity"))
+    def request = new ValueSetTransactionRequest()
+    request.setValueSet(vs)
+    request.setVersion(version)
+    valueSetService.save(request)
+    def versionId = valueSetVersionService.load(VS_ID, VS_VERSION).orElseThrow().getId()
+
+    // fn01 — stored path, by version id
+    def stored = conceptRepository.expand(versionId).collect { it.concept?.code }.findAll { it != null } as Set
+
+    // fn37 — inline path, fed the FHIR JSON of the same version
+    def fhirJson = FhirMapper.toJson(vsFhirMapper.toFhir(vs, version, []))
+    def inline = conceptRepository.expandFromJson(fhirJson).collect { it.concept?.code }.findAll { it != null } as Set
+
+    return [stored: stored, inline: inline]
+  }
+
+  private ValueSetVersionRule allConcepts() {
+    return new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID).setCodeSystemUri(CS_URI)
+  }
+
+  private ValueSetVersionRule exactConcepts(String... codes) {
+    def concepts = codes.collect { c ->
+      new ValueSetVersionConcept().setConcept(new ValueSetVersionConcept.ValueSetVersionConceptValue().setCode(c))
+    }
+    return new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID).setCodeSystemUri(CS_URI).setConcepts(concepts)
+  }
+
+  private ValueSetVersionRule filtered(ValueSetRuleFilter... filters) {
+    return new ValueSetVersionRule().setType("include").setCodeSystem(CS_ID).setCodeSystemUri(CS_URI).setFilters(filters.toList())
+  }
+
+  private static ValueSetRuleFilter filter(String property, String operator, Object value) {
+    return new ValueSetRuleFilter().setProperty(new PropertyReference().setName(property)).setOperator(operator).setValue(value)
+  }
+
+  private void importHierarchyCs() {
+    def json = readFixtureString("fhir/vsexpand/cs-hierarchy.json")
+    def fhir = FhirMapper.fromJson(json, com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    def cs = csFhirMapper.fromFhirCodeSystem(fhir)
+    importService.importCodeSystem(cs, [], new CodeSystemImportAction().setActivate(true).setCleanRun(true).setCleanConceptRun(false))
+  }
+
+  private String readFixtureString(String relativePath) {
+    def stream = getClass().getClassLoader().getResourceAsStream(relativePath)
+    assert stream != null, "fixture not found: ${relativePath}"
+    return new String(stream.readAllBytes(), "UTF-8")
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandPinnedVersionIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/valueset/ValueSetExpandPinnedVersionIT.groovy
@@ -22,23 +22,20 @@ import org.termx.ts.valueset.ValueSetTransactionRequest
 import org.termx.ts.valueset.ValueSetVersion
 import org.termx.ts.valueset.ValueSetVersionRuleSet
 import org.termx.ts.valueset.ValueSetVersionRuleSet.ValueSetVersionRule
-import spock.lang.PendingFeature
 
 import java.time.LocalDate
 
 /**
- * A ValueSet rule pinned to a specific CodeSystem version must expand to ONLY that
- * version's members. The stored-version path {@code terminology.value_set_expand(bigint)}
- * ({@code 01-value_set_expand.sql}) currently applies a cumulative {@code release_date <=} fallback:
- * a concept that is NOT a member of the pinned version but WAS a member of an earlier version is
- * pulled forward and returned (tagged with the earlier version). For a code system whose versions
- * are full releases this over-includes retired/removed concepts.
+ * A ValueSet rule pinned to a specific CodeSystem version must expand to ONLY that version's members.
+ * The stored-version path {@code terminology.value_set_expand(bigint)} ({@code 01-value_set_expand.sql})
+ * is strict per-version: a concept that is NOT a member of the pinned version is not returned, even if
+ * it was a member of an earlier version.
  *
- * <p>The fallback was introduced in {@code 5af30777} ("TEHIK fixes") to support delta-versioned code
- * systems (each version carries only changed concepts), where pulling earlier concepts forward is
- * required to reconstruct the full set. Any fix therefore must keep delta semantics working while
- * making full-release pins strict — so this regression is captured as a {@link PendingFeature}
- * until that behaviour is decided/implemented.
+ * <p>Historically fn01 carried a cumulative {@code release_date <=} fallback (added in {@code 5af30777}
+ * "TEHIK fixes" for delta-versioned code systems) that pulled earlier-version concepts forward. It was
+ * removed: FHIR has no cross-version delta semantics ({@code include.version = X} means X's content
+ * as-is), so a version that ships only deltas must be normalised to a full release at import time, not
+ * reconstructed at expansion time.
  *
  * <p>Fixture: code system {@code vsexpand-pinned-cs} imported as two full releases —
  * <pre>
@@ -77,7 +74,6 @@ class ValueSetExpandPinnedVersionIT extends TermxIntegTest {
     SessionStore.clearLocal()
   }
 
-  @PendingFeature(reason = "Known gap: stored expansion pinned to a version still pulls concepts forward from earlier versions (cumulative release_date<= fallback added in 5af30777 for delta-versioned code systems)")
   def "expansion pinned to a CodeSystem version returns only that version's members"() {
     expect:
     expandPinnedTo("2.0.0") == ["keep"] as Set


### PR DESCRIPTION
Integration branch for the 01/37 expansion-engine unification. **Behavior-changing — do not merge until the tx-conformance suite (`tx-conformance.yml`) and TEHIK validation pass.**

## In this PR so far
- **#5 — strict per-version expansion.** Removed the cumulative `release_date <=` fallback from `value_set_expand(bigint)` (fn01). A ValueSet pinned to a CodeSystem version now expands to exactly that version's members, matching `value_set_expand(text)` (fn37) and FHIR (`include.version = X` = X's content as-is; no cross-version delta semantics). A delta-only source must be normalised to a full release at **import** time.
- **Phase 1 — engine-parity gate.** `ValueSetExpandEngineParityIT` expands one stored version through both engines (fn37 fed the FHIR JSON of the same version) and asserts equal concept sets across all-concepts / exact / property / code-in / is-a / descendent-of. Currently **green** → the two engines agree on the covered cases.

## Verified
- `terminology.valueset.*` + `terminology.fhir.*` integration suite: no regressions from the strict change (only the 3 pre-existing supplement-conformance gaps remain, unchanged).
- Pinned-version regression test flipped from `@PendingFeature` to passing.

## Risk / open
- Strict expansion will drop carry-over concepts for any code system whose per-version memberships are incomplete (delta-loaded). Mitigation = import-time membership carry-forward + a backfill migration (Phase 2). **Needs TEHIK data validation before merge.**
- Phases 2–4 (import carry-forward + backfill, single-engine swap, shared decoration / the 3 supplement tests) land on this branch next.