### PR TITLE
feat(ucum): fragment content model + $expand contains.system for concept-less CS

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -3,6 +3,7 @@ package org.termx.terminology.terminology.valueset.expansion;
 import com.kodality.commons.util.DateUtil;
 import org.termx.core.auth.SessionStore;
 import org.termx.terminology.Privilege;
+import org.termx.terminology.terminology.codesystem.CodeSystemService;
 import org.termx.terminology.terminology.codesystem.concept.ConceptUtil;
 import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService;
 import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropertyService;
@@ -10,6 +11,8 @@ import org.termx.terminology.terminology.valueset.version.ValueSetVersionReposit
 import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotService;
 import org.termx.ts.PublicationStatus;
 import org.termx.core.ts.ValueSetExternalExpandProvider;
+import org.termx.ts.codesystem.CodeSystem;
+import org.termx.ts.codesystem.CodeSystemQueryParams;
 import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
@@ -50,6 +53,7 @@ public class ValueSetVersionConceptService {
   private final CodeSystemEntityVersionService codeSystemEntityVersionService;
   private final EntityPropertyService entityPropertyService;
   private final ValueSetCodeSystemVersionResolver codeSystemVersionResolver;
+  private final CodeSystemService codeSystemService;
 
   private static final String DEPRECATION_DATE = "deprecationDate";
   private static final String INACTIVE = "inactive";
@@ -345,7 +349,36 @@ public class ValueSetVersionConceptService {
                 .setEntityPropertyType(properties.get("modifiedBy").getType()));
           }
         }).toList();
+    backfillCodeSystemUri(res);
     return res;
