### PR TITLE
fix(ucum): stamp system uri on UCUM expansion concepts ($expand contains.system)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -3,7 +3,6 @@ package org.termx.terminology.terminology.valueset.expansion;
 import com.kodality.commons.util.DateUtil;
 import org.termx.core.auth.SessionStore;
 import org.termx.terminology.Privilege;
-import org.termx.terminology.terminology.codesystem.CodeSystemService;
 import org.termx.terminology.terminology.codesystem.concept.ConceptUtil;
 import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService;
 import org.termx.terminology.terminology.codesystem.entityproperty.EntityPropertyService;
@@ -11,7 +10,6 @@ import org.termx.terminology.terminology.valueset.version.ValueSetVersionReposit
 import org.termx.terminology.terminology.valueset.snapshot.ValueSetSnapshotService;
 import org.termx.ts.PublicationStatus;
 import org.termx.core.ts.ValueSetExternalExpandProvider;
-import org.termx.ts.codesystem.CodeSystem;
 import org.termx.ts.codesystem.CodeSystemEntityVersion;
 import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
@@ -52,7 +50,6 @@ public class ValueSetVersionConceptService {
   private final CodeSystemEntityVersionService codeSystemEntityVersionService;
   private final EntityPropertyService entityPropertyService;
   private final ValueSetCodeSystemVersionResolver codeSystemVersionResolver;
-  private final CodeSystemService codeSystemService;
 
   private static final String DEPRECATION_DATE = "deprecationDate";
   private static final String INACTIVE = "inactive";
@@ -348,39 +345,7 @@ public class ValueSetVersionConceptService {
                 .setEntityPropertyType(properties.get("modifiedBy").getType()));
           }
         }).toList();
-    backfillCodeSystemUri(res);
     return res;
