### PR TITLE
fix(ucum): rebuild ucum-ee VS include rule via drop-before-reimport

### DIFF
--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -11,16 +11,29 @@
     </customChange>
   </changeSet>
 
-  <!-- runOnChange: re-imports the Estonian/ELHR UCUM value set whenever its enumerated
-       code list changes, so added units propagate to already-migrated databases. -->
-  <!-- id bumped ucum-ee-2 -> ucum-ee-3 to force a re-import AFTER ucum-drop-redundant-cs-2 (CS changelog,
-       included before this one) hard-deletes the redundant 'unitsofmeasure.org' CodeSystem: that delete
-       cascades to the value_set_version_rule which — on databases where the VS was first imported against the
-       redundant CS — was bound to it, leaving the VS ruleless (getRules() NPE on $expand/$validate-code).
-       Re-importing here rebuilds the include rule bound to the single surviving `ucum` CodeSystem.
-       Earlier bump (ucum-ee -> ucum-ee-2) recovered from the TE110 "code system does not exist" failure that
-       ValueSetFhirImport swallowed before ucum-3 corrected the canonical url. -->
-  <changeSet id="ucum-ee-3" author="termx" runOnChange="true">
+  <!-- Delete the ucum-ee value set before the (re-)import below. ValueSetImportService rejects re-importing an
+       existing active/final version with TE104 ("version is already created and final"), and ValueSetFhirImport
+       swallows that error — so a plain re-import cannot rebuild the value set. This bites after
+       ucum-drop-redundant-cs-2 (CS changelog, included before this one) hard-deletes the redundant
+       'unitsofmeasure.org' CodeSystem: that delete cascades to the value_set_version_rule which — on databases
+       where the VS was first imported against the redundant CS — was bound to it, leaving the VS ruleless
+       (getRules() NPE on $expand/$validate-code). Dropping the VS here lets the next changeset re-create it from
+       scratch, with its include rule bound to the single surviving `ucum` CodeSystem. No-op on fresh installs. -->
+  <changeSet id="ucum-ee-drop-before-reimport" author="termx">
+    <sql splitStatements="false"><![CDATA[
+      do $$
+      begin
+        if exists (select 1 from terminology.value_set where id = 'ucum-ee') then
+          perform terminology.delete_value_set('ucum-ee');
+        end if;
+      end $$;
+    ]]></sql>
+  </changeSet>
+
+  <!-- Re-imports the Estonian/ELHR UCUM value set. Runs after ucum-ee-drop-before-reimport so it always creates
+       a fresh version (no TE104), rebuilding the include rule against `ucum`. Bump this id (not runOnChange) to
+       force a re-import when ucum-ee.json changes; the drop changeset above must be re-bumped alongside it. -->
+  <changeSet id="ucum-ee-4" author="termx">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
     </customChange>


### PR DESCRIPTION
## Problem
After #379 hard-deleted the redundant `unitsofmeasure.org` CodeSystem, the `ucum-ee` ValueSet was left **ruleless** — `getRules()` NPE on `$expand`/`$validate-code`. On databases where the VS was first imported against the redundant CS, its `value_set_version_rule` was bound to that CS and got cascade-deleted by the hard delete.

The re-import bumped in #379 (`ucum-ee-3`) could not repair it: `ValueSetImportService` rejects re-importing an existing **active/final** version with `TE104: Version '1.0.0' is already created and final`, and `ValueSetFhirImport` swallows the exception — so the rule was never rebuilt.

## Fix
Add `ucum-ee-drop-before-reimport` (calls `terminology.delete_value_set('ucum-ee')` if present) ahead of a bumped import (`ucum-ee-3` → `ucum-ee-4`, no longer `runOnChange`). Dropping first means the import always creates a fresh version — no TE104 — rebuilding the include rule bound to the single surviving `ucum` CodeSystem. Guarded / no-op on fresh installs.

## Test
Redeploy re-creates the VS with a rule bound to `ucum`; `$validate-code`/`$expand` verified on dev.termx.org + tx.helex.dev after deploy.