### PR TITLE
Surface concept properties in implicit CodeSystem $expand

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java
@@ -2534,6 +2534,13 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
     Integer total = result.getMeta() != null ? result.getMeta().getTotal() : null;
     List<Concept> concepts = result.getData() != null ? result.getData() : Collections.emptyList();
 
+    // Concept property values are not carried on the query result (like the stored-snapshot path, the
+    // concept query omits them); load them by entity-version id when the client asks for properties,
+    // so this implicit expansion surfaces contains[].property just like the main $expand path.
+    List<String> requestedProperties = designationOrPropertyRequested(req, "property");
+    java.util.Map<Long, List<org.termx.ts.codesystem.EntityPropertyValue>> propertyValuesByVersionId =
+        requestedProperties.isEmpty() ? java.util.Map.of() : loadConceptPropertyValues(concepts);
+
     com.kodality.zmei.fhir.resource.terminology.ValueSet response = new com.kodality.zmei.fhir.resource.terminology.ValueSet();
     response.setUrl(stripped);
     response.setStatus("active");
@@ -2561,9 +2568,60 @@ public class ValueSetExpandOperation implements InstanceOperationDefinition, Typ
       if (display != null) {
         contain.setDisplay(display.getName());
       }
+      if (!requestedProperties.isEmpty()) {
+        Long versionId = firstVersionId(c);
+        List<org.termx.ts.codesystem.EntityPropertyValue> propertyValues =
+            versionId != null ? propertyValuesByVersionId.get(versionId) : null;
+        if (propertyValues != null) {
+          List<com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionContainsProperty> props =
+              ValueSetFhirMapper.toFhirContainsProperties(propertyValues, requestedProperties::contains, displayLang);
+          if (!props.isEmpty()) {
+            contain.setProperty(props);
+          }
+        }
+      }
       return contain;
     }).toList());
+
+    // Declare the requested properties so contains[].property references a declared expansion.property (valid
+    // FHIR). Each declared property carries its uri — from a tx-resource CodeSystem definition when supplied,
+    // falling back to the FHIR concept-properties uri for the built-in codes.
+    if (!requestedProperties.isEmpty()) {
+      java.util.Map<String, String> propertyUris = propertyUris(req);
+      expansion.setProperty(requestedProperties.stream()
+          .map(code -> new com.kodality.zmei.fhir.resource.terminology.ValueSet.ValueSetExpansionProperty().setCode(code)
+              .setUri(propertyUris.getOrDefault(code, "http://hl7.org/fhir/concept-properties#" + code)))
+          .toList());
+    }
+
     response.setExpansion(expansion);
     return response;
+  }
+
+  /** First (primary) entity-version id for a queried concept, used to key its loaded property values. */
+  private static Long firstVersionId(Concept concept) {
+    return concept.getVersions() != null && !concept.getVersions().isEmpty()
+        ? concept.getVersions().get(0).getId() : null;
+  }
+
+  /**
+   * Load concept property values by entity-version id for the given queried concepts — the concept query
+   * result omits them, so mirror {@link #decoratePropertyValues} and fetch them from the entity-version service.
+   */
+  private java.util.Map<Long, List<org.termx.ts.codesystem.EntityPropertyValue>> loadConceptPropertyValues(List<Concept> concepts) {
+    String ids = concepts.stream()
+        .map(ValueSetExpandOperation::firstVersionId)
+        .filter(java.util.Objects::nonNull).distinct().map(String::valueOf)
+        .collect(java.util.stream.Collectors.joining(","));
+    if (StringUtils.isEmpty(ids)) {
+      return java.util.Map.of();
+    }
+    org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams params = new org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams();
+    params.setIds(ids);
+    params.setLimit(-1);
+    return codeSystemEntityVersionService.query(params).getData().stream()
+        .filter(v -> v.getPropertyValues() != null)
+        .collect(java.util.stream.Collectors.toMap(CodeSystemEntityVersion::getId,
+            CodeSystemEntityVersion::getPropertyValues, (a, b) -> a));
   }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy
@@ -598,6 +598,80 @@ class ValueSetExpandOperationTest extends Specification {
     result.expansion.contains[0].display == "Decreased"
   }
 
