### PR TITLE
feat(valueset): resolve secondary-code aliases in $validate-code

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperation.java
@@ -1741,6 +1741,19 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
       }
     }
 
+    // Secondary-code alias: a code that is not a member itself but is recorded as an `alias`-type designation on
+    // a member (UCUM secondary codes, e.g. [BU] -> [beth'U], mmHg -> mm[Hg]) validates as that member. Resolve to
+    // the canonical member; result=true, echoing the canonical code + a normalized-code / information note.
+    boolean viaAlias = false;
+    if (concept == null) {
+      concept = vsConcepts.stream()
+          .filter(c -> systemMatches(c, finalSystem))
+          .filter(c -> Optional.ofNullable(c.getAdditionalDesignations()).orElse(List.of()).stream()
+              .anyMatch(d -> "alias".equals(d.getDesignationType()) && finalCode.equals(d.getName())))
+          .findFirst().orElse(null);
+      viaAlias = concept != null;
+    }
+
     if (concept == null) {
       return notInValueSet(finalCode, finalSystem, vsConcepts, codeLocation(req));
     }
@@ -1752,6 +1765,13 @@ public class ValueSetValidateCodeOperation implements InstanceOperationDefinitio
     parameters.addParameter(new ParametersParameter("code").setValueCode(concept.getConcept().getCode()));
     parameters.addParameter(new ParametersParameter("system").setValueUri(concept.getConcept().getCodeSystemUri()));
     parameters.addParameter(new ParametersParameter("display").setValueString(conceptDisplay));
+    if (viaAlias && displayValid) {
+      parameters.addParameter(new ParametersParameter("normalized-code").setValueCode(concept.getConcept().getCode()));
+      String aliasNote = String.format("The code '%s' is a recognised secondary code (alias) for '%s' in code system '%s'",
+          finalCode, concept.getConcept().getCode(), concept.getConcept().getCodeSystemUri());
+      parameters.addParameter(new ParametersParameter("issues").setResource(org.termx.terminology.fhir.TxIssues.outcome(
+          org.termx.terminology.fhir.TxIssues.issue("information", "business-rule", "code-rule", aliasNote, codeLocation(req)))));
+    }
     String conceptVersion = Optional.ofNullable(concept.getConcept().getCodeSystemVersions()).orElse(List.of()).stream().findFirst().orElse(null);
     if (conceptVersion != null) {
       parameters.addParameter(new ParametersParameter("version").setValueString(conceptVersion));

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetValidateCodeOperationTest.groovy
@@ -154,6 +154,65 @@ class ValueSetValidateCodeOperationTest extends Specification {
     oo.getIssue().find { it.code == "invalid" && it.severity == "warning" } != null
   }
 
+  def "resolves a secondary-code alias to its canonical value set member (with system)"() {
+    given: "the member [beth'U] carries 'alias'-type designations [BU] and BU"
+    valueSetVersionConceptService.expand(vsVersion, _) >> [bethWithAlias()]
+
+    when: "validating the alias code [BU] with the UCUM system"
+    def resp = operation.run(vsVersion, codeReq("[BU]", "http://unitsofmeasure.org"))
+
+    then: "it validates as the canonical member and echoes the canonical code + normalized-code"
+    bool(resp, "result")
+    resp.findParameter("code").get().getValueCode() == "[beth'U]"
+    resp.findParameter("normalized-code").get().getValueCode() == "[beth'U]"
+  }
+
+  def "resolves a secondary-code alias without a supplied system (single-system value set)"() {
+    given:
+    valueSetVersionConceptService.expand(vsVersion, _) >> [bethWithAlias()]
+
+    when: "validating the alias code [BU] with no system"
+    def resp = operation.run(vsVersion, codeReq("[BU]", null))
+
+    then:
+    bool(resp, "result")
+    resp.findParameter("code").get().getValueCode() == "[beth'U]"
+  }
+
+  def "a code that is neither a member nor a known alias is not in the value set"() {
+    given:
+    valueSetVersionConceptService.expand(vsVersion, _) >> [bethWithAlias()]
+
+    when:
+    def resp = operation.run(vsVersion, codeReq("xyzzy", "http://unitsofmeasure.org"))
+
+    then:
+    !bool(resp, "result")
+  }
+
+  private static ValueSetVersionConcept bethWithAlias() {
+    return new ValueSetVersionConcept()
+        .setActive(true)
+        .setConcept(new ValueSetVersionConceptValue()
+            .setCode("[beth'U]")
+            .setCodeSystem("ucum")
+            .setCodeSystemUri("http://unitsofmeasure.org"))
+        .setDisplay(new Designation().setName("Bethesda unit").setLanguage("en").setDesignationType("display"))
+        .setAdditionalDesignations([
+            new Designation().setName("[BU]").setLanguage("et").setDesignationType("alias"),
+            new Designation().setName("BU").setLanguage("et").setDesignationType("alias")
+        ])
+  }
+
+  private static Parameters codeReq(String code, String system) {
+    Parameters p = new Parameters()
+    p.addParameter(new ParametersParameter("code").setValueCode(code))
+    if (system != null) {
+      p.addParameter(new ParametersParameter("system").setValueUri(system))
+    }
+    return p
+  }
+
   private static ValueSetVersionConcept concept() {
     return new ValueSetVersionConcept()
         .setActive(true)


### PR DESCRIPTION
## Summary
`ValueSet/$validate-code` now resolves **secondary-code aliases** to their canonical member. A code that is not itself a member but is recorded as an `alias`-type designation on a member (UCUM secondary codes, e.g. `[BU]` → `[beth'U]`, `mmHg` → `mm[Hg]`) validates as that member — with or without a supplied `system`. The response returns `result=true`, the canonical `code` + `normalized-code`, and an information note.

Implemented in the stored-VS path (`doRun`), where an alias is a `Designation` with `designationType="alias"`. CS-level alias validation was already handled by `UcumCodeSystemProvider`.

## Test
New unit tests (`ValueSetValidateCodeOperationTest`): alias resolves **with** and **without** a system; a genuine non-member/non-alias code stays `not-in-vs`. Suite green (11/11); `CodeSystemValidateCodeOperationTest` unaffected (5/5). Verified end-to-end on a local DB: `[BU]`/`mmHg` → true, canonical `mmol/L` → true, `xyzzy` → false.