### PR TITLE
fix(ucum): re-import UCUM CS + ucum-ee VS via new changeset ids

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
@@ -11,7 +11,10 @@
     </customChange>
   </changeSet>
 
-  <changeSet id="ucum-2" author="termx">
+  <!-- id bumped ucum-2 -> ucum-3 to force a re-import: ucum-2 carried validCheckSum=ANY, so a canonical-url
+       correction in ucum.json (to http://unitsofmeasure.org) never re-ran on databases that already executed
+       it (e.g. dev.termx.org held the stale https://units-of-measurement.org). A new id runs it once more. -->
+  <changeSet id="ucum-3" author="termx">
     <validCheckSum>ANY</validCheckSum>
     <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">
       <param name="files" value="terminology/changelog/data/codesystem/ucum.json"/>

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -13,7 +13,11 @@
 
   <!-- runOnChange: re-imports the Estonian/ELHR UCUM value set whenever its enumerated
        code list changes, so added units propagate to already-migrated databases. -->
-  <changeSet id="ucum-ee" author="termx" runOnChange="true">
+  <!-- id bumped ucum-ee -> ucum-ee-2 to force a re-import: the first run failed on databases whose UCUM
+       CodeSystem still had the wrong canonical url (TE110 "code system http://unitsofmeasure.org does not
+       exist"); ValueSetFhirImport swallowed the error so runOnChange saw no change to retry. Re-runs after
+       the ucum-3 CodeSystem re-import above has corrected the url. -->
+  <changeSet id="ucum-ee-2" author="termx" runOnChange="true">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
     </customChange>


### PR DESCRIPTION
dev.termx.org held a stale UCUM canonical (`https://units-of-measurement.org`). `ucum-2` had `validCheckSum=ANY`, so the corrected `ucum.json` url (`http://unitsofmeasure.org`) never re-ran on already-migrated DBs — which failed the ucum-ee ValueSet import (`TE110: code system http://unitsofmeasure.org does not exist`).

Bump `ucum-2`→`ucum-3` and `ucum-ee`→`ucum-ee-2` so both re-run once: the CodeSystem re-import fixes the url, then the ValueSet import succeeds.