+  }
+
+  /**
+   * Backfill the code system uri on concepts that the expand returned with only a code system id. This happens
+   * when a value set enumerates codes from a code system that has no stored concept rows — e.g. a `fragment` /
+   * `not-present` grammar system like UCUM, whose codes are materialised virtually rather than stored, so the
+   * expand SQL (which derives the uri from a code system entity) leaves it null. Without the uri,
+   * ValueSetFhirMapper emits an $expand `contains` entry with no `system` (invalid FHIR) and system-qualified
+   * $validate-code can't match the code against the value set. Resolve the uri from the code system id. No-op
+   * for the common case where every concept already carries a uri.
+   */
+  private void backfillCodeSystemUri(List<ValueSetVersionConcept> concepts) {
+    List<String> ids = concepts.stream().map(ValueSetVersionConcept::getConcept).filter(Objects::nonNull)
+        .filter(c -> c.getCodeSystemUri() == null && c.getBaseCodeSystemUri() == null && c.getCodeSystem() != null)
+        .map(c -> c.getCodeSystem()).distinct().toList();
+    if (ids.isEmpty()) {
+      return;
+    }
+    Map<String, String> uriById = codeSystemService.query(new CodeSystemQueryParams()
+            .setIds(String.join(",", ids)).limit(ids.size())).getData().stream()
+        .filter(cs -> cs.getUri() != null)
+        .collect(Collectors.toMap(CodeSystem::getId, CodeSystem::getUri, (a, b) -> a));
+    concepts.forEach(c -> {
+      var cc = c.getConcept();
+      if (cc != null && cc.getCodeSystemUri() == null && cc.getBaseCodeSystemUri() == null && cc.getCodeSystem() != null) {
+        cc.setCodeSystemUri(uriById.get(cc.getCodeSystem()));
+      }
+    });
   }
 
   /**

--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/changelog-data-codesystem.xml
@@ -85,6 +85,20 @@
     ]]></sql>
   </changeSet>
 
+  <!-- The base UCUM CodeSystem is `fragment`, not `not-present`/`complete`: termx materialises only a subset of
+       UCUM (the essence atoms, served virtually by UcumCodeSystemProvider) — so `complete` (which some databases
+       stored via an early bootstrap) falsely tells the terminology-explorer router it can validate every UCUM
+       code locally, and `not-present` understates what is resolvable. Reconcile the stored content; a
+       CodeSystemFhirImport re-import can't change it (metadata frozen, TE104 swallowed). Idempotent / no-op once
+       already `fragment`. -->
+  <changeSet id="ucum-content-fragment" author="termx">
+    <sql splitStatements="false"><![CDATA[
+      update terminology.code_system
+         set content = 'fragment'
+       where id = 'ucum' and content is distinct from 'fragment';
+    ]]></sql>
+  </changeSet>
+
   <changeSet id="publication-status" author="termx">
     <validCheckSum>ANY</validCheckSum>
     <customChange class="org.termx.terminology.liquibase.CodeSystemFhirImport">

--- a/terminology/src/main/resources/terminology/changelog/data/codesystem/ucum.json
+++ b/terminology/src/main/resources/terminology/changelog/data/codesystem/ucum.json
@@ -34,5 +34,5 @@
   "description": "The Unified Code for Units of Measure (UCUM) is a code system intended to include all units of measures being contemporarily used in international science, engineering, and business. The purpose is to facilitate unambiguous electronic communication of quantities together with their units. The focus is on electronic communication, as opposed to communication between humans. A typical application of The Unified Code for Units of Measure are electronic data interchange (EDI) protocols, but there is nothing that prevents it from being used in other types of machine communication.",
   "copyright": "The UCUM codes, UCUM table (regardless of format), and UCUM Specification are copyright 1999-2009, Regenstrief Institute, Inc. and the Unified Codes for Units of Measures (UCUM) Organization. All rights reserved. https://ucum.org/trac/wiki/TermsOfUse",
   "caseSensitive": true,
-  "content": "not-present"
+  "content": "fragment"
 }

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -18,8 +18,11 @@
        'unitsofmeasure.org' CodeSystem: that delete cascades to the value_set_version_rule which — on databases
        where the VS was first imported against the redundant CS — was bound to it, leaving the VS ruleless
        (getRules() NPE on $expand/$validate-code). Dropping the VS here lets the next changeset re-create it from
-       scratch, with its include rule bound to the single surviving `ucum` CodeSystem. No-op on fresh installs. -->
-  <changeSet id="ucum-ee-drop-before-reimport" author="termx">
+       scratch, with its include rule bound to the single surviving `ucum` CodeSystem. No-op on fresh installs.
+       id re-bumped (-> -2) alongside ucum-ee-5 to regenerate the stored expansion snapshot under the
+       codeSystemUri backfill (ValueSetVersionConceptService): the active version's snapshot is served verbatim,
+       so the backfilled contains.system only reaches $expand/$validate-code after a fresh re-import. -->
+  <changeSet id="ucum-ee-drop-before-reimport-2" author="termx">
     <sql splitStatements="false"><![CDATA[
       do $$
       begin
@@ -30,10 +33,12 @@
     ]]></sql>
   </changeSet>
 
-  <!-- Re-imports the Estonian/ELHR UCUM value set. Runs after ucum-ee-drop-before-reimport so it always creates
-       a fresh version (no TE104), rebuilding the include rule against `ucum`. Bump this id (not runOnChange) to
-       force a re-import when ucum-ee.json changes; the drop changeset above must be re-bumped alongside it. -->
-  <changeSet id="ucum-ee-4" author="termx">
+  <!-- Re-imports the Estonian/ELHR UCUM value set. Runs after ucum-ee-drop-before-reimport-2 so it always creates
+       a fresh version (no TE104), rebuilding the include rule against `ucum` and regenerating the expansion
+       snapshot (now with contains.system backfilled for the concept-less UCUM CS). Bump this id (not
+       runOnChange) to force a re-import when ucum-ee.json or the expansion logic changes; re-bump the drop
+       changeset above alongside it. -->
+  <changeSet id="ucum-ee-5" author="termx">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
     </customChange>

--- a/ucum/src/main/java/org/termx/ucum/service/UcumAdministrationService.java
+++ b/ucum/src/main/java/org/termx/ucum/service/UcumAdministrationService.java
@@ -62,7 +62,11 @@ public class UcumAdministrationService {
         .setUri(UCUM_URI)
         .setName("UCUM")
         .setTitle(new LocalizedName(Map.of("en", "Unified Code for Units of Measure (UCUM)")))
-        .setContent(CodeSystemContent.notPresent)
+        // fragment, not not-present: termx materialises a subset of UCUM (the essence atoms, served virtually by
+        // UcumCodeSystemProvider) rather than none — and the terminology-explorer router keys off this to
+        // validate fragment code systems locally-first, then forward on miss (a not-present CS is always
+        // forwarded, a complete one never is). See ucum.json / the ucum-content-fragment changeset.
+        .setContent(CodeSystemContent.fragment)
         .setCaseSensitive("true"));
   }
 


### PR DESCRIPTION
## Fragment content model (issue B enabler)
The base UCUM CodeSystem is now **content=fragment** rather than `not-present`/`complete`. termx materialises only a subset of UCUM (the essence atoms, served virtually by `UcumCodeSystemProvider`), so `complete` (which an early bootstrap stored, with 0 concept rows) falsely tells the terminology-explorer router it can validate every UCUM code locally, and `not-present` understates what is resolvable. `fragment` drives the router's local-first-then-forward path.
Applied in `ensureUcumCodeSystem()`, `ucum.json`, and a guarded `ucum-content-fragment` changeset for already-migrated databases. termx UCUM handling is identity-based (`UcumCodeSystemProvider`), so this doesn't affect $lookup/$expand/grammar-$validate-code.

## Fix A — $expand `contains.system` for a concept-less CS
`value_set_expand` derives a concept's code system uri from a code system *entity*. A value set that enumerates codes from a CS with **no stored concept rows** (UCUM) came back with only the CS id — so `$expand` emitted `contains` entries with **no `system`** (invalid FHIR) and system-qualified `$validate-code` couldn't match. `ValueSetVersionConceptService.decorate()` now backfills the uri from the CS id (no-op when already present).
The `ucum-ee` value set is re-imported (`ucum-ee-drop-before-reimport-2` + `ucum-ee-5`) so its active-version expansion snapshot regenerates under the backfill.

Pairs with the terminology-explorer router change (fragment/example → local-first-then-forward). Verification matrix on dev.termx.org + tx.helex.dev after deploy.