### PR TITLE
fix(github): drop com.sun.jdi import that 500s Space edit on the JRE image

### DIFF
--- a/termx-core/src/main/java/org/termx/core/github/GithubService.java
+++ b/termx-core/src/main/java/org/termx/core/github/GithubService.java
@@ -12,7 +12,6 @@ import com.kodality.commons.util.MapUtil;
 import org.termx.core.auth.SessionStore;
 import org.termx.core.github.GithubService.GithubContent.GithubContentEncoding;
 import org.termx.core.github.GithubService.GithubTreeItem.GithubTreeType;
-import com.sun.jdi.request.InvalidRequestStateException;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.http.HttpHeaders;
@@ -94,7 +93,7 @@ public class GithubService {
   public String authorizeUser(String state, String code) {
     Map<String, String> stateObj = (Map<String, String>) this.cacheManager.getCache("state").get(state);
     if (stateObj == null) {
-      throw new InvalidRequestStateException("invalid 'state'");
+      throw new IllegalStateException("invalid 'state'");
     }
     String user = stateObj.get("user");
     String repo = stateObj.get("repo");

--- a/termx-core/src/test/groovy/org/termx/core/github/GithubServiceRuntimeSafetySpec.groovy
+++ b/termx-core/src/test/groovy/org/termx/core/github/GithubServiceRuntimeSafetySpec.groovy
@@ -1,0 +1,34 @@
+package org.termx.core.github
+
+import spock.lang.Specification
+
+/**
+ * Regression guard for the "Spaces -> Edit -> XX100 System error" incident.
+ *
+ * GithubService.authorizeUser() threw `com.sun.jdi.request.InvalidRequestStateException`
+ * (an IDE auto-import mistake - JDI is the Java Debug Interface, module jdk.jdi).
+ * That module is NOT shipped in the eclipse-temurin *-jre runtime image the app runs on.
+ * When Micronaut instantiates GithubService, the JVM verifier links authorizeUser() and,
+ * because of the `throw new InvalidRequestStateException(...)`, tries to load the class to
+ * confirm it is a Throwable -> NoClassDefFoundError: com/sun/jdi/request/InvalidRequestStateException
+ * -> BeanInstantiationException -> GET /api/spaces/github/providers returns 500 -> the Edit
+ * Space page shows "XX100 System error".
+ *
+ * It compiled fine and passed on a JDK, so a plain instantiate-the-bean test would NOT catch it.
+ * This test scans the compiled bytecode's constant pool instead: class references are stored as
+ * slash-separated UTF-8 (e.g. "com/sun/jdi/request/InvalidRequestStateException"), so a byte
+ * scan reproduces exactly what the runtime verifier would choke on - deterministically, under a JDK.
+ */
+class GithubServiceRuntimeSafetySpec extends Specification {
+
+  def "GithubService bytecode must not reference JDK-only modules missing from the runtime JRE (jdk.jdi)"() {
+    given: "the compiled bytecode of GithubService"
+    byte[] bytecode = GithubService.getResourceAsStream("GithubService.class").withCloseable { it.bytes }
+    // ISO-8859-1 is a byte-preserving decode: every byte maps 1:1 to a char, so the
+    // constant-pool UTF-8 class names survive intact for substring matching.
+    String constantPool = new String(bytecode, "ISO-8859-1")
+
+    expect: "no reference to com.sun.jdi - it is absent from the eclipse-temurin:*-jre image"
+    !constantPool.contains("com/sun/jdi")
+  }
+}


### PR DESCRIPTION
## Problem

Opening **Spaces → (a space) → Edit** on dev.termx.org renders an empty "Edit space" form and pops a red **XX100 — System error** toast. The Edit view fires `GET /api/spaces/github/providers`, which returns **HTTP 500** with a Micronaut `BeanInstantiationException` for `SpaceGithubService` → its dependency `GithubService`.

The underlying cause is `NoClassDefFoundError: com/sun/jdi/request/InvalidRequestStateException`.

## Root cause

`GithubService` imported `com.sun.jdi.request.InvalidRequestStateException` — a **Java Debug Interface** type from the JDK-only module **`jdk.jdi`** — and threw it in `authorizeUser()`. This was an IDE auto-import mistake and has been present since the original GitHub integration.

`jdk.jdi` is **not shipped in the `eclipse-temurin:*-jre` runtime image**. Once the Docker base image moved from a JDK (`openjdk:17.0.1-slim`) to a JRE (`eclipse-temurin:25-jre`, commit `d8eacb48` "Switch to Java25"), the class became unresolvable at runtime. When Micronaut instantiates `GithubService`, the JVM verifier links `authorizeUser()`; the `throw new InvalidRequestStateException(...)` forces the class to load to confirm it's a `Throwable`, which fails → the 500 → **XX100**.

> Note: this is **not** related to the Azure DevOps / OAuth2 HTTP-client work (#371) — that PR doesn't touch `GithubService`.

## Fix

- Throw `java.lang.IllegalStateException` (from `java.base`, always present) instead of the JDI type, and remove the bad import. It was the only `com.sun.jdi` reference in the repo.

## Test

- `GithubServiceRuntimeSafetySpec` scans `GithubService`'s compiled bytecode constant pool for `com/sun/jdi`. It reproduces exactly what the runtime verifier chokes on and fails **deterministically even under a JDK test JVM** — where instantiating the bean would falsely pass because the JDK *has* `jdk.jdi`.
  - Against the buggy code: **FAILED** (reproduces the incident)
  - After the fix: **PASSED**