### PR TITLE
feat(ucum): Estonian UCUM supplement + value set with alias resolution

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java
@@ -231,7 +231,9 @@ public class CodeSystemLookupOperation implements InstanceOperationDefinition, T
     // The `status` concept property (active/retired/deprecated). A retired/deprecated code carries its status
     // explicitly; an active code leaves it as the implicit default (the reference server omits it there too).
     String conceptStatus = c.getVersions().stream().findFirst().map(CodeSystemEntityVersion::getStatus).orElse(null);
-    if ((allProps || properties.contains("status")) && List.of("retired", "deprecated").contains(conceptStatus)) {
+    // conceptStatus is null for concepts with no explicit status (e.g. virtual UCUM concepts); guard the
+    // membership test — List.of(...).contains(null) throws NPE rather than returning false.
+    if ((allProps || properties.contains("status")) && conceptStatus != null && List.of("retired", "deprecated").contains(conceptStatus)) {
       resp.addParameter(new ParametersParameter("property")
           .addPart(new ParametersParameter("code").setValueCode("status"))
           .addPart(new ParametersParameter("value").setValueCode(conceptStatus)));

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -2125,7 +2125,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       }
       final Designation display = chosen;
       c.setDisplay(display);
-      c.setAdditionalDesignations(all.values().stream().filter(d -> d != display).toList());
+      // Drop the chosen display from the designation array so it is not echoed twice — EXCEPT when it came from
+      // a supplement: a supplement's localized designation surfaces as BOTH the display and a designation (the
+      // tx-ecosystem http examples #16/#17), the same way the stored-VS mapper keeps it. A base/primary display
+      // that also happens to sit in the designation set is still de-duped away.
+      c.setAdditionalDesignations(all.values().stream()
+          .filter(d -> d != display || (display != null && display.isSupplement()))
+          .toList());
       // The concept's PRIMARY (resource-language) display, when it is NOT the chosen display — because another
       // language was chosen, or the display was omitted (strict) — is kept as a designation tagged
       // use=preferredForLanguage (hl7TermMaintInfra), per the tx-ecosystem convention. Matched by primary value AND

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -81,12 +81,13 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     // A structurally-malformed displayLanguage (e.g. a bare '-') is rejected up front with a 400 processing
     // error, the way the reference engine does (tx-ecosystem validation-wrong-de-en-bad).
     requireValidDisplayLanguage(req);
-    // No code to validate at all (no coding / codeableConcept / code+system / code+inferSystem) is an error, not a
-    // normal Parameters result — the reference returns an OperationOutcome (tx-ecosystem batch-validate-bad[1]).
-    boolean inferSystemReq = req.findParameter("inferSystem")
-        .map(p -> Boolean.TRUE.equals(p.getValueBoolean()) || "true".equals(p.getValueString())).orElse(false);
+    // Nothing to validate at all (no coding / codeableConcept / code) is an error, not a normal Parameters
+    // result — the reference returns an OperationOutcome (tx-ecosystem batch-validate-bad[1]). A bare `code`
+    // WITHOUT a system IS accepted here: this is value-set validation, so the system is implied by the value
+    // set (a single-system value set) or inferred from its expansion downstream. A coding/codeableConcept that
+    // lacks a system is handled later with a proper not-in-vs + no-system outcome, not this hard error.
     if (req.findParameter("coding").isEmpty() && req.findParameter("codeableConcept").isEmpty()
-        && !(req.findParameter("code").isPresent() && (req.findParameter("system").isPresent() || inferSystemReq))) {
+        && req.findParameter("code").isEmpty()) {
       throw org.termx.terminology.fhir.TxIssues.noCodeToValidateException();
     }
     String rawUrl = req.findParameter("url")

--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
@@ -18,6 +18,14 @@
     </customChange>
   </changeSet>
 
+  <!-- runOnChange: re-imports the Estonian/Russian UCUM supplement whenever it changes,
+       so added units/designations propagate to already-migrated databases. -->
+  <changeSet id="ucum-supplement-ee" author="termx" runOnChange="true">
+    <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">
+      <param name="files" value="terminology/changelog/data/codesystem/ucum-supplement-ee.json"/>
+    </customChange>
+  </changeSet>
+
   <changeSet id="publication-status" author="termx">
     <validCheckSum>ANY</validCheckSum>
     <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">

--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/ucum-supplement-ee.json
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/ucum-supplement-ee.json
@@ -1,0 +1,1291 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "ucum-ee",
+  "url": "https://fhir.ee/CodeSystem/ucum-supplement-ee",
+  "version": "1.0.0",
+  "name": "UCUMee",
+  "title": "Estonian UCUM localisation",
+  "status": "active",
+  "experimental": false,
+  "publisher": "TEHIK / Helex",
+  "description": "Estonian (et) and Russian (ru) localisation of the UCUM unit codes used by Estonian laboratory (ELHR) observations. Supplements http://unitsofmeasure.org with display designations; does not define new codes.",
+  "caseSensitive": true,
+  "content": "supplement",
+  "supplements": "http://unitsofmeasure.org",
+  "concept": [
+    {
+      "code": "%",
+      "display": "Percent",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Protsent"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Процент"
+        }
+      ]
+    },
+    {
+      "code": "/100{WBC}",
+      "display": "Per 100 white blood cells",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "100 leukotsüüdi kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "На 100 лейкоцитов"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "/100WBC"
+        }
+      ]
+    },
+    {
+      "code": "/[HPF]",
+      "display": "Per high power field",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Suure suurenduse vaatevälja kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "В поле зрения при большом увеличении"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "/hpf"
+        }
+      ]
+    },
+    {
+      "code": "10*6/L",
+      "display": "Million per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Miljon liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллион на литр"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "E6/L"
+        }
+      ]
+    },
+    {
+      "code": "10*9/L",
+      "display": "Billion per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Miljard liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиард на литр"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "E9/L"
+        }
+      ]
+    },
+    {
+      "code": "10*12/L",
+      "display": "Trillion per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Triljon liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Триллион на литр"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "E12/L"
+        }
+      ]
+    },
+    {
+      "code": "Cel",
+      "display": "Degrees Celsius",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Kraadi Celsiuse järgi"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Градус Цельсия"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "C"
+        }
+      ]
+    },
+    {
+      "code": "U/L",
+      "display": "Units per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Ühikut liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Единиц на литр"
+        }
+      ]
+    },
+    {
+      "code": "U/g",
+      "display": "Units per gram",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Ühikut grammi kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Единиц на грамм"
+        }
+      ]
+    },
+    {
+      "code": "[beth'U]",
+      "display": "Bethesda unit",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Bethesda ühik"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Единица Бетесда"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "BU"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "[BU]"
+        }
+      ]
+    },
+    {
+      "code": "[arb'U]",
+      "display": "Arbitrary unit",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Suvaline ühik"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Условная (произвольная) единица"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "U"
+        }
+      ]
+    },
+    {
+      "code": "fL",
+      "display": "Femtoliter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Femtoliiter"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Фемтолитр"
+        }
+      ]
+    },
+    {
+      "code": "g/(5.h)",
+      "display": "Gram per 5 hours",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Grammi 5 tunni kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Грамм за 5 часов"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "g/5h"
+        }
+      ]
+    },
+    {
+      "code": "g/L",
+      "display": "Grams per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Grammi liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Грамм на литр"
+        }
+      ]
+    },
+    {
+      "code": "g/d",
+      "display": "Gram per day",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Grammi ööpäevas"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Грамм в сутки"
+        }
+      ]
+    },
+    {
+      "code": "g/mol",
+      "display": "Gram per mole",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Grammi mooli kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Грамм на моль"
+        }
+      ]
+    },
+    {
+      "code": "k[IU]/L",
+      "display": "Kilo international units per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Kilorahvusvahelist ühikut liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Килоединиц (МЕ) на литр"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "kU/L"
+        }
+      ]
+    },
+    {
+      "code": "k[IU]/mol",
+      "display": "Kilo international units per mole",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Kilorahvusvahelist ühikut mooli kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Килоединиц (МЕ) на моль"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "kU/mol"
+        }
+      ]
+    },
+    {
+      "code": "mL",
+      "display": "Milliliter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milliliiter"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mL/dL",
+      "display": "Milliliter per deciliter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milliliiter detsiliitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллилитр на децилитр"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "Vol%"
+        }
+      ]
+    },
+    {
+      "code": "mL/min",
+      "display": "Milliliter per minute",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milliliiter minutis"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллилитр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mL/min/{1.73_m2}",
+      "display": "Milliliter per minute per 1.73 square metre",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milliliiter minutis 1,73 m² kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллилитр в минуту на 1,73 м²"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "mL/min/1.73m2"
+        }
+      ]
+    },
+    {
+      "code": "mS/cm",
+      "display": "Millisiemens per centimetre",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millisiimensit sentimeetri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллисименс на сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "m[IU]/L",
+      "display": "Milli international units per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millirahvusvahelist ühikut liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиединиц (МЕ) на литр"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "mU/L"
+        }
+      ]
+    },
+    {
+      "code": "mg/L",
+      "display": "Milligrams per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milligrammi liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиграмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "mg/d",
+      "display": "Milligram per day",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milligrammi ööpäevas"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиграмм в сутки"
+        }
+      ]
+    },
+    {
+      "code": "mg/h",
+      "display": "Milligram per hour",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milligrammi tunnis"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиграмм в час"
+        }
+      ]
+    },
+    {
+      "code": "mg/mol",
+      "display": "Milligram per mole",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milligrammi mooli kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиграмм на моль"
+        }
+      ]
+    },
+    {
+      "code": "min",
+      "display": "Minute",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Minut"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Минута"
+        }
+      ]
+    },
+    {
+      "code": "mm/h",
+      "display": "Millimetre per hour",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millimeetrit tunnis"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиметр в час"
+        }
+      ]
+    },
+    {
+      "code": "mm[Hg]",
+      "display": "Millimetre of mercury",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millimeetrit elavhõbedasammast"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиметр ртутного столба"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "mmHg"
+        }
+      ]
+    },
+    {
+      "code": "mm[Hg]/%",
+      "display": "Millimetre of mercury per percent",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millimeetrit elavhõbedasammast protsendi kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиметр ртутного столба на процент"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "mmHg/%"
+        }
+      ]
+    },
+    {
+      "code": "mmol/L",
+      "display": "Millimoles per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millimooli liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллимоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "mmol/d",
+      "display": "Millimole per day",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millimooli ööpäevas"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллимоль в сутки"
+        }
+      ]
+    },
+    {
+      "code": "mmol/mol",
+      "display": "Millimoles per mole",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Millimooli mooli kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллимоль на моль"
+        }
+      ]
+    },
+    {
+      "code": "mol/mol",
+      "display": "Mole per mole",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mooli mooli kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Моль на моль"
+        }
+      ]
+    },
+    {
+      "code": "mosm/kg{H2O}",
+      "display": "Milliosmoles per kilogram of water",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Milliosmooli vee kilogrammi kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Миллиосмоль на килограмм воды"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "mosm/kgH2O"
+        }
+      ]
+    },
+    {
+      "code": "ng/L",
+      "display": "Nanograms per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Nanogrammi liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Нанограмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "ng/dL",
+      "display": "Nanograms per deciliter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Nanogrammi detsiliitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Нанограмм на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "ng/mL{RBC}/h",
+      "display": "Nanogram per millilitre of red cells per hour",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Nanogrammi erütrotsüütide milliliitri kohta tunnis"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Нанограмм на миллилитр эритроцитов в час"
+        },
+        {
+          "language": "et",
+          "use": {
+            "system": "https://termx.org/fhir/CodeSystem/designation-usage",
+            "code": "alias"
+          },
+          "value": "ng/mL(RBC)/h"
+        }
+      ]
+    },
+    {
+      "code": "nmol/L",
+      "display": "Nanomoles per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Nanomooli liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Наномоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/d",
+      "display": "Nanomole per day",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Nanomooli ööpäevas"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Наномоль в сутки"
+        }
+      ]
+    },
+    {
+      "code": "pg",
+      "display": "Picogram",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Pikogramm"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Пикограмм"
+        }
+      ]
+    },
+    {
+      "code": "pmol/L",
+      "display": "Picomoles per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Pikomooli liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Пикомоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "s",
+      "display": "Second",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Sekund"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Секунда"
+        }
+      ]
+    },
+    {
+      "code": "ug/L",
+      "display": "Micrograms per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mikrogrammi liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Микрограмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "ug/d",
+      "display": "Microgram per day",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mikrogrammi ööpäevas"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Микрограмм в сутки"
+        }
+      ]
+    },
+    {
+      "code": "ug/g",
+      "display": "Micrograms per gram",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mikrogrammi grammi kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Микрограмм на грамм"
+        }
+      ]
+    },
+    {
+      "code": "ug/min",
+      "display": "Microgram per minute",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mikrogrammi minutis"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Микрограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "umol/L",
+      "display": "Micromoles per liter",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mikromooli liitri kohta"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Микромоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "umol/d",
+      "display": "Micromole per day",
+      "designation": [
+        {
+          "language": "et",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Mikromooli ööpäevas"
+        },
+        {
+          "language": "ru",
+          "use": {
+            "system": "http://terminology.hl7.org/CodeSystem/designation-usage",
+            "code": "display"
+          },
+          "value": "Микромоль в сутки"
+        }
+      ]
+    }
+  ]
+}

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -11,6 +11,14 @@
     </customChange>
   </changeSet>
 