+  def "implicit-CS expand with property= surfaces contains[].property (incl. a Coding) and declares it"() {
+    // The concept-query result omits property values, so the operation loads them by entity-version id
+    // and, when the client requests properties, attaches contains[].property via the shared FHIR mapper —
+    // Coding-typed properties surface as valueCoding, matching the main $expand path.
+    given:
+    valueSetService.query(_) >> QueryResult.empty()
+    codeSystemService.query(_) >> { args ->
+      CodeSystemQueryParams p = args[0]
+      return p.uri == "http://example.org/CodeSystem/service-events"
+          ? new QueryResult<>([new CodeSystem().setUri("http://example.org/CodeSystem/service-events").tap { setId("service-events") }])
+          : QueryResult.empty()
+    }
+    conceptService.query(_) >> {
+      def qr = new QueryResult<Concept>([cncptWithVersionId("AAD001", "Male doctor visit", 100L)])
+      qr.meta.total = 1
+      return qr
+    }
+    // Property values loaded by entity-version id: a Coding property plus a code property.
+    codeSystemEntityVersionService.query(_) >> new QueryResult<CodeSystemEntityVersion>([
+        new CodeSystemEntityVersion().setId(100L).setPropertyValues([
+            codingPropertyValue("teenuseValdkond", "AD", "http://example.org/CodeSystem/teenuste-valdkonnad"),
+            codePropertyValue("status", "active")])])
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/CodeSystem/service-events?fhir_vs"))
+        .addParameter(new Parameters.ParametersParameter("property").setValueCode("teenuseValdkond"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 1
+    def contain = result.expansion.contains[0]
+    contain.code == "AAD001"
+    def prop = contain.property.find { it.code == "teenuseValdkond" }
+    prop != null
+    prop.valueCoding != null
+    prop.valueCoding.code == "AD"
+    prop.valueCoding.system == "http://example.org/CodeSystem/teenuste-valdkonnad"
+    // `status` was not requested, so it is filtered out.
+    contain.property.every { it.code != "status" }
+    // The requested property is declared on the expansion (valid FHIR — contains.property references it).
+    result.expansion.property.find { it.code == "teenuseValdkond" } != null
+  }
+
+  def "implicit-CS expand without property= attaches no properties and skips the property-value load"() {
+    given:
+    valueSetService.query(_) >> QueryResult.empty()
+    codeSystemService.query(_) >> { args ->
+      CodeSystemQueryParams p = args[0]
+      return p.uri == "http://example.org/CodeSystem/service-events"
+          ? new QueryResult<>([new CodeSystem().setUri("http://example.org/CodeSystem/service-events").tap { setId("service-events") }])
+          : QueryResult.empty()
+    }
+    conceptService.query(_) >> {
+      def qr = new QueryResult<Concept>([cncptWithVersionId("AAD001", "Male doctor visit", 100L)])
+      qr.meta.total = 1
+      return qr
+    }
+
+    def req = new Parameters()
+        .addParameter(new Parameters.ParametersParameter("url").setValueUrl("http://example.org/CodeSystem/service-events?fhir_vs"))
+
+    when:
+    def result = operation.run(req)
+
+    then:
+    result.expansion.contains.size() == 1
+    result.expansion.contains[0].property == null || result.expansion.contains[0].property.isEmpty()
+    result.expansion.property == null || result.expansion.property.isEmpty()
+    // No property requested → no extra entity-version query.
+    0 * codeSystemEntityVersionService.query(_)
+  }
+
 
   // ---------------------------------------------------------------------------
   // SNOMED CT implicit-ValueSet URLs
@@ -976,6 +1050,30 @@ class ValueSetExpandOperationTest extends Specification {
           new Designation().setName(displayName).setLanguage("en").setDesignationType("display")
       ])])
     }
+  }
+
+  /** Like {@link #cncpt} but stamps the entity-version id the property-value lookup keys on. */
+  private static Concept cncptWithVersionId(String code, String displayName, Long versionId) {
+    return new Concept().tap { c ->
+      c.setCode(code)
+      c.setVersions([new CodeSystemEntityVersion().setId(versionId).setDesignations([
+          new Designation().setName(displayName).setLanguage("en").setDesignationType("display")
+      ])])
+    }
+  }
+
+  private static org.termx.ts.codesystem.EntityPropertyValue codingPropertyValue(String propertyCode, String code, String codeSystem) {
+    return new org.termx.ts.codesystem.EntityPropertyValue()
+        .setEntityProperty(propertyCode)
+        .setEntityPropertyType(org.termx.ts.codesystem.EntityPropertyType.coding)
+        .setValue(new org.termx.ts.codesystem.EntityPropertyValue.EntityPropertyValueCodingValue(code, codeSystem))
+  }
+
+  private static org.termx.ts.codesystem.EntityPropertyValue codePropertyValue(String propertyCode, String value) {
+    return new org.termx.ts.codesystem.EntityPropertyValue()
+        .setEntityProperty(propertyCode)
+        .setEntityPropertyType(org.termx.ts.codesystem.EntityPropertyType.code)
+        .setValue(value)
   }
 
   /**


### PR DESCRIPTION
## Problem

The implicit-ValueSet-over-a-stored-CodeSystem path (`tryExpandCodeSystemImplicit` — e.g. `$expand?url=<cs>?fhir_vs`, or a bare canonical that matches a stored CodeSystem) built expansion members from `ConceptService.query` with only `system`/`code`/`display`. It never attached `contains[].property`, so a `property=` request against an implicit CodeSystem expansion came back with no properties — even though the main `$expand` path surfaces them via `toFhirContainsProperties`.

## Change

- Load each concept's property values by entity-version id — the concept query omits them, exactly as the stored-snapshot path does (`decoratePropertyValues`), so this mirrors that with a small `loadConceptPropertyValues` helper.
- When the client requests properties (`property=`), attach `contains[].property` via the shared `ValueSetFhirMapper.toFhirContainsProperties` (so **Coding-typed** properties surface as `valueCoding`), and declare the requested properties in `expansion.property` (with uris from a `tx-resource` CodeSystem when supplied, else the FHIR `concept-properties#<code>` uri).
- Gated on `property=`: an implicit VS has no `compose.property` to auto-include from, so this mirrors the main path's request gating. No extra entity-version query runs when properties aren't requested.

**SNOMED implicit (`?fhir_vs=...`) is intentionally unchanged** — its concepts come from Snowstorm via the external expand provider and carry no stored `EntityPropertyValue`s, so there is no local property source to attach. That would require Snowstorm property support (a separate feature).

## Tests

Added to `ValueSetExpandOperationTest`:
- `implicit-CS expand with property=` surfaces a `valueCoding` property, declares it in `expansion.property`, and filters out an unrequested property.
- `implicit-CS expand without property=` attaches no properties and skips the entity-version load (`0 *` interaction).

`:terminology:test --tests ValueSetExpandOperationTest` → 32 tests, 0 failures.

## Context

Companion to the terminology-explorer property-in-`$expand` work (termx-health/terminology-explorer #92, #95). This closes the equivalent gap in termx-server's own implicit expand path.