### PR TITLE
fix(ucum): resolve backfilled code system uri via load(), not query()

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -12,7 +12,6 @@ import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotServi
 import org.termx.ts.PublicationStatus;
 import org.termx.core.ts.ValueSetExternalExpandProvider;
 import org.termx.ts.codesystem.CodeSystem;
-import org.termx.ts.codesystem.CodeSystemQueryParams;
 import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
@@ -369,14 +368,17 @@ public class ValueSetVersionConceptService {
     if (ids.isEmpty()) {
       return;
     }
-    Map<String, String> uriById = codeSystemService.query(new CodeSystemQueryParams()
-            .setIds(String.join(",", ids)).limit(ids.size())).getData().stream()
-        .filter(cs -> cs.getUri() != null)
-        .collect(Collectors.toMap(CodeSystem::getId, CodeSystem::getUri, (a, b) -> a));
+    // load() (a direct by-id fetch), not query(): query() applies the session's permitted-id filter, which in
+    // the Liquibase import context (no session) matches nothing, so the uri never resolved.
+    Map<String, String> uriById = new HashMap<>();
+    ids.forEach(id -> codeSystemService.load(id).map(CodeSystem::getUri).ifPresent(uri -> uriById.put(id, uri)));
     concepts.forEach(c -> {
       var cc = c.getConcept();
       if (cc != null && cc.getCodeSystemUri() == null && cc.getBaseCodeSystemUri() == null && cc.getCodeSystem() != null) {
-        cc.setCodeSystemUri(uriById.get(cc.getCodeSystem()));
+        String uri = uriById.get(cc.getCodeSystem());
+        if (uri != null) {
+          cc.setCodeSystemUri(uri);
+        }
       }
     });
   }

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -22,7 +22,7 @@
        id re-bumped (-> -2) alongside ucum-ee-5 to regenerate the stored expansion snapshot under the
        codeSystemUri backfill (ValueSetVersionConceptService): the active version's snapshot is served verbatim,
        so the backfilled contains.system only reaches $expand/$validate-code after a fresh re-import. -->
-  <changeSet id="ucum-ee-drop-before-reimport-2" author="termx">
+  <changeSet id="ucum-ee-drop-before-reimport-3" author="termx">
     <sql splitStatements="false"><![CDATA[
       do $$
       begin
@@ -38,7 +38,7 @@
        snapshot (now with contains.system backfilled for the concept-less UCUM CS). Bump this id (not
        runOnChange) to force a re-import when ucum-ee.json or the expansion logic changes; re-bump the drop
        changeset above alongside it. -->
-  <changeSet id="ucum-ee-5" author="termx">
+  <changeSet id="ucum-ee-6" author="termx">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
     </customChange>


### PR DESCRIPTION
Follow-up to #382. The `contains.system` backfill resolved the uri with `codeSystemService.query()`, which applies the session's permitted-id filter — empty in the Liquibase import context, so nothing resolved and the snapshot was still built without `system`. Switch to `load()` (direct by-id, unfiltered) and re-import the ucum-ee value set (`drop-before-reimport-3` + `ucum-ee-6`) so its active-version snapshot regenerates with `contains.system` populated.