### PR TITLE
fix(ucum): hard-delete redundant unitsofmeasure.org CS + re-bind ucum-ee VS

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
@@ -24,11 +24,12 @@
   <!-- Consolidate to a single UCUM CodeSystem. Some databases carry a redundant content=not-present CS with
        id 'unitsofmeasure.org' — created by importing ucum.json when a legacy essence-based `ucum` CodeSystem
        (holding the stale https://units-of-measurement.org canonical) already occupied id=ucum, so the import
-       fell back to a url-derived id. Self-heal the `ucum` canonical to http://unitsofmeasure.org and drop the
-       redundant CS (cancel_code_system also detaches the value_set_version_rule that referenced it), so the
-       ucum-ee supplement + value set that follow re-resolve (by canonical uri) to the single `ucum`
-       CodeSystem. No-op on databases that only ever had the single `ucum` CS. -->
-  <changeSet id="ucum-drop-redundant-cs" author="termx">
+       fell back to a url-derived id. Self-heal the `ucum` canonical to http://unitsofmeasure.org and hard-delete
+       the redundant CS (delete_code_system removes its concepts/designations/versions and the
+       value_set_version_rule that referenced it), so the ucum-ee supplement + value set that follow re-resolve
+       (by canonical uri) to the single `ucum` CodeSystem. No-op on databases that only ever had the single
+       `ucum` CS. -->
+  <changeSet id="ucum-drop-redundant-cs-2" author="termx">
     <sql splitStatements="false"><![CDATA[
       update terminology.code_system
          set uri = 'http://unitsofmeasure.org'
@@ -37,7 +38,7 @@
       do $$
       begin
         if exists (select 1 from terminology.code_system where id = 'unitsofmeasure.org') then
-          perform terminology.cancel_code_system('unitsofmeasure.org');
+          perform terminology.delete_code_system('unitsofmeasure.org', true);
         end if;
       end $$;
     ]]></sql>
@@ -53,6 +54,23 @@
     <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">
       <param name="files" value="terminology/changelog/data/codesystem/ucum-supplement-ee.json"/>
     </customChange>
+  </changeSet>
+
+  <!-- The ucum-ee CodeSystem/ValueSet canonicals were renamed (-> https://fhir.ee/{CodeSystem,ValueSet}/ucum)
+       in the JSON, but CodeSystemFhirImport/ValueSetFhirImport match an existing resource by id and preserve
+       its stored uri, so the rename does not propagate to already-migrated databases on re-import. Apply it
+       explicitly. Idempotent: guarded on the old uri, so it is a no-op on fresh installs (whose import already
+       creates the resources at the new uri) and on any re-run. -->
+  <changeSet id="ucum-rename-ee-canonicals" author="termx">
+    <sql splitStatements="false"><![CDATA[
+      update terminology.code_system
+         set uri = 'https://fhir.ee/CodeSystem/ucum'
+       where id = 'ucum-ee' and uri = 'https://fhir.ee/CodeSystem/ucum-supplement-ee';
+
+      update terminology.value_set
+         set uri = 'https://fhir.ee/ValueSet/ucum'
+       where id = 'ucum-ee' and uri = 'https://fhir.ee/ValueSet/ucum-ee';
+    ]]></sql>
   </changeSet>
 
   <changeSet id="publication-status" author="termx">

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -13,11 +13,14 @@
 
   <!-- runOnChange: re-imports the Estonian/ELHR UCUM value set whenever its enumerated
        code list changes, so added units propagate to already-migrated databases. -->
-  <!-- id bumped ucum-ee -> ucum-ee-2 to force a re-import: the first run failed on databases whose UCUM
-       CodeSystem still had the wrong canonical url (TE110 "code system http://unitsofmeasure.org does not
-       exist"); ValueSetFhirImport swallowed the error so runOnChange saw no change to retry. Re-runs after
-       the ucum-3 CodeSystem re-import above has corrected the url. -->
-  <changeSet id="ucum-ee-2" author="termx" runOnChange="true">
+  <!-- id bumped ucum-ee-2 -> ucum-ee-3 to force a re-import AFTER ucum-drop-redundant-cs-2 (CS changelog,
+       included before this one) hard-deletes the redundant 'unitsofmeasure.org' CodeSystem: that delete
+       cascades to the value_set_version_rule which — on databases where the VS was first imported against the
+       redundant CS — was bound to it, leaving the VS ruleless (getRules() NPE on $expand/$validate-code).
+       Re-importing here rebuilds the include rule bound to the single surviving `ucum` CodeSystem.
+       Earlier bump (ucum-ee -> ucum-ee-2) recovered from the TE110 "code system does not exist" failure that
+       ValueSetFhirImport swallowed before ucum-3 corrected the canonical url. -->
+  <changeSet id="ucum-ee-3" author="termx" runOnChange="true">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
     </customChange>


### PR DESCRIPTION
## Summary
Follow-up to #378. Consolidates UCUM to a single CodeSystem reproducibly across environments.

- **Hard delete instead of soft cancel.** `ucum-drop-redundant-cs` now calls `terminology.delete_code_system('unitsofmeasure.org', true)` (id bumped to `ucum-drop-redundant-cs-2`) so the redundant `content=not-present` CodeSystem is fully removed, not left `sys_status='D'`.
- **Propagate the fhir.ee canonical rename.** `CodeSystemFhirImport`/`ValueSetFhirImport` match an existing resource by `id` and preserve its stored `uri`, so the #377 rename to `https://fhir.ee/{CodeSystem,ValueSet}/ucum` never reached already-migrated databases. New `ucum-rename-ee-canonicals` changeset applies it (idempotent, guarded on the old uri).
- **Re-bind the ucum-ee ValueSet.** The hard delete cascades to the `value_set_version_rule`; on databases where the VS was first imported against the redundant CS, that rule was bound to it, leaving the VS ruleless (`getRules()` NPE on `$expand`/`$validate-code`). Bumping the VS import id (`ucum-ee-2` → `ucum-ee-3`) forces a re-import after the delete (CS changelog is included before the VS changelog) that rebuilds the include rule against the single surviving `ucum` CodeSystem.

All changesets are idempotent / no-ops on databases that only ever had the single `ucum` CS.

## Test
Verified end-to-end on dev.termx.org after applying the equivalent SQL: single `ucum` CS at `http://unitsofmeasure.org`, `unitsofmeasure.org` CS removed, ucum-ee CS/VS at the `/ucum` canonicals, `$lookup` returns Estonian designations. Router (tx.helex.dev) verification follows the redeploy.