-  }
-
-  /**
-   * Backfill the code system uri on concepts that the expand returned with only a code system id. This happens
-   * when a value set enumerates codes from a code system that has no stored concept rows — e.g. a `fragment` /
-   * `not-present` grammar system like UCUM, whose codes are materialised virtually rather than stored, so the
-   * expand SQL (which derives the uri from a code system entity) leaves it null. Without the uri,
-   * ValueSetFhirMapper emits an $expand `contains` entry with no `system` (invalid FHIR) and system-qualified
-   * $validate-code can't match the code against the value set. Resolve the uri from the code system id. No-op
-   * for the common case where every concept already carries a uri.
-   */
-  private void backfillCodeSystemUri(List<ValueSetVersionConcept> concepts) {
-    List<String> ids = concepts.stream().map(ValueSetVersionConcept::getConcept).filter(Objects::nonNull)
-        .filter(c -> c.getCodeSystemUri() == null && c.getBaseCodeSystemUri() == null && c.getCodeSystem() != null)
-        .map(c -> c.getCodeSystem()).distinct().toList();
-    if (ids.isEmpty()) {
-      return;
-    }
-    // load() (a direct by-id fetch), not query(): query() applies the session's permitted-id filter, which in
-    // the Liquibase import context (no session) matches nothing, so the uri never resolved.
-    Map<String, String> uriById = new HashMap<>();
-    ids.forEach(id -> codeSystemService.load(id).map(CodeSystem::getUri).ifPresent(uri -> uriById.put(id, uri)));
-    concepts.forEach(c -> {
-      var cc = c.getConcept();
-      if (cc != null && cc.getCodeSystemUri() == null && cc.getBaseCodeSystemUri() == null && cc.getCodeSystem() != null) {
-        String uri = uriById.get(cc.getCodeSystem());
-        if (uri != null) {
-          cc.setCodeSystemUri(uri);
-        }
-      }
-    });
   }
 
   /**

--- a/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
+++ b/terminology/src/main/resources/terminology/changelog/data/valueset/changelog-data-valueset.xml
@@ -19,10 +19,10 @@
        where the VS was first imported against the redundant CS — was bound to it, leaving the VS ruleless
        (getRules() NPE on $expand/$validate-code). Dropping the VS here lets the next changeset re-create it from
        scratch, with its include rule bound to the single surviving `ucum` CodeSystem. No-op on fresh installs.
-       id re-bumped (-> -2) alongside ucum-ee-5 to regenerate the stored expansion snapshot under the
-       codeSystemUri backfill (ValueSetVersionConceptService): the active version's snapshot is served verbatim,
-       so the backfilled contains.system only reaches $expand/$validate-code after a fresh re-import. -->
-  <changeSet id="ucum-ee-drop-before-reimport-3" author="termx">
+       id re-bumped (-> -4) alongside ucum-ee-7 to regenerate the stored expansion snapshot after UcumConceptResolver
+       began stamping the UCUM system uri on the concepts it emits: the active version's snapshot is served
+       verbatim, so contains.system only reaches $expand/$validate-code after a fresh re-import. -->
+  <changeSet id="ucum-ee-drop-before-reimport-4" author="termx">
     <sql splitStatements="false"><![CDATA[
       do $$
       begin
@@ -33,12 +33,13 @@
     ]]></sql>
   </changeSet>
 
-  <!-- Re-imports the Estonian/ELHR UCUM value set. Runs after ucum-ee-drop-before-reimport-2 so it always creates
+  <!-- Re-imports the Estonian/ELHR UCUM value set. Runs after ucum-ee-drop-before-reimport-4 so it always creates
        a fresh version (no TE104), rebuilding the include rule against `ucum` and regenerating the expansion
-       snapshot (now with contains.system backfilled for the concept-less UCUM CS). Bump this id (not
-       runOnChange) to force a re-import when ucum-ee.json or the expansion logic changes; re-bump the drop
-       changeset above alongside it. -->
-  <changeSet id="ucum-ee-6" author="termx">
+       snapshot. The UCUM concepts come from UcumValueSetExpandProvider (the concept-less UCUM CS has no stored
+       rows for value_set_expand); UcumConceptResolver.decorate now stamps their system uri so contains.system is
+       emitted. Bump this id (not runOnChange) to force a re-import when ucum-ee.json or the UCUM expansion logic
+       changes; re-bump the drop changeset above alongside it. -->
+  <changeSet id="ucum-ee-7" author="termx">
     <customChange class="org.termx.terminology.liquibase.ValueSetFhirImport">
       <param name="files" value="terminology/changelog/data/valueset/ucum-ee.json"/>
     </customChange>

--- a/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java
+++ b/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java
@@ -28,6 +28,8 @@ import org.termx.ucum.service.UcumService;
 @Singleton
 @RequiredArgsConstructor
 public class UcumConceptResolver {
+  private static final String UCUM = "ucum";
+  private static final String UCUM_URI = "http://unitsofmeasure.org";
   private final UcumMapper mapper;
   private final UcumService ucumService;
   private final UcumSupplementDesignationService ucumSupplementDesignationService;
@@ -120,12 +122,17 @@ public class UcumConceptResolver {
     if (c == null || c.getConcept() == null || StringUtils.isEmpty(c.getConcept().getCode())) {
       return;
     }
+    // Stamp the UCUM system identity on every concept this provider emits — not only essence atoms matched by
+    // findByCode, but also grammar-derived composites (e.g. mmol/L) that findByCode never resolves. Without the
+    // uri, $expand emits a `contains` entry with no `system` (invalid FHIR) and system-qualified $validate-code
+    // can't match the code against the value set.
+    c.getConcept().setCodeSystem(UCUM);
+    c.getConcept().setCodeSystemUri(UCUM_URI);
     findByCode(c.getConcept().getCode()).ifPresent(concept -> {
       if (c.getAdditionalDesignations() == null || c.getAdditionalDesignations().isEmpty()) {
         c.setAdditionalDesignations(concept.getVersions().stream().findFirst().map(v -> v.getDesignations()).orElse(List.of()));
       }
       c.setActive(true);
-      c.getConcept().setCodeSystem("ucum");
     });
     if (!isValidCode(c.getConcept().getCode())) {
       c.setActive(false);

--- a/ucum/src/test/groovy/org/termx/ucum/ts/UcumExternalProviderTest.groovy
+++ b/ucum/src/test/groovy/org/termx/ucum/ts/UcumExternalProviderTest.groovy
@@ -259,6 +259,10 @@ class UcumExternalProviderTest extends Specification {
     result.size() == 1
     result.first().active
     result.first().additionalDesignations*.name == ["mg/(24.h)"]
+    // The system identity is stamped even for a grammar-derived composite that is not a stored essence atom,
+    // so $expand emits contains.system and system-qualified $validate-code can match it. (Issue A.)
+    result.first().concept.codeSystem == "ucum"
+    result.first().concept.codeSystemUri == "http://unitsofmeasure.org"
   }
 
   private UcumCodeSystemProvider provider(Map<String, List<Designation>> supplementDesignations = [:]) {


### PR DESCRIPTION
## Root cause
The `ucum-ee` value set's 51 concepts are produced by **`UcumValueSetExpandProvider`**, not the `value_set_expand` SQL function (the concept-less UCUM CS has no stored rows — it returns 0 rows). So the generic `decorate()` backfill added in #382/#383 never saw them: `$expand` still emitted `contains` entries with **no `system`** (invalid FHIR) and system-qualified `$validate-code` returned false.

## Fix
`UcumConceptResolver.decorate()` now stamps `codeSystem` + the UCUM **system uri** on every emitted concept — including grammar-derived composites (`mmol/L`) that `findByCode` never resolves (it only matches stored essence atoms). Revert the ineffective `ValueSetVersionConceptService` backfill. Re-import the value set (`drop-before-reimport-4` + `ucum-ee-7`) so the active-version snapshot regenerates.

## Test
- New assertion in `UcumExternalProviderTest` (composite `mg/(24.h)` → `codeSystemUri = http://unitsofmeasure.org`); ucum suite green (13/13).
- Verified end-to-end on a fresh local DB: `$expand` emits `system: http://unitsofmeasure.org`, system-qualified `$validate-code` (`mmol/L`, `[beth'U]`) → true, et/ru displays + `$lookup` unaffected, content=fragment.