### PR TITLE
fix(ucum): re-import ucum-supplement-ee so baseCodeSystem re-links

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
@@ -21,9 +21,13 @@
     </customChange>
   </changeSet>
 
-  <!-- runOnChange: re-imports the Estonian/Russian UCUM supplement whenever it changes,
-       so added units/designations propagate to already-migrated databases. -->
-  <changeSet id="ucum-supplement-ee" author="termx" runOnChange="true">
+  <!-- runOnChange: re-imports the Estonian/Russian UCUM supplement whenever it changes, so added
+       units/designations propagate to already-migrated databases.
+       id bumped ucum-supplement-ee -> ucum-supplement-ee-2 to force a re-import after ucum-3 above:
+       on databases whose UCUM CodeSystem url was corrected by ucum-3, the supplement must re-run so its
+       baseCodeSystem link resolves (an initial import against the stale url left base_code_system null, so
+       supplement designations + aliases were not discovered by UcumSupplementDesignationService). -->
+  <changeSet id="ucum-supplement-ee-2" author="termx" runOnChange="true">
     <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">
       <param name="files" value="terminology/changelog/data/codesystem/ucum-supplement-ee.json"/>
     </customChange>


### PR DESCRIPTION
An initial supplement import against the stale UCUM canonical (`https://units-of-measurement.org`) left `base_code_system` null, so supplement designations were not merged into $expand. Bump `ucum-supplement-ee` → `ucum-supplement-ee-2` so it re-runs after `ucum-3` corrects the base CodeSystem url. Verified on dev.termx.org: after re-import the base links and $expand surfaces Estonian designations (incl. through tx.helex.dev).