+  <!-- runOnChange: re-imports the Estonian/ELHR UCUM value set whenever its enumerated
+       code list changes, so added units propagate to already-migrated databases. -->
+  <changeSet id="ucum-ee" author="termx" runOnChange="true">
+    <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
+      <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
+    </customChange>
+  </changeSet>
+
   <changeSet id="codesystem-content-mode" author="termx">
     <validCheckSum>ANY</validCheckSum>
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/ucum-ee.json
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/ucum-ee.json
@@ -1,0 +1,225 @@
+{
+  "resourceType": "ValueSet",
+  "id": "ucum-ee",
+  "url": "https://fhir.ee/ValueSet/ucum-ee",
+  "version": "1.0.0",
+  "name": "UcumEe",
+  "title": "UCUM Units (Estonia / ELHR)",
+  "status": "active",
+  "experimental": false,
+  "publisher": "TEHIK / Helex",
+  "description": "Enumerated UCUM unit codes used by Estonian laboratory (ELHR) observations (the Estonian 'common units' analogue of the FHIR ucum-common value set). Localised displays are provided by the ucum-ee CodeSystem supplement.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://unitsofmeasure.org",
+        "concept": [
+          {
+            "code": "%",
+            "display": "Percent"
+          },
+          {
+            "code": "/100{WBC}",
+            "display": "Per 100 white blood cells"
+          },
+          {
+            "code": "/[HPF]",
+            "display": "Per high power field"
+          },
+          {
+            "code": "10*6/L",
+            "display": "Million per liter"
+          },
+          {
+            "code": "10*9/L",
+            "display": "Billion per liter"
+          },
+          {
+            "code": "10*12/L",
+            "display": "Trillion per liter"
+          },
+          {
+            "code": "Cel",
+            "display": "Degrees Celsius"
+          },
+          {
+            "code": "U/L",
+            "display": "Units per liter"
+          },
+          {
+            "code": "U/g",
+            "display": "Units per gram"
+          },
+          {
+            "code": "[beth'U]",
+            "display": "Bethesda unit"
+          },
+          {
+            "code": "[arb'U]",
+            "display": "Arbitrary unit"
+          },
+          {
+            "code": "fL",
+            "display": "Femtoliter"
+          },
+          {
+            "code": "g/(5.h)",
+            "display": "Gram per 5 hours"
+          },
+          {
+            "code": "g/L",
+            "display": "Grams per liter"
+          },
+          {
+            "code": "g/d",
+            "display": "Gram per day"
+          },
+          {
+            "code": "g/mol",
+            "display": "Gram per mole"
+          },
+          {
+            "code": "k[IU]/L",
+            "display": "Kilo international units per liter"
+          },
+          {
+            "code": "k[IU]/mol",
+            "display": "Kilo international units per mole"
+          },
+          {
+            "code": "mL",
+            "display": "Milliliter"
+          },
+          {
+            "code": "mL/dL",
+            "display": "Milliliter per deciliter"
+          },
+          {
+            "code": "mL/min",
+            "display": "Milliliter per minute"
+          },
+          {
+            "code": "mL/min/{1.73_m2}",
+            "display": "Milliliter per minute per 1.73 square metre"
+          },
+          {
+            "code": "mS/cm",
+            "display": "Millisiemens per centimetre"
+          },
+          {
+            "code": "m[IU]/L",
+            "display": "Milli international units per liter"
+          },
+          {
+            "code": "mg/L",
+            "display": "Milligrams per liter"
+          },
+          {
+            "code": "mg/d",
+            "display": "Milligram per day"
+          },
+          {
+            "code": "mg/h",
+            "display": "Milligram per hour"
+          },
+          {
+            "code": "mg/mol",
+            "display": "Milligram per mole"
+          },
+          {
+            "code": "min",
+            "display": "Minute"
+          },
+          {
+            "code": "mm/h",
+            "display": "Millimetre per hour"
+          },
+          {
+            "code": "mm[Hg]",
+            "display": "Millimetre of mercury"
+          },
+          {
+            "code": "mm[Hg]/%",
+            "display": "Millimetre of mercury per percent"
+          },
+          {
+            "code": "mmol/L",
+            "display": "Millimoles per liter"
+          },
+          {
+            "code": "mmol/d",
+            "display": "Millimole per day"
+          },
+          {
+            "code": "mmol/mol",
+            "display": "Millimoles per mole"
+          },
+          {
+            "code": "mol/mol",
+            "display": "Mole per mole"
+          },
+          {
+            "code": "mosm/kg{H2O}",
+            "display": "Milliosmoles per kilogram of water"
+          },
+          {
+            "code": "ng/L",
+            "display": "Nanograms per liter"
+          },
+          {
+            "code": "ng/dL",
+            "display": "Nanograms per deciliter"
+          },
+          {
+            "code": "ng/mL{RBC}/h",
+            "display": "Nanogram per millilitre of red cells per hour"
+          },
+          {
+            "code": "nmol/L",
+            "display": "Nanomoles per liter"
+          },
+          {
+            "code": "nmol/d",
+            "display": "Nanomole per day"
+          },
+          {
+            "code": "pg",
+            "display": "Picogram"
+          },
+          {
+            "code": "pmol/L",
+            "display": "Picomoles per liter"
+          },
+          {
+            "code": "s",
+            "display": "Second"
+          },
+          {
+            "code": "ug/L",
+            "display": "Micrograms per liter"
+          },
+          {
+            "code": "ug/d",
+            "display": "Microgram per day"
+          },
+          {
+            "code": "ug/g",
+            "display": "Micrograms per gram"
+          },
+          {
+            "code": "ug/min",
+            "display": "Microgram per minute"
+          },
+          {
+            "code": "umol/L",
+            "display": "Micromoles per liter"
+          },
+          {
+            "code": "umol/d",
+            "display": "Micromole per day"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/conformance/TxConformanceSetupLoaderTest.groovy
@@ -60,22 +60,21 @@ class TxConformanceSetupLoaderTest extends Specification {
     null                                                                                  || false
   }
 
-  def "isSetupFile accepts setup resources of the kind and rejects test artifacts"() {
+  def "isSetupFile accepts setup resources and rejects test request/response artifacts"() {
     expect:
-    TxConformanceSetupLoader.isSetupFile(name, prefix) == expected
+    TxConformanceSetupLoader.isSetupFile(name) == expected
 
     where:
-    name                                          | prefix         || expected
-    "codesystem-simple.json"                      | "codesystem-"  || true
-    "codesystem-noversion.json"                   | "codesystem-"  || true
-    "valueset-all.json"                           | "valueset-"    || true
-    "valueset-filter-isa.json"                    | "valueset-"    || true
+    name                                          || expected
+    "codesystem-simple.json"                      || true
+    "codesystem-noversion.json"                   || true
+    "valueset-all.json"                           || true
+    "valueset-filter-isa.json"                    || true
     // test request/response artifacts are NOT content
-    "simple-expand-all-request-parameters.json"   | "valueset-"    || false
-    "simple-expand-all-response-valueSet.json"    | "valueset-"    || false
-    "valueset-all-response.json"                  | "valueset-"    || false
-    // wrong kind / wrong extension
-    "valueset-all.json"                           | "codesystem-"  || false
-    "codesystem-simple.xml"                       | "codesystem-"  || false
+    "simple-expand-all-request-parameters.json"   || false
+    "simple-expand-all-response-valueSet.json"    || false
+    "valueset-all-response.json"                  || false
+    // non-.json is not a setup file
+    "codesystem-simple.xml"                       || false
   }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
@@ -26,8 +26,9 @@ class ValueSetValidateCodeOperationTest extends Specification {
   def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
   def conceptService = Mock(ConceptService)
   def expandOperation = Mock(org.termx.terminology.fhir.valueset.operations.ValueSetExpandOperation)
+  def codeSystemService = Mock(org.termx.terminology.terminology.codesystem.CodeSystemService)
 
-  def operation = new ValueSetValidateCodeOperation(valueSetVersionService, valueSetVersionConceptService, conceptService, expandOperation)
+  def operation = new ValueSetValidateCodeOperation(valueSetVersionService, valueSetVersionConceptService, conceptService, expandOperation, codeSystemService)
 
   ValueSetVersion vsVersion = new ValueSetVersion().setValueSet("ehr-feed-category").setVersion("1.0.0")
 

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionServiceTest.groovy
@@ -1,6 +1,7 @@
 package org.termx.terminology.terminology.codesystem.version
 
 import jakarta.inject.Provider
+import org.termx.core.ts.CodeSystemExternalProvider
 import org.termx.core.ts.UcumSearchCacheInvalidator
 import org.termx.terminology.terminology.codesystem.CodeSystemRepository
 import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService
@@ -17,8 +18,9 @@ class CodeSystemVersionServiceTest extends Specification {
   def impactService = Mock(ValueSetCodeSystemImpactService)
   def codeSystemRepository = Mock(CodeSystemRepository)
   def ucumSearchCacheInvalidator = Mock(UcumSearchCacheInvalidator)
+  List<CodeSystemExternalProvider> codeSystemProviders = []
 
-  def service = new CodeSystemVersionService(repository, entityVersionService, impactServiceProvider, codeSystemRepository, ucumSearchCacheInvalidator)
+  def service = new CodeSystemVersionService(repository, entityVersionService, impactServiceProvider, codeSystemRepository, ucumSearchCacheInvalidator, codeSystemProviders)
 
   def "activate refreshes dynamic value sets for any activation caller"() {
     given:

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java
@@ -36,6 +36,7 @@ public class UcumConceptResolver {
 
   private volatile List<UcumUnitDefinition> unitsCache;
   private volatile Map<String, UcumUnitDefinition> unitByCodeCache;
+  private volatile Map<String, String> aliasIndexCache;
   private volatile long cacheExpiresAtMillis;
 
   public QueryResult<Concept> search(ConceptQueryParams params) {
@@ -80,6 +81,13 @@ public class UcumConceptResolver {
       return Optional.empty();
     }
     if (!isValidCode(code)) {
+      // The code is not valid UCUM grammar. It may still be a known secondary-code alias (e.g. the ELHR
+      // form "mmHg" for "mm[Hg]"); resolve it to its canonical code so $validate-code / $lookup succeed and
+      // echo the main code. Guard against a self-referential or non-resolving alias.
+      String canonical = getAliasIndex().get(code);
+      if (StringUtils.isNotEmpty(canonical) && !canonical.equals(code) && isValidCode(canonical)) {
+        return findByCode(canonical);
+      }
       return Optional.empty();
     }
     UcumUnitDefinition knownUnit = getUnitByCode().get(code);
@@ -127,7 +135,16 @@ public class UcumConceptResolver {
   public synchronized void invalidateCache() {
     unitsCache = null;
     unitByCodeCache = null;
+    aliasIndexCache = null;
     cacheExpiresAtMillis = 0L;
+  }
+
+  private Map<String, String> getAliasIndex() {
+    if (aliasIndexCache == null || isCacheExpired()) {
+      getUnits();
+    }
+    Map<String, String> local = aliasIndexCache;
+    return local != null ? local : Map.of();
   }
 
   private List<UcumUnitDefinition> getUnits() {
@@ -140,6 +157,7 @@ public class UcumConceptResolver {
         unitsCache = loadUnits();
         unitByCodeCache = unitsCache.stream()
             .collect(Collectors.toMap(UcumUnitDefinition::getCode, u -> u, (a, b) -> a, LinkedHashMap::new));
+        aliasIndexCache = ucumSupplementDesignationService.loadAliasIndex();
         cacheExpiresAtMillis = System.currentTimeMillis() + Math.max(cacheTtlMillis, 0L);
       }
       return unitsCache;
@@ -167,8 +185,26 @@ public class UcumConceptResolver {
 
     return all.stream()
         .filter(u -> StringUtils.isNotEmpty(u.getCode()))
-        .collect(Collectors.collectingAndThen(Collectors.toMap(UcumUnitDefinition::getCode, u -> u, (a, b) -> a, LinkedHashMap::new),
+        .collect(Collectors.collectingAndThen(
+            Collectors.toMap(UcumUnitDefinition::getCode, u -> u, UcumConceptResolver::mergeDefinitions, LinkedHashMap::new),
             m -> new ArrayList<>(m.values())));
+  }
+
+  /** Merge two definitions for the same code: keep the first's English names, union the supplement designations. */
+  private static UcumUnitDefinition mergeDefinitions(UcumUnitDefinition left, UcumUnitDefinition right) {
+    List<Designation> designations = new ArrayList<>(Optional.ofNullable(left.getSupplementDesignations()).orElse(List.of()));
+    designations.addAll(Optional.ofNullable(right.getSupplementDesignations()).orElse(List.of()));
+    left.setSupplementDesignations(designations);
+    if (left.getNames() == null || left.getNames().isEmpty()) {
+      left.setNames(right.getNames());
+    }
+    if (left.getKind() == null) {
+      left.setKind(right.getKind());
+    }
+    if (left.getProperty() == null) {
+      left.setProperty(right.getProperty());
+    }
+    return left;
   }
 
   private boolean isCacheExpired() {
@@ -188,13 +224,7 @@ public class UcumConceptResolver {
           List<String> names = new ArrayList<>(Optional.ofNullable(left.getNames()).orElse(List.of()));
           names.addAll(Optional.ofNullable(right.getNames()).orElse(List.of()));
           left.setNames(names.stream().filter(StringUtils::isNotEmpty).distinct().toList());
-          if (left.getKind() == null) {
-            left.setKind(right.getKind());
-          }
-          if (left.getProperty() == null) {
-            left.setProperty(right.getProperty());
-          }
-          return left;
+          return mergeDefinitions(left, right);
         }));
     return new ArrayList<>(merged.values());
   }
@@ -239,8 +269,15 @@ public class UcumConceptResolver {
     }
     return unit.getCode().equalsIgnoreCase(designationCiEq)
         || Optional.ofNullable(unit.getNames()).orElse(List.of()).stream().anyMatch(name -> name.equalsIgnoreCase(designationCiEq))
-        || Optional.ofNullable(supplementDesignations).orElse(List.of()).stream().map(Designation::getName)
-        .anyMatch(name -> name != null && name.equalsIgnoreCase(designationCiEq));
+        || designationNames(unit, supplementDesignations).anyMatch(name -> name.equalsIgnoreCase(designationCiEq));
+  }
+
+  /** All supplement designation names for a unit: its own cached ones plus any loaded for this search. */
+  private static java.util.stream.Stream<String> designationNames(UcumUnitDefinition unit, List<Designation> supplementDesignations) {
+    return java.util.stream.Stream.concat(
+            Optional.ofNullable(unit.getSupplementDesignations()).orElse(List.of()).stream(),
+            Optional.ofNullable(supplementDesignations).orElse(List.of()).stream())
+        .map(Designation::getName).filter(Objects::nonNull);
   }
 
   private static boolean matchesTextContains(UcumUnitDefinition unit, List<Designation> supplementDesignations, String textContains) {
@@ -251,8 +288,7 @@ public class UcumConceptResolver {
         || containsIgnoreCase(unit.getKind(), textContains)
         || containsIgnoreCase(unit.getProperty(), textContains)
         || Optional.ofNullable(unit.getNames()).orElse(List.of()).stream().anyMatch(n -> containsIgnoreCase(n, textContains))
-        || Optional.ofNullable(supplementDesignations).orElse(List.of()).stream().map(Designation::getName)
-        .anyMatch(n -> containsIgnoreCase(n, textContains));
+        || designationNames(unit, supplementDesignations).anyMatch(n -> containsIgnoreCase(n, textContains));
   }
 
   private static boolean matchesKindOrProperty(UcumUnitDefinition unit, Set<String> requested) {

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumMapper.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumMapper.java
@@ -48,19 +48,51 @@ public class UcumMapper {
     version.setCodeSystem(UCUM);
     version.setStatus(PublicationStatus.draft);
 
-    List<Designation> designations = Optional.ofNullable(unit.getNames()).orElse(List.of()).stream()
+    List<Designation> designations = new ArrayList<>();
+    // Base UCUM (English) display names, from the essence file.
+    Optional.ofNullable(unit.getNames()).orElse(List.of()).stream()
         .filter(Objects::nonNull)
         .map(String::trim)
         .filter(n -> !n.isEmpty())
         .distinct()
         .map(this::toDisplayDesignation)
-        .collect(Collectors.toCollection(ArrayList::new));
+        .forEach(designations::add);
+    // Supplement designations, keeping their real language + type (et/ru displays, aliases) instead of
+    // defaulting to English — otherwise localized values are mislabelled `en`.
+    Optional.ofNullable(unit.getSupplementDesignations()).orElse(List.of()).stream()
+        .filter(d -> d != null && d.getName() != null && !d.getName().isBlank())
+        .map(this::toSupplementDesignation)
+        .forEach(designations::add);
+    designations = dedupeDesignations(designations);
     if (designations.isEmpty()) {
       designations.add(toDisplayDesignation(unit.getCode()));
     }
     designations.get(0).setPreferred(true);
     version.setDesignations(designations);
     return version;
+  }
+
+  private Designation toSupplementDesignation(Designation source) {
+    Designation designation = new Designation();
+    designation.setName(source.getName());
+    designation.setLanguage(source.getLanguage());
+    designation.setDesignationType(source.getDesignationType() == null || source.getDesignationType().isBlank()
+        ? "display" : source.getDesignationType());
+    designation.setCaseSignificance(CaseSignificance.entire_term_case_insensitive);
+    designation.setStatus(PublicationStatus.active);
+    return designation;
+  }
+
+  /** De-dupe by (language, type, name) so a supplement designation that repeats a base name is not emitted twice. */
+  private static List<Designation> dedupeDesignations(List<Designation> designations) {
+    java.util.LinkedHashMap<String, Designation> byKey = new java.util.LinkedHashMap<>();
+    for (Designation d : designations) {
+      String key = (d.getLanguage() == null ? "" : d.getLanguage()) + "|"
+          + (d.getDesignationType() == null ? "" : d.getDesignationType()) + "|"
+          + (d.getName() == null ? "" : d.getName());
+      byKey.putIfAbsent(key, d);
+    }
+    return new ArrayList<>(byKey.values());
   }
 
   private CodeSystemEntityVersion toExpressionConceptVersion(String code) {

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumSupplementDesignationService.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumSupplementDesignationService.java
@@ -36,6 +36,9 @@ import org.termx.ts.valueset.ValueSetVersionConcept;
 public class UcumSupplementDesignationService {
   private static final String UCUM = "ucum";
   private static final String UCUM_URI = "http://unitsofmeasure.org";
+  // Designation-property name under which a secondary-code alias is stored (FHIR designation.use
+  // https://termx.org/fhir/CodeSystem/designation-usage#alias — see CodeSystemFhirMapper).
+  private static final String ALIAS_TYPE = "alias";
 
   private final CodeSystemRepository codeSystemRepository;
   private final CodeSystemVersionRepository codeSystemVersionRepository;
@@ -82,6 +85,65 @@ public class UcumSupplementDesignationService {
         .toList());
   }
 
+  /**
+   * Reverse index of secondary-code aliases → canonical UCUM code, built from every UCUM supplement's
+   * {@code alias}-type designations (e.g. the ELHR display form {@code "mmHg"} → {@code "mm[Hg]"}). Used to
+   * validate and resolve non-canonical code forms that ucum-java's grammar rejects. Global rather than
+   * language-scoped: an alias is a code synonym, not a translation.
+   */
+  public Map<String, String> loadAliasIndex() {
+    Map<String, String> aliasToCode = new LinkedHashMap<>();
+    List<ResolvedSupplement> supplements = loadUcumSupplements().stream()
+        .map(codeSystem -> resolveSupplementVersion(codeSystem.getId(), null)
+            .map(version -> new ResolvedSupplement(codeSystem.getId(), version))
+            .orElse(null))
+        .filter(Objects::nonNull)
+        .toList();
+
+    for (ResolvedSupplement supplement : supplements) {
+      List<Concept> concepts = conceptRepository.query(new ConceptQueryParams()
+          .setCodeSystem(supplement.id())
+          .all()).getData();
+      if (CollectionUtils.isEmpty(concepts)) {
+        continue;
+      }
+
+      List<String> conceptIds = concepts.stream().map(Concept::getId).filter(Objects::nonNull).map(String::valueOf).toList();
+      if (conceptIds.isEmpty()) {
+        continue;
+      }
+
+      List<CodeSystemEntityVersion> versions = codeSystemEntityVersionRepository.query(new CodeSystemEntityVersionQueryParams()
+          .setCodeSystem(supplement.id())
+          .setCodeSystemVersion(supplement.version())
+          .setCodeSystemEntityIds(String.join(",", conceptIds))
+          .limit(conceptIds.size())).getData();
+      if (CollectionUtils.isEmpty(versions)) {
+        continue;
+      }
+
+      Map<Long, String> versionIdToCode = versions.stream()
+          .filter(v -> v.getId() != null && StringUtils.isNotEmpty(v.getCode()))
+          .collect(Collectors.toMap(CodeSystemEntityVersion::getId, CodeSystemEntityVersion::getCode, (left, right) -> left, LinkedHashMap::new));
+      if (versionIdToCode.isEmpty()) {
+        continue;
+      }
+
+      designationService.query(new DesignationQueryParams()
+          .setCodeSystemEntityVersionId(String.join(",", versionIdToCode.keySet().stream().map(String::valueOf).toList()))
+          .limit(-1)).getData().stream()
+          .filter(d -> ALIAS_TYPE.equals(d.getDesignationType()))
+          .filter(d -> StringUtils.isNotEmpty(d.getName()))
+          .forEach(d -> {
+            String code = versionIdToCode.get(d.getCodeSystemEntityVersionId());
+            if (StringUtils.isNotEmpty(code)) {
+              aliasToCode.putIfAbsent(d.getName(), code);
+            }
+          });
+    }
+    return aliasToCode;
+  }
+
   public List<UcumUnitDefinition> loadSupplementUnitDefinitions(ConceptQueryParams params) {
     if (params == null || StringUtils.isEmpty(params.getUseSupplement())) {
       return List.of();
@@ -122,18 +184,20 @@ public class UcumSupplementDesignationService {
           .filter(v -> StringUtils.isNotEmpty(v.getCode()))
           .forEach(version -> units.add(new UcumUnitDefinition()
               .setCode(version.getCode())
-              .setNames(distinctDesignations(designationsByVersionId.getOrDefault(version.getId(), List.of())).stream()
-                  .map(Designation::getName)
-                  .filter(StringUtils::isNotEmpty)
+              // Carry the supplement's designations WITH their language + type (do NOT flatten to `names`,
+              // which the UCUM mapper emits as English — that mislabels et/ru values as `en`).
+              .setSupplementDesignations(distinctDesignations(designationsByVersionId.getOrDefault(version.getId(), List.of())).stream()
+                  .filter(d -> StringUtils.isNotEmpty(d.getName()))
+                  .map(UcumSupplementDesignationService::copyDesignation)
                   .toList())));
     }
     return units.stream()
         .filter(unit -> StringUtils.isNotEmpty(unit.getCode()))
         .collect(Collectors.collectingAndThen(
             Collectors.toMap(UcumUnitDefinition::getCode, unit -> unit, (left, right) -> {
-              List<String> names = new ArrayList<>(Optional.ofNullable(left.getNames()).orElse(List.of()));
-              names.addAll(Optional.ofNullable(right.getNames()).orElse(List.of()));
-              left.setNames(names.stream().filter(StringUtils::isNotEmpty).distinct().toList());
+              List<Designation> merged = new ArrayList<>(Optional.ofNullable(left.getSupplementDesignations()).orElse(List.of()));
+              merged.addAll(Optional.ofNullable(right.getSupplementDesignations()).orElse(List.of()));
+              left.setSupplementDesignations(distinctDesignations(merged));
               return left;
             }, LinkedHashMap::new),
             map -> new ArrayList<>(map.values())));

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumUnitDefinition.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumUnitDefinition.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.termx.ts.codesystem.Designation;
 
 @Getter
 @Setter
@@ -12,5 +13,8 @@ public class UcumUnitDefinition {
   private String code;
   private String kind;
   private String property;
+  /** Base (UCUM, English) display names — from the essence file. */
   private List<String> names;
+  /** Supplement-contributed designations, carrying their real language + type (et/ru display, aliases, …). */
+  private List<Designation> supplementDesignations;
 }

--- a/ucum/src/test/groovy/org/termx/ucum/service/UcumAdministrationServiceTest.groovy
+++ b/ucum/src/test/groovy/org/termx/ucum/service/UcumAdministrationServiceTest.groovy
@@ -57,7 +57,7 @@ class UcumAdministrationServiceTest extends Specification {
       @Override
       void invalidate() {
       }
-    }) {
+    }, []) {
       @Override
       Optional<CodeSystemVersion> load(String codeSystem, String versionCode) {
         return Optional.empty()

--- a/ucum/src/test/groovy/org/termx/ucum/ts/UcumExternalProviderTest.groovy
+++ b/ucum/src/test/groovy/org/termx/ucum/ts/UcumExternalProviderTest.groovy
@@ -57,6 +57,40 @@ class UcumExternalProviderTest extends Specification {
     result.data.isEmpty()
   }
 
+  def "codesystem provider resolves a secondary-code alias to its canonical UCUM code"() {
+    given:
+    ucumService.getBaseUnits() >> []
+    ucumService.getDefinedUnits() >> []
+    ucumService.validate("mmHg") >> valid(false)   // ELHR form is not valid UCUM grammar
+    ucumService.validate("mm[Hg]") >> valid(true)  // its canonical form is
+    def provider = provider([
+        "mm[Hg]": [designation("alias", "et", "mmHg", false, true)]
+    ])
+
+    when:
+    def result = provider.searchConcepts(new ConceptQueryParams().setCodeSystem("ucum").setCodeEq("mmHg"))
+
+    then:
+    result.data*.code == ["mm[Hg]"]
+  }
+
+  def "codesystem provider does not resolve a display designation as a code"() {
+    given:
+    ucumService.getBaseUnits() >> []
+    ucumService.getDefinedUnits() >> []
+    ucumService.validate("Millimeetrit elavhõbedasammast") >> valid(false)
+    ucumService.validate("mm[Hg]") >> valid(true)
+    def provider = provider([
+        "mm[Hg]": [designation("display", "et", "Millimeetrit elavhõbedasammast", false, true)]
+    ])
+
+    when: "a localized display name is submitted as a code — only alias-typed designations resolve"
+    def result = provider.searchConcepts(new ConceptQueryParams().setCodeSystem("ucum").setCodeEq("Millimeetrit elavhõbedasammast"))
+
+    then:
+    result.data.isEmpty()
+  }
+
   def "codesystem provider text search matches supplement designations"() {
     given:
     ucumService.getBaseUnits() >> []
@@ -74,6 +108,46 @@ class UcumExternalProviderTest extends Specification {
 
     then:
     result.data*.code == ["mL"]
+  }
+
+  def "codesystem provider surfaces ucum-ee Estonian and Russian supplement designations"() {
+    given: "the ucum-ee supplement adds et + ru display designations to a UCUM unit (as ucum-supplement-ee.json does)"
+    ucumService.getBaseUnits() >> []
+    ucumService.getDefinedUnits() >> [definedUnit("mL", "volume", ["milliliter"])]
+    def provider = provider([
+        "mL": [designation("display", "et", "Milliliiter", false, true),
+               designation("display", "ru", "Миллилитр", false, true)]
+    ])
+
+    expect: "the code is found by either localized designation"
+    provider.searchConcepts(new ConceptQueryParams().setCodeSystem("ucum")
+        .setTextContains(needle).setIncludeSupplement(true).setDisplayLanguage(lang)).data*.code == ["mL"]
+
+    where:
+    lang | needle
+    "et" | "Milliliiter"
+    "ru" | "Миллилитр"
+  }
+
+  def "codesystem provider emits supplement designations with their real language and type, not en"() {
+    given: "a supplement-only UCUM expression carrying et + ru display designations and an et alias"
+    ucumService.getBaseUnits() >> []
+    ucumService.getDefinedUnits() >> []
+    ucumService.validate("mm[Hg]") >> valid(true)
+    def provider = provider([
+        "mm[Hg]": [designation("display", "et", "Millimeetrit elavhõbedasammast", false, true),
+                   designation("display", "ru", "Миллиметр ртутного столба", false, true),
+                   designation("alias", "et", "mmHg", false, true)]
+    ])
+
+    when:
+    def concept = provider.searchConcepts(new ConceptQueryParams().setCodeSystem("ucum").setCodeEq("mm[Hg]")).data.first()
+    def byName = concept.versions.first().designations.collectEntries { [(it.name): [it.language, it.designationType]] }
+
+    then: "each designation keeps its real language + type — none is defaulted to en"
+    byName["Millimeetrit elavhõbedasammast"] == ["et", "display"]
+    byName["Миллиметр ртутного столба"] == ["ru", "display"]
+    byName["mmHg"] == ["et", "alias"]
   }
 
   def "codesystem provider text search finds supplement-only ucum expressions"() {


### PR DESCRIPTION
## ucum-ee supplement + value set
- `ucum-supplement-ee.json` — `content=supplement`, `supplements=http://unitsofmeasure.org`; Estonian (`et`) + Russian (`ru`) designations for the 51 UCUM units used by ELHR lab observations, plus ELHR secondary-code **aliases** (e.g. `mmHg`, `E6/L`, `BU`, `[BU]`).
- `ucum-ee.json` — value set enumerating those 51 codes (the Estonian "common units" analogue).
- Canonical URLs under `https://fhir.ee/`. Both wired into the terminology changelogs.

## UCUM provider
- **Alias resolution**: a secondary-code alias (`mmHg` → `mm[Hg]`, `[BU]` → `[beth'U]`) now validates and resolves to its canonical UCUM code in `$validate-code` / `$lookup`.
- **Designation language**: supplement designations are emitted with their real language + type instead of defaulting to `en` (`UcumUnitDefinition` carries language-tagged designations; verified end-to-end on a fresh DB).

## Terminology operation fixes (surfaced by the ucum-ee work)
- `$lookup`: null-guard the `status` membership test (`List.of(...).contains(null)` NPE for concepts with no status, e.g. virtual UCUM).
- `$validate-code`: accept a bare `code` with no `system` when validating against a value set (system inferred from a single-system VS).
- `$expand`: a supplement designation promoted to the display is also kept in the `designation` array (tx-ecosystem http examples #16/#17).

## Test repairs
Stale unit tests drifted from production constructors/signatures brought back to green: `CodeSystemVersionServiceTest`, `ValueSetValidateCodeOperationTest`, `UcumAdministrationServiceTest`, `TxConformanceSetupLoaderTest`.

Full unit suite + `termx-integtest` integration suite green.