### PR TITLE
docs: validate feature docs against source and fix inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ By default the `yupi` session is granted the full set of action wildcards (`*.*.
 ./gradlew :termx-app:run -Pdev -PyupiPrivileges='icd-10.CodeSystem.read'
 ```
 
-The value is a comma-separated list of dotted privilege strings (`{resource}.{type}.{action}`); whitespace and empty tokens are ignored. Common preset values and their expected UI effect are documented in [docs/specification/terminology-server/privileges-migration-guide.md](../docs/specification/terminology-server/privileges-migration-guide.md#qa-testing-with-the-yupi-privilege-override) and inline in [`YupiSessionProvider`](termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java).
+The value is a comma-separated list of dotted privilege strings (`{resource}.{type}.{action}`); whitespace and empty tokens are ignored. The privilege/action model (GitHub-based `read`/`triage`/`write`/`maintain`) and how privilege sets map to visibility is documented in [docs/features/task-access-control.md](docs/features/task-access-control.md), with preset values inline in [`YupiSessionProvider`](termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java).
 
 For ad-hoc per-request overrides without restarting the server, send a JSON-encoded `SessionInfo` directly in the header:
 

--- a/docs/code-system-supplements-analysis.md
+++ b/docs/code-system-supplements-analysis.md
@@ -27,29 +27,29 @@ Supplements are stored as separate code systems with:
 
 Relevant file:
 
-- [`CodeSystemSupplementService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java)
+- [`CodeSystemSupplementService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java)
 
 When supplement entity versions are created from base entity versions, the supplement entity version keeps a pointer to the base entity version through `baseEntityVersionId`.
 
 Relevant file:
 
-- [`CodeSystemSupplementService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java)
+- [`CodeSystemSupplementService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java)
 
 At entity-version decoration time, base and supplement data can be merged, with base-derived items marked using `supplement=true`.
 
 Relevant file:
 
-- [`CodeSystemEntityVersionService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionService.java)
+- [`CodeSystemEntityVersionService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionService.java)
 
 ## Generic Runtime Supplement Enrichment
 
 Runtime supplement enrichment for concept responses is centralized in:
 
-- [`ConceptSupplementService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java)
+- [`ConceptSupplementService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java)
 
 The request model is carried through:
 
-- [`ConceptQueryParams.java`](/job/helex/htx/termx-server/termx-api/src/main/java/org/termx/ts/codesystem/ConceptQueryParams.java)
+- [`ConceptQueryParams.java`](../termx-api/src/main/java/org/termx/ts/codesystem/ConceptQueryParams.java)
 
 Current semantics:
 
@@ -71,7 +71,7 @@ The merge is currently designation-focused:
 
 Relevant file:
 
-- [`CodeSystemLookupOperation.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java)
+- [`CodeSystemLookupOperation.java`](../terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java)
 
 Current behavior:
 
@@ -86,7 +86,7 @@ Current behavior:
 
 Relevant file:
 
-- [`CodeSystemValidateCodeOperation.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java)
+- [`CodeSystemValidateCodeOperation.java`](../terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java)
 
 Current behavior:
 
@@ -101,9 +101,9 @@ TS concept query/load endpoints are also supplement-aware through the same share
 
 Relevant files:
 
-- [`ConceptService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptService.java)
-- [`ConceptController.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptController.java)
-- [`CodeSystemController.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java)
+- [`ConceptService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptService.java)
+- [`ConceptController.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptController.java)
+- [`CodeSystemController.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java)
 
 This is the main change from the earlier supplement state: supplement-aware runtime concept loading is no longer limited to FHIR operations.
 
@@ -113,8 +113,8 @@ Value set expansion still does not implement the same generic runtime supplement
 
 Relevant files:
 
-- [`ValueSetExpandOperation.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java)
-- [`ValueSetVersionConceptService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java)
+- [`ValueSetExpandOperation.java`](../terminology/src/main/java/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperation.java)
+- [`ValueSetVersionConceptService.java`](../terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java)
 
 Current behavior:
 
@@ -134,7 +134,7 @@ The FHIR mapper can represent supplement semantics in exported ValueSets by:
 
 Relevant file:
 
-- [`ValueSetFhirMapper.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java)
+- [`ValueSetFhirMapper.java`](../terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetFhirMapper.java)
 
 That affects representation and export. It does not mean `$expand` consumes the same extension into generic runtime supplement loading.
 

--- a/docs/features/architecture.md
+++ b/docs/features/architecture.md
@@ -26,7 +26,7 @@ TermX Server uses two Java package root namespaces:
 |-----------|---------|
 | `org.termx.*` | All modules (API contracts, core infrastructure, and feature implementations) |
 
-All code uses `org.termx.*` namespace. The migration from `com.kodality.termx.*` to `org.termx.*` has been completed for all modules including `termx-api` and `termx-core`.
+All code uses `org.termx.*` namespace. The migration from `org.termx.*` to `org.termx.*` has been completed for all modules including `termx-api` and `termx-core`.
 
 ---
 
@@ -61,6 +61,7 @@ All business logic lives here. Each Gradle subproject maps to a single top-level
 | `terminology` | `org.termx.terminology` | Core terminology services: code systems, value sets, map sets, FHIR adapters, file importers |
 | `ucum` | `org.termx.ucum` | UCUM unit-of-measure service: measurement units, FHIR integration, essence store |
 | `wiki` | `org.termx.wiki` | Wiki module: pages, content, comments, tags, templates, links, attachments |
+| `wiki-pdf` | `com.asseco.termx.wiki.pdf` | Wiki PDF export (controller + rendering) |
 | `bob` | `org.termx.bob` | Binary Object Store (BOB) — general-purpose file/attachment storage |
 | `modeler` | `org.termx.modeler` | Structure Definition and Transformation Definition modelling |
 | `snomed` | `org.termx.snomed` | SNOMED CT integration (Snowstorm client, RF2 import/export, translations) |
@@ -71,6 +72,7 @@ All business logic lives here. Each Gradle subproject maps to a single top-level
 | `edition-uzb` | `org.termx.editionuzb` | Uzbek national edition extensions (IchiUz) |
 | `uam` | `org.termx.uam` | User and Access Management |
 | `termx-app` | `org.termx` | Application entry point, Micronaut bootstrap, OpenAPI aggregation |
+| `termx-integtest` | `org.termx` | Integration-test harness (test application + FHIR/Groovy integration tests) |
 
 ---
 
@@ -144,8 +146,8 @@ All build files use Gradle Kotlin DSL for type-safe configuration:
 | `publish` | Publishes Maven artifacts to GitHub Packages | Yes |
 | `run` | Runs the application (from `termx-app`; use `:termx-app:run`) | No |
 | `shadowJar` | Builds the fat JAR for `termx-app` | No (Docker build uses context) |
-| `spotbugsCheck` | Runs SpotBugs on all projects; **manual only**, not part of `check` | No |
-| `pmdCheck` | Runs PMD on all projects; **manual only**, not part of `check` | No |
+| `spotbugsCheck` | Runs SpotBugs on all projects; not part of `check` | Yes (release + weekly) |
+| `pmdCheck` | Runs PMD on all projects; not part of `check` | Yes (release + weekly) |
 
 **Verification:** `check` runs only tests. SpotBugs and PMD are excluded from `check` to keep CI fast; run `./gradlew spotbugsCheck` or `./gradlew pmdCheck` when you want static analysis.
 
@@ -171,9 +173,9 @@ All build files use Gradle Kotlin DSL for type-safe configuration:
 - Multi-platform: `linux/amd64`, `linux/arm64`
 
 **CI/CD:** GitHub Actions
-- Builds on push to `main` or version tags
-- Single Gradle step: `clean assemble check publish` (then Docker build and push)
-- Publishes Maven artifacts and Docker images automatically
+- **Push build** (`.github/workflows/build.yml`) — on push to `main` or version tags: `./gradlew clean assemble --no-daemon` (no tests, no static analysis, no publish), then Docker build and multi-platform push.
+- **Release build** (`.github/workflows/build-release.yml`) — on version tags: `./gradlew clean assemble check pmdCheck spotbugsCheck dependencyCheckAggregate publish` (full verification + Maven publish to GitHub Packages).
+- **Weekly checks** (`.github/workflows/weekly-checks.yml`) — Monday 05:00 UTC: `check pmdCheck spotbugsCheck` plus an advisory OWASP `dependencyCheckAggregate`.
 
 ---
 

--- a/docs/features/code-system-supplement-and-lookup.md
+++ b/docs/features/code-system-supplement-and-lookup.md
@@ -200,7 +200,7 @@ Content-Type: application/json
 
 ## 5. Implementation notes (TermX codebase)
 
-- **Lookup + supplements:** `CodeSystemLookupOperation` loads the concept from the base system, then calls `loadSupplementDesignations(...)` which:
+- **Lookup + supplements:** `CodeSystemLookupOperation` resolves the concept through the shared concept-query path — it builds a `ConceptQueryParams` with `setIncludeSupplement(true)`, `setDisplayLanguage(...)`, and `setUseSupplement(extractUseSupplement(req))` and calls `conceptService.query(...)` (`CodeSystemLookupOperation.java:125-133`). There is no dedicated `loadSupplementDesignations` method; supplement enrichment happens inside that query path (`ConceptSupplementService`), which:
   - collects supplement references from `useSupplement` parameters (valueCanonical/valueUri/valueUrl/valueString),
   - if `displayLanguage` is set, discovers supplements by `baseCodeSystem` + `content = supplement`,
   - for each supplement, loads the concept by the same `code` in the supplement and merges designations, filtered by `displayLanguage`.

--- a/docs/features/codesystem-concept-export-specification.md
+++ b/docs/features/codesystem-concept-export-specification.md
@@ -64,12 +64,14 @@ Format: `{propertyName}#code::{order}` and `{propertyName}#system::{order}` (whe
 
 ### Special Columns
 - `status` - Concept status (active, draft, retired, etc.)
-- `is-a` - Parent concepts (comma-separated)
-- `parent` - Parent concepts (comma-separated)
-- `child` - Child concepts (comma-separated)
-- `partOf` - Part-of relationships (comma-separated)
-- `groupedBy` - Grouped-by relationships (comma-separated)
-- `classifiedWith` - Classified-with relationships (comma-separated)
+- `is-a` - Parent concepts (`#`-separated)
+- `parent` - Parent concepts (`#`-separated)
+- `child` - Child concepts (`#`-separated)
+- `partOf` - Part-of relationships (`#`-separated)
+- `groupedBy` - Grouped-by relationships (`#`-separated)
+- `classifiedWith` - Classified-with relationships (`#`-separated)
+
+> **Note on association columns**: The parent/child code sets are built from **all active associations with no association-type filter** (`ConceptExportService.java:75-80,365-368`). Every parent-direction column (`is-a`, `parent`, `partOf`, `groupedBy`, `classifiedWith`) emits the **same** unfiltered set of parent target codes, and `child` emits the unfiltered set of child codes. The column names do **not** select associations by type.
 
 ## Column Ordering
 
@@ -129,7 +131,7 @@ Columns appear in the following order:
 - **Empty**: Empty string if no version exists
 
 #### Association Columns (is-a, parent, child, partOf, groupedBy, classifiedWith)
-- **Value**: Comma-separated list of target concept codes
+- **Value**: `#`-separated list of target concept codes
 - **Format**: `String.join("#", codes)`
 - **Filtering**: Only active associations are included
 - **Empty**: Empty string if no associations exist

--- a/docs/features/codesystem-concept-import-specification.md
+++ b/docs/features/codesystem-concept-import-specification.md
@@ -15,7 +15,7 @@ Designation columns encode the value's language with a `type:language` header (e
   - Column separator: semicolon (`;`) or comma (`,`)
 - **TSV**: Tab-separated values with UTF-8 encoding
   - Column separator: Tab character
-- **XLSX**: Excel format with worksheet named "concepts" (or first worksheet)
+- **XLSX**: Excel format with a worksheet named "concepts" (required — import fails with `ApiError.TE740` if absent)
 
 ## Column Naming Conventions
 
@@ -146,7 +146,7 @@ This order ensures that `type#code::1` is correctly identified as a coding prope
 #### String
 - **Value**: Cell value is used as-is
 - **Delimiter support**: If property delimiter is configured, values are split and multiple property values are created
-  - **Maximum delimiter length**: 3 characters
+  - **Maximum delimiter length**: 3 characters (a UI/config guideline only — the backend parser splits on the delimiter as-is and does not enforce any length limit)
   - **Applies to**: Coding and string datatypes only
   - **Processing**: Split string into parts, trim each part, validate each part separately, create property value for every part
 - **Empty cells**: Skipped
@@ -215,7 +215,7 @@ Each property in the import request includes:
   - Shown only for date type properties
 - `propertyCodeSystem`: Code system URI for coding properties (legacy format)
 - `propertyDelimiter`: Delimiter for splitting multiple values (e.g., "|")
-  - Maximum 3 characters
+  - Maximum 3 characters (UI/config guideline only; not enforced by the backend parser)
   - Shown for Coding and string datatypes only
   - When specified: split string into parts, trim parts, validate each separately, create property for every part
 - `language`: Language code for designation properties
@@ -299,7 +299,7 @@ The `import` flag (whether to import a column) is automatically set based on col
   - **When**: A property in the import configuration has no `propertyType`
 
 - **TE707**: Multiple preferred identifiers
-  - **Message**: "Multiple preferred identifier properties found"
+  - **Message**: "The 'concept-code' and 'hierarchical-concept' can not be used simultaneously. Please specify only one of them"
   - **When**: More than one identifier property is marked as preferred
 
 - **TE721**: No designation property

--- a/docs/features/codesystem-import.md
+++ b/docs/features/codesystem-import.md
@@ -41,14 +41,18 @@ FHIR resource) to persisted concepts and **entity versions**, the merge vs. repl
 3. `saveCodeSystem` — upsert code-system metadata.
 4. `saveCodeSystemVersion` — the target version (honours `cleanRun`).
 5. `saveProperties` — entity properties, including designation-type properties.
-6. `saveConcepts(prepareConcepts(...), version, properties, cleanConceptRun)`.
+6. `saveConcepts(prepareConcepts(...), version, entityProperties, replaceConceptVersions, retireRedundant)` — the two
+   booleans are derived from the action: `retireRedundant = cleanRun || cleanConceptRun` and
+   `replaceConceptVersions = cleanConceptRun && !cleanRun` (`CodeSystemImportService.java:109-112`).
 7. `activate` / `retire` the version as requested (re-checks `CS_MAINTAIN`).
 8. Optionally add to a space and/or generate a value set.
 
 ## 4. `saveConcepts` — concepts and their versions
 
 1. `batchSave` the concept **entities** (code/description rows).
-2. **Replace only** — `cancelOrRetireRedundantConcepts`: concepts absent from the file are retired.
+2. **Replace *or* clean-version** — `cancelOrRetireRedundantConcepts`: concepts absent from the file are retired.
+   This runs whenever `retireRedundant = cleanRun || cleanConceptRun` (`CodeSystemImportService.java:274`), i.e. for
+   both "replace concepts" and "clean version" (see the §4 blockquote), not for a plain merge.
 3. For each concept, build a prepared `CodeSystemEntityVersion` (status `draft`), resolving property
    value ids/types and designation-type ids (`prepareEntityVersion`).
 4. **Per-concept version decision** — `holdUnchangedAndMerge` (both modes):
@@ -110,12 +114,18 @@ retired) or updated (draft) version.
 
 _Merged from the former `codesystem-import-export-implementation-validation.md`._
 
+> **Audit snapshot (2026-03-20).** This section is a point-in-time compliance audit, not a live cross-reference.
+> The `line NNN` citations reflect the source as of the validation date and have since drifted (e.g. the decimal
+> formatting is now at `ConceptExportService.java:424-426`, TE808 further down the file); rely on the referenced
+> **method names** rather than the exact line numbers. The spec versions and the association/decimal-formatting
+> notes above have been corrected in place.
+
 
 ### Overview
 
 This document validates that the current implementation matches the specifications defined in:
-- `codesystem-concept-export-specification.md` (Version 1.0.2)
-- `codesystem-concept-import-specification.md` (Version 1.0.2)
+- `codesystem-concept-export-specification.md` (Version 1.1.0)
+- `codesystem-concept-import-specification.md` (Version 1.1.0)
 - the "Test coverage" section below
 
 ### Validation Date
@@ -167,7 +177,7 @@ This document validates that the current implementation matches the specificatio
 
 **Simple Property Types:**
 - ✅ String: value as-is (line 420)
-- ✅ Decimal: Uses `BigDecimal.toPlainString()` (line 421-422)
+- ✅ Decimal: Uses `BigDecimal.stripTrailingZeros().toPlainString()` (`ConceptExportService.java:424-426`)
 - ✅ DateTime: Local date portion only (line 424)
 - ✅ Other types: JSON representation (line 426)
 
@@ -179,7 +189,7 @@ This document validates that the current implementation matches the specificatio
 
 **Special Columns:**
 - ✅ Status: from first concept version (line 363)
-- ✅ Association columns: comma-separated list of target codes (lines 365-376)
+- ✅ Association columns: `#`-separated list of target codes (`composeRow`, `String.join("#", codes)`)
 - ✅ Only active associations included (line 77)
 
 ##### ✅ Header Generation Logic
@@ -239,9 +249,9 @@ This document validates that the current implementation matches the specificatio
 
 ##### ⚠️ Minor Observations
 
-1. **Decimal Formatting**: Implementation uses `BigDecimal.toPlainString()` which is correct, but specification mentions trailing zeros removal. The implementation may include trailing zeros (e.g., `10.00`). This is acceptable as `toPlainString()` preserves precision.
+1. **Decimal Formatting**: Implementation uses `BigDecimal.stripTrailingZeros().toPlainString()` (`ConceptExportService.java:424-426`), so trailing zeros **are** removed (e.g., `10.00` → `10`), matching the specification.
 
-2. **Association Format**: Specification says `String.join("#", codes)` but implementation uses comma-separated format. Need to verify this matches specification requirement.
+2. **Association Format**: Implementation uses `String.join("#", codes)` (`ConceptExportService.java:366-368`), matching the specification — association target codes are `#`-separated, not comma-separated.
 
 ---
 
@@ -463,7 +473,7 @@ All major specification requirements are implemented correctly:
 - Header and row generation logic with proper column processing order
 
 **Minor Notes:**
-- Association format may need verification (specification says `String.join("#", codes)` but implementation may use comma-separated)
+- Association format confirmed: implementation uses `String.join("#", codes)` (`ConceptExportService.java:366-368`) — target codes are `#`-separated, matching the specification
 
 #### ✅ Import Implementation
 **Status**: **FULLY COMPLIANT**
@@ -494,7 +504,7 @@ All 25 tests (10 processor + 15 mapper) are implemented and cover:
 
 ### Recommendations
 
-1. **Verify Association Format**: Check if association columns use `#` separator as specified or comma-separated format. Update specification or implementation to match.
+1. **Association Format** (resolved): Association columns use the `#` separator (`ConceptExportService.java:366-368`), matching the specification. No action needed.
 
 2. **Date Format Verification**: Verify that `transformDate()` method in `CodeSystemFileImportProcessor` correctly handles all four date formats (YYYY-MM-DD, DD.MM.YY, DD.MM.YYYY, MM/DD/YYYY).
 

--- a/docs/features/deployment-configuration.md
+++ b/docs/features/deployment-configuration.md
@@ -81,10 +81,8 @@ Development-only auth (do **not** use in production):
 ### 1.6 Large terminology import (SNOMED + LOINC archives) — see [`snomed-import-management.md`](snomed-import-management.md), [`loinc-import-management.md`](loinc-import-management.md)
 | Env var / property | Default | Purpose |
 |---|---|---|
-| `termx.terminology-archive.bucket` | `terminology-archives` | MinIO bucket for stored archives (auto-created) |
-| `termx.terminology-archive.retention-per-edition` | `3` | Archives kept per edition before cleanup |
-| `termx.snomed.delta-generator.timeout-seconds` | `1800` | Hard cap on the delta-generator subprocess |
-| `micronaut.server.max-request-size` | `1610612736` (1.5 GB) | Max multipart upload (SNOMED Intl ≈ 1 GB) |
+| `micronaut.server.max-request-size` | `629145600` (600 MB) | Max multipart upload (SNOMED International RF2 ≈ 549 MB) |
+| `micronaut.server.multipart.max-file-size` | `629145600` (600 MB) | Per-file multipart cap (same value) |
 
 > **Delta-generator jar is bundled — no env var.** The IHTSDO `DeltaGeneratorTool-3.0.0.jar` is
 > vendored in the image (`snomed/src/main/resources/snomed/delta-generator-tool/`) and auto-extracted
@@ -176,10 +174,10 @@ In the shipped image `validator_cli.jar` is downloaded in the Dockerfile and
 
 | Env var | Property | Default | Purpose |
 |---|---|---|---|
-| `TERMX_CONFORMANCE_VALIDATOR_JAR` | `conformance.validator-jar` | (baked into image) | Absolute path to `validator_cli.jar` |
-| `TERMX_CONFORMANCE_TX_URL` | `conformance.tx-url` | `http://localhost:8200/fhir` | This server's externally-reachable FHIR base, used as the `-tx` target |
-| `TERMX_CONFORMANCE_TEST_PACKAGE_DIR` | `conformance.test-package-dir` | (validator package cache) | Dir holding the tx-ecosystem test fixtures for `loadSetup=true` runs |
-| `TERMX_CONFORMANCE_SETUP_AUTH_TOKEN` | `conformance.setup-auth-token` | (none) | Bearer token the setup loader uses to write fixtures (needs CS/VS create+update privileges) |
+| `TERMX_CONFORMANCE_VALIDATOR_JAR` | `termx.conformance.validator-jar` | (baked into image) | Absolute path to `validator_cli.jar` |
+| `TERMX_CONFORMANCE_TX_URL` | `termx.conformance.tx-url` | `http://localhost:8200/fhir` | This server's externally-reachable FHIR base, used as the `-tx` target |
+| `TERMX_CONFORMANCE_TEST_PACKAGE_DIR` | `termx.conformance.test-package-dir` | (validator package cache) | Dir holding the tx-ecosystem test fixtures for `loadSetup=true` runs |
+| `TERMX_CONFORMANCE_SETUP_AUTH_TOKEN` | `termx.conformance.setup-auth-token` | (none) | Bearer token the setup loader uses to write fixtures (needs CS/VS create+update privileges) |
 
 ### 1.16 Global search (3.3+)
 
@@ -285,7 +283,7 @@ credentials (`minio`/`minio123`).
 | Path | Upstream | Notes |
 |---|---|---|
 | `/` | termx-web | SPA |
-| `/api/` | termx-server `:8200` | raise client max body size (≈1.5 GB for SNOMED import) |
+| `/api/` | termx-server `:8200` | raise client max body size (≈600 MB for SNOMED import) |
 | `/swagger` | swagger-ui `:8000` | |
 | `/chef/` | fsh-chef `:8500` | |
 | `/plantuml` | plantuml `:8501` | |
@@ -327,8 +325,9 @@ credentials (`minio`/`minio123`).
   `BOB_MINIO_*` user must match what the init container created.
 - **No object storage ⇒ import endpoints fail (503).** SNOMED/LOINC archive import and wiki file
   storage require MinIO; without `BOB_MINIO_*` those features are unavailable.
-- **Request-size limits.** SNOMED International archives are ≈1 GB; raise both
-  `micronaut.server.max-request-size` (default 1.5 GB) and the reverse-proxy body limit or uploads fail.
+- **Request-size limits.** SNOMED International RF2 archives are ≈549 MB; the default
+  `micronaut.server.max-request-size` / `multipart.max-file-size` is **600 MB** (`629145600`). Raise
+  both these and the reverse-proxy body limit if you import larger archives, or uploads fail.
 - **OOM ⇒ container restart by design.** The image runs with `-XX:+ExitOnOutOfMemoryError` and dumps
   to `/app/logs`, so Docker's restart policy recovers it — size `JAVA_OPTS -Xmx` for your workload.
   **Set a container memory limit** (`mem_limit` / `--memory`) at least as large as `-Xmx` plus

--- a/docs/features/email-import-notifications.md
+++ b/docs/features/email-import-notifications.md
@@ -90,7 +90,7 @@ micronaut:
 4. Import completes with 50,000 concepts imported
 5. Email automatically sent to all recipients
 
-**Outcome:** Team receives email with "Import Completed: LOINC 2.76" containing duration (15 min), success count (50,000), and zero errors.
+**Outcome:** Team receives email with subject "[TermX] loinc-import (loinc-2.76) - Completed" containing duration (15 min), success count (50,000), and zero errors.
 
 ### Scenario 2: Failed Import Alert
 
@@ -194,7 +194,7 @@ curl -X POST -H "Content-Type: multipart/form-data" \
 # 2. Wait for import to complete (check UI or poll job status)
 
 # 3. Check email inbox
-# Expected: Email with subject "Import Completed: LOINC 2.76"
+# Expected: Email with subject "[TermX] loinc-import (loinc-2.76) - Completed"
 ```
 
 ### Test with CodeSystem import
@@ -361,9 +361,9 @@ sequenceDiagram
     participant Email as EmailService
     participant SMTP as SMTP Server
     
-    Import->>JobLog: finish(jobLog)
+    Import->>JobLog: finish(id, successes, warnings, errors)
     JobLog->>Database: Save job record
-    JobLog->>Notification: sendImportCompletionEmail(jobLog)
+    JobLog->>Notification: sendImportCompletionNotification(jobLog)
     Notification->>Notification: Format HTML email
     Notification->>Notification: Calculate duration
     Notification->>Email: sendToMultiple(recipients, subject, body)
@@ -379,12 +379,12 @@ sequenceDiagram
 
 | File | Description |
 |------|-------------|
-| `termx-core/src/main/java/com/kodality/termx/core/sys/email/EmailService.java` | SMTP service with multi-recipient support |
-| `termx-core/src/main/java/com/kodality/termx/core/sys/job/logger/ImportNotificationService.java` | Formats and sends import completion emails |
-| `termx-core/src/main/java/com/kodality/termx/core/sys/job/JobLogService.java` | Hooks email notifications into finish() method |
-| `snomed/src/main/java/com/kodality/termx/snomed/snomed/SnomedImportPollingService.java` | Background polling for SNOMED imports |
-| `snomed/src/main/java/com/kodality/termx/snomed/snomed/SnomedImportTracking.java` | Tracks SNOMED import jobs |
-| `snomed/src/main/java/com/kodality/termx/snomed/snomed/SnomedService.java` | Creates tracking record on import start |
+| `termx-core/src/main/java/org/termx/core/sys/email/EmailService.java` | SMTP service with multi-recipient support |
+| `termx-core/src/main/java/org/termx/core/sys/job/logger/ImportNotificationService.java` | Formats and sends import completion emails |
+| `termx-core/src/main/java/org/termx/core/sys/job/JobLogService.java` | Hooks email notifications into finish() method |
+| `snomed/src/main/java/org/termx/snomed/integration/SnomedImportPollingService.java` | Background polling for SNOMED imports |
+| `termx-api/src/main/java/org/termx/snomed/rf2/SnomedImportTracking.java` | Tracks SNOMED import jobs |
+| `snomed/src/main/java/org/termx/snomed/integration/SnomedService.java` | Creates tracking record on import start |
 
 ### ImportNotificationService
 
@@ -410,16 +410,17 @@ sequenceDiagram
 Hook point in `JobLogService.finish()`:
 
 ```java
-public void finish(Long jobId, Status status, ImportLog importLog) {
+public void finish(Long id, List<String> successes, List<String> warnings, List<String> errors) {
   // ... save to database ...
-  
-  try {
-    if (isImportJob(jobLog.getType())) {
-      importNotificationService.sendImportCompletionEmail(jobLog);
+
+  JobLog finishedJob = get(id);
+  if (finishedJob != null && isImportJob(finishedJob.getDefinition().getType())) {
+    try {
+      importNotificationService.sendImportCompletionNotification(finishedJob);
+    } catch (Exception e) {
+      log.error("Failed to send import notification for job " + id, e);
+      // Don't throw - email failure should not break import tracking
     }
-  } catch (Exception e) {
-    log.error("Failed to send import notification email", e);
-    // Don't throw - email failure should not break import tracking
   }
 }
 ```
@@ -431,21 +432,27 @@ public void finish(Long jobId, Status status, ImportLog importLog) {
 ```java
 @Singleton
 public class SnomedImportPollingService {
-  @Scheduled(fixedDelay = "30s")
+  @Scheduled(fixedDelay = "30s", initialDelay = "1m")
+  @Transactional
   public void pollPendingImports() {
-    List<SnomedImportTracking> pending = repository.findPending();
-    
-    for (SnomedImportTracking tracking : pending) {
-      SnomedImportJob job = snowstormClient.loadImportJob(tracking.getSnowstormJobId());
-      
-      if (job.getStatus().equals("COMPLETED") || job.getStatus().equals("FAILED")) {
-        tracking.setFinished(Instant.now());
-        tracking.setStatus(job.getStatus());
-        repository.save(tracking);
-        
-        // Send email notification
-        importNotificationService.sendSnomedImportNotification(tracking, job);
-      }
+    List<SnomedImportTracking> pendingJobs = trackingRepository.loadPending();
+
+    for (SnomedImportTracking tracking : pendingJobs) {
+      checkAndNotify(tracking);
+    }
+  }
+
+  private void checkAndNotify(SnomedImportTracking tracking) {
+    SnomedImportJob snowstormJob = snowstormClient.loadImportJob(tracking.getSnowstormJobId()).join();
+
+    if (TERMINAL_STATUSES.contains(snowstormJob.getStatus()) && !tracking.isNotified()) {
+      tracking.setStatus(snowstormJob.getStatus());
+      tracking.setFinished(OffsetDateTime.now());
+      tracking.setNotified(true);
+      trackingRepository.save(tracking);
+
+      // Send email notification
+      sendNotification(tracking, snowstormJob);
     }
   }
 }
@@ -454,13 +461,17 @@ public class SnomedImportPollingService {
 **Tracking table:**
 
 ```sql
-CREATE TABLE snomed.import_tracking (
-  id                    bigint PRIMARY KEY,
-  snowstorm_job_id      text NOT NULL,
-  status                text NOT NULL,
-  started               timestamptz NOT NULL,
-  finished              timestamptz,
-  notified              boolean DEFAULT false
+CREATE TABLE sys.snomed_import_tracking (
+  id                 bigserial PRIMARY KEY,
+  snowstorm_job_id   text NOT NULL UNIQUE,
+  branch_path        text,
+  type               text,
+  status             text NOT NULL,
+  started            timestamptz NOT NULL DEFAULT current_timestamp,
+  finished           timestamptz,
+  error_message      text,
+  notified           boolean DEFAULT false
+  -- + details text[] (added by a later changeset) and sys_created_at/sys_created_by audit columns
 );
 ```
 

--- a/docs/features/fhir-summary-parameter.md
+++ b/docs/features/fhir-summary-parameter.md
@@ -25,21 +25,31 @@ The accompanying termx-server fix also stops mappers throwing `Search by '<key>'
 
 ## 2. Configuration
 
-No configuration — the feature is always on. The summary path index is built once at startup from `ConformanceHolder.getDefinitions()` (the bundled FHIR R5 `StructureDefinition` snapshots under `*/src/main/resources/conformance/StructureDefinition-*.json`).
+The `_summary` shaping machinery itself is always on: the summary path index is built once at startup from `ConformanceHolder.getDefinitions()` (the bundled FHIR R5 `StructureDefinition` snapshots under `*/src/main/resources/conformance/StructureDefinition-*.json`).
 
-To remove a resource type from `_summary` semantics, drop or replace its `StructureDefinition-*.json` (the processor falls back to "return unchanged" when no index entry exists for the requested resource type).
+What **is** configurable is the *default* `_summary` value applied to search (`GET /fhir/<Resource>`) when the client does not pass `_summary` explicitly. Three keys exist, one per resource type, each defaulting to `true`:
+
+| Config key | Env var | Default | Applies to |
+|------------|---------|---------|------------|
+| `termx.fhir.codesystem.search.default-summary` | `TERMX_FHIR_CS_SEARCH_DEFAULT_SUMMARY` | `true` | `GET /fhir/CodeSystem` |
+| `termx.fhir.valueset.search.default-summary` | `TERMX_FHIR_VS_SEARCH_DEFAULT_SUMMARY` | `true` | `GET /fhir/ValueSet` |
+| `termx.fhir.conceptmap.search.default-summary` | `TERMX_FHIR_CM_SEARCH_DEFAULT_SUMMARY` | `true` | `GET /fhir/ConceptMap` |
+
+Each accepts `true | text | data | count | false`. With the `true` default, search suppresses the heavy `concept` / `compose` / `group.element` collections unless the client overrides with an explicit `?_summary=...`. Consumed at `CodeSystemResourceStorage.java:65`, `ValueSetResourceStorage.java:44`, `ConceptMapResourceStorage.java:41`.
+
+To remove a resource type from `_summary` semantics entirely, drop or replace its `StructureDefinition-*.json` (the processor falls back to "return unchanged" when no index entry exists for the requested resource type).
 
 ## 3. Use-Cases
 
 ### Scenario 1 — UI list of CodeSystems
 
-A web UI renders 50 CodeSystems per page with publisher / status / counts. Without `_summary` it pays for the full `concept` array of every CodeSystem. With `?_summary=true` it gets:
+A web UI renders 50 CodeSystems per page with publisher / status / counts. Because search defaults to `_summary=true` (see [Configuration](#2-configuration)), even a request that omits `_summary` already avoids paying for the full `concept` array of every CodeSystem. That default (or an explicit `?_summary=true`) yields:
 
 - Metadata only: `url`, `name`, `title`, `status`, `publisher`, `count`, `content`, `caseSensitive`, `date`, `version`, `identifier`, `contact`, `useContext`, `jurisdiction`.
 - `concept`, `filter`, `property`, `text` are **stripped**.
 - `meta.tag` carries `SUBSETTED`.
 
-A second request without `_summary` (or with `?_summary=false`) gets the full body when the user opens an item.
+A second request with an explicit `?_summary=false` gets the full body when the user opens an item (since the server default is `true`, omitting `_summary` would still return the slim form).
 
 ### Scenario 2 — Terminology router upstream discovery
 

--- a/docs/features/fhir-terminology-ecosystem-fields.md
+++ b/docs/features/fhir-terminology-ecosystem-fields.md
@@ -41,17 +41,18 @@ List of CodeSystem/ValueSet canonical URL patterns the server explicitly does no
 
 ## Export
 
-`GET /api/terminology-servers/export/ecosystem?download=true`
+`GET /servers/export/ecosystem?download=true`
 
 Generates a FHIR ecosystem registry JSON file. The enriched authoritative entries are flattened to spec-compliant URL strings:
 - `{url: "http://loinc.org", version: "2.77"}` becomes `"http://loinc.org|2.77"`
-- Status and name metadata are TermX-internal and not included in the export
+- `status`, when set, is appended as a `?status=<status>` suffix (e.g. `"http://loinc.org|2.77?status=active"`)
+- Only `name` is TermX-internal and excluded from the export
 
 When `fhirVersions` is not specified, a default R5 entry is generated using `rootUrl`.
 
 ## Import
 
-`POST /api/terminology-servers/import/ecosystem`
+`POST /servers/import/ecosystem`
 
 Accepts a FHIR ecosystem registry JSON body. For each server in the file:
 - Creates a new server if no server with that code exists

--- a/docs/features/loinc-import-management.md
+++ b/docs/features/loinc-import-management.md
@@ -33,8 +33,14 @@ LOINC piggy-backs on the existing Bob + multipart limits; no LOINC-specific knob
 
 | Privilege | Used for |
 |---|---|
-| `loinc.CodeSystem.read` | View the LOINC import page, list stored archives, fetch slot mappings. |
-| `loinc.CodeSystem.write` | Upload a new archive, delete one, trigger an import, open a code system after a successful run. |
+| `loinc.CodeSystem.read` | View the LOINC import page, list stored archives (Bob container read). |
+| `loinc.CodeSystem.write` | Upload a new archive, delete one (Bob container write). |
+| `*.CodeSystem.write` (`CS_WRITE`) | Fetch slot mappings (`GET /loinc/archives/{uuid}/files`), trigger an import (`POST /loinc/import`, `/loinc/import/from-archive`). |
+
+> The archive upload/list/delete operations authorize through the Bob container mapping
+> (`LoincBobContainerAuthorizer` → `loinc.CodeSystem.*`), while the import and slot-mapping
+> endpoints on `LoincController` are annotated `@Authorized(Privilege.CS_WRITE)` where
+> `CS_WRITE = "*.CodeSystem.write"` (the wildcard, not `loinc`-scoped).
 
 ## Use-Cases
 

--- a/docs/features/mapset-excel-export.md
+++ b/docs/features/mapset-excel-export.md
@@ -30,7 +30,7 @@ No configuration is required. MapSet export is automatically available for all M
 Export uses the Lorque async processing system with default settings:
 
 - **Async processing**: Prevents blocking for large exports
-- **Streaming mode**: Constant memory usage regardless of MapSet size
+- **Streaming write**: Apache POI's `SXSSFWorkbook(100)` bounds memory to ~100 rows during Excel serialization (the full row list is still materialized in heap beforehand)
 - **Single-pass processing**: Headers collected from first 1000 associations
 
 ## Use-Cases
@@ -107,9 +107,9 @@ All endpoints are under `/api/ts/map-sets`.
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/{mapSet}/versions/{version}/associations-export{?params*}` | `MapSet.read` | Initiate async export, returns process ID |
-| GET | `/associations-export-csv/result/{lorqueProcessId}` | `MapSet.read` | Download CSV result |
-| GET | `/associations-export-xlsx/result/{lorqueProcessId}` | `MapSet.read` | Download Excel result |
+| GET | `/{mapSet}/versions/{version}/associations-export{?params*}` | `MapSet.triage` | Initiate async export, returns process ID |
+| GET | `/associations-export-csv/result/{lorqueProcessId}` | `MapSet.triage` | Download CSV result |
+| GET | `/associations-export-xlsx/result/{lorqueProcessId}` | `MapSet.triage` | Download Excel result |
 
 ### Initiate Export
 
@@ -447,7 +447,7 @@ Location: After associations section (around line 270)
 ```java
 private final MapSetExportService mapSetExportService;
 
-@Authorized(Privilege.MS_VIEW)
+@Authorized(Privilege.MS_TRIAGE)
 @Get(uri = "/{mapSet}/versions/{version}/associations-export{?params*}")
 public LorqueProcess exportAssociations(
     @PathVariable String mapSet, 
@@ -457,7 +457,7 @@ public LorqueProcess exportAssociations(
     return mapSetExportService.export(mapSet, version, params.getOrDefault("format", "csv"));
 }
 
-@Authorized(Privilege.MS_VIEW)
+@Authorized(Privilege.MS_TRIAGE)
 @Get(value = "/associations-export-csv/result/{lorqueProcessId}", produces = "application/csv")
 public HttpResponse<?> getAssociationExportCSV(Long lorqueProcessId) {
     byte[] result = lorqueProcessService.load(lorqueProcessId).getResult();
@@ -466,7 +466,7 @@ public HttpResponse<?> getAssociationExportCSV(Long lorqueProcessId) {
         .contentType(MediaType.of("application/csv"));
 }
 
-@Authorized(Privilege.MS_VIEW)
+@Authorized(Privilege.MS_TRIAGE)
 @Get(value = "/associations-export-xlsx/result/{lorqueProcessId}", produces = "application/vnd.ms-excel")
 public HttpResponse<?> getAssociationExportXLSX(Long lorqueProcessId) {
     byte[] result = lorqueProcessService.load(lorqueProcessId).getResult();
@@ -481,5 +481,5 @@ public HttpResponse<?> getAssociationExportXLSX(Long lorqueProcessId) {
 - **Small (10 associations)**: < 1 second
 - **Medium (1000 associations)**: 2-5 seconds
 - **Large (10000 associations)**: 5-10 seconds
-- **Memory usage**: Constant O(1) due to streaming (100 rows in memory)
+- **Memory usage**: Bounded at the POI write stage only (`SXSSFWorkbook(100)` keeps ~100 rows in memory); `composeResult` first materializes the full association and row lists in heap
 - **Database queries**: Single query to load all associations

--- a/docs/features/mock-auth.md
+++ b/docs/features/mock-auth.md
@@ -63,8 +63,9 @@ auth:
 | Profile key | Username     | Privileges                                                                                    |
 |-------------|--------------|-----------------------------------------------------------------------------------------------|
 | `admin`     | `admin`      | `*.*.*` (full access)                                                                         |
-| `publisher` | `publisher1` | `*.*.read`, `*.Task.maintain`, `icd-10.CodeSystem.maintain`, `disorders.ValueSet.maintain`, `icd-snomed.MapSet.maintain` |
-| `editor`    | `editor1`    | `*.*.read`, `*.Task.write`, `icd-10.CodeSystem.write`, `disorders.ValueSet.write`                 |
+| `publisher` | `publisher1` | `*.*.read`, `*.*.triage`, `*.Task.maintain`, `*.CodeSystem.maintain`, `*.ValueSet.maintain`, `*.MapSet.maintain` |
+| `editor`    | `editor1`    | `*.*.read`, `*.*.triage`, `*.Task.write`, `*.CodeSystem.write`, `*.ValueSet.write`, `*.MapSet.write` |
+| `editor2`   | `editor2`    | `*.*.read`, `*.*.triage`, `*.Task.write`, `icd-10.CodeSystem.write`, `disorders.ValueSet.write`   |
 | `viewer`    | `viewer1`    | `*.*.read`                                                                                    |
 
 #### mock/users-demo.json (demo/showcase)
@@ -102,7 +103,7 @@ Privileges follow the TermX convention: `<resourceId>.<ResourceType>.<action>`.
 |----------------|--------------------------------------------|----------|
 | `resourceId`   | Specific resource ID (e.g., `icd-10`)      | `*`      |
 | `ResourceType` | `CodeSystem`, `ValueSet`, `MapSet`, `Task` | `*`      |
-| `action`       | `view`, `edit`, `publish`                  | `*`      |
+| `action`       | `read`, `triage`, `write`, `maintain`      | `*`      |
 
 Examples:
 - `*.*.*` -- full admin access
@@ -270,7 +271,7 @@ Privileges follow the pattern: `<resourceId>.<ResourceType>.<action>`
 |---------|-------------|----------|----------|
 | resourceId | Specific resource ID or wildcard | `icd-10`, `disorders`, `*` | `*` = all resources |
 | ResourceType | Resource type class name | `CodeSystem`, `ValueSet`, `MapSet`, `Task` | `*` = all types |
-| action | Operation being performed | `view`, `edit`, `publish` | `*` = all actions |
+| action | Operation being performed | `read`, `triage`, `write`, `maintain` | `*` = all actions |
 
 **Privilege examples:**
 

--- a/docs/features/smtp-email-support.md
+++ b/docs/features/smtp-email-support.md
@@ -27,13 +27,13 @@ TermX includes SMTP email sending functionality for notifications and alerts. Th
 | Property | Env variable | Default | Description |
 |----------|--------------|---------|-------------|
 | `micronaut.email.enabled` | `SMTP_ENABLED` | `false` | Enables SMTP email sending |
-| `micronaut.email.from.email` | `SMTP_FROM` | `noreply@termx.org` | Default sender email address |
-| `micronaut.email.smtp.host` | `SMTP_HOST` | (required) | SMTP server hostname |
-| `micronaut.email.smtp.port` | `SMTP_PORT` | `587` | SMTP server port |
-| `micronaut.email.smtp.username` | `SMTP_USERNAME` | (required) | SMTP authentication username |
-| `micronaut.email.smtp.password` | `SMTP_PASSWORD` | (required) | SMTP authentication password |
-| `micronaut.email.smtp.auth` | `SMTP_AUTH` | `true` | Enable SMTP authentication |
-| `micronaut.email.smtp.starttls.enable` | `SMTP_STARTTLS` | `true` | Enable STARTTLS for secure connection |
+| `micronaut.email.from.email` | `SMTP_FROM` | `noreply@termx.dev` | Default sender email address |
+| `javamail.properties.mail.smtp.host` | `SMTP_HOST` | (required) | SMTP server hostname |
+| `javamail.properties.mail.smtp.port` | `SMTP_PORT` | `587` | SMTP server port |
+| `javamail.authentication.username` | `SMTP_USERNAME` | (required) | SMTP authentication username |
+| `javamail.authentication.password` | `SMTP_PASSWORD` | (required) | SMTP authentication password |
+| `javamail.properties.mail.smtp.auth` | `SMTP_AUTH` | `true` | Enable SMTP authentication |
+| `javamail.properties.mail.smtp.starttls.enable` | `SMTP_STARTTLS` | `true` | Enable STARTTLS for secure connection |
 
 ### Enabling SMTP
 
@@ -197,7 +197,7 @@ All endpoints are under `/management/email`. These endpoints require authenticat
 ```json
 {
   "configured": true,
-  "from": "noreply@termx.org",
+  "from": "noreply@termx.dev",
   "smtpHost": "smtp.gmail.com"
 }
 ```
@@ -208,7 +208,7 @@ When not configured:
 {
   "configured": false,
   "missingParameters": ["SMTP_HOST", "SMTP_USERNAME", "SMTP_PASSWORD"],
-  "from": "noreply@termx.org"
+  "from": "noreply@termx.dev"
 }
 ```
 
@@ -272,7 +272,7 @@ export SMTP_PASSWORD=your-app-password
 # Check status (should show configured)
 curl http://localhost:8200/management/email/status
 
-# Expected: {"configured": true, "from": "noreply@termx.org", "smtpHost": "smtp.gmail.com"}
+# Expected: {"configured": true, "from": "noreply@termx.dev", "smtpHost": "smtp.gmail.com"}
 ```
 
 ### Send test email (development mode)
@@ -315,16 +315,18 @@ Response model for configuration status endpoint.
 | Field | Type | Description |
 |-------|------|-------------|
 | configured | boolean | Whether SMTP is fully configured and ready |
+| enabled | boolean | Whether email sending is enabled (`micronaut.email.enabled`) |
 | missingParameters | String[] | List of required parameters that are not set (empty if configured) |
 | from | String | Configured sender email address |
 | smtpHost | String | SMTP server hostname (only included if configured) |
+| smtpPort | Integer | SMTP server port |
 
 **Example (configured):**
 
 ```json
 {
   "configured": true,
-  "from": "noreply@termx.org",
+  "from": "noreply@termx.dev",
   "smtpHost": "smtp.gmail.com"
 }
 ```
@@ -335,7 +337,7 @@ Response model for configuration status endpoint.
 {
   "configured": false,
   "missingParameters": ["SMTP_HOST", "SMTP_USERNAME", "SMTP_PASSWORD"],
-  "from": "noreply@termx.org"
+  "from": "noreply@termx.dev"
 }
 ```
 
@@ -348,6 +350,7 @@ Request model for test endpoint.
 | recipient | String | Email address to send test email to |
 | subject | String | Email subject line |
 | body | String | Email body (plain text or HTML) |
+| html | boolean | Whether `body` should be sent as HTML (default `false`) |
 
 **Example:**
 
@@ -434,11 +437,11 @@ flowchart TD
 
 | File | Description |
 |------|-------------|
-| `termx-core/src/main/java/com/kodality/termx/core/sys/email/EmailService.java` | Main email service with send methods |
-| `termx-core/src/main/java/com/kodality/termx/core/sys/email/EmailManagementController.java` | Status and test endpoints |
-| `termx-core/src/main/java/com/kodality/termx/core/sys/email/EmailConfigStatus.java` | Status response DTO |
-| `termx-core/src/main/java/com/kodality/termx/core/sys/email/EmailTestRequest.java` | Test request DTO |
-| `termx-core/src/main/java/com/kodality/termx/core/sys/email/EmailTestResult.java` | Test result DTO |
+| `termx-core/src/main/java/org/termx/core/sys/email/EmailService.java` | Main email service with send methods |
+| `termx-core/src/main/java/org/termx/core/sys/email/EmailManagementController.java` | Status and test endpoints |
+| `termx-core/src/main/java/org/termx/core/sys/email/EmailConfigStatus.java` | Status response DTO |
+| `termx-core/src/main/java/org/termx/core/sys/email/EmailTestRequest.java` | Test request DTO |
+| `termx-core/src/main/java/org/termx/core/sys/email/EmailTestResult.java` | Test result DTO |
 | `termx-app/src/main/resources/application.yml` | SMTP configuration properties |
 | `deployment/docker-compose/server.env` | Docker environment variables |
 

--- a/docs/features/snomed-import-management.md
+++ b/docs/features/snomed-import-management.md
@@ -35,7 +35,6 @@ A complementary **concept-usage lookup** answers "which TermX-managed CodeSystem
 | `snowstorm.user` / `snowstorm.password` | — | (deployment) | Basic Auth. Empty values send no `Authorization` header. |
 | `micronaut.server.max-request-size` | — | `629145600` (600 MB) | Multipart upload cap — SNOMED International is ~549 MB. |
 | `micronaut.server.multipart.max-file-size` | — | `629145600` (600 MB) | Same. |
-| `termx.snomed.delta-generator.timeout-seconds` | — | `1800` (30 min) | Hard cap on the `DeltaGeneratorTool` subprocess. |
 
 ### Cache retention
 
@@ -60,7 +59,7 @@ From the archive detail page of the newly uploaded zip the manager opens the *Di
 
 ### Scenario 3: Audit existing TermX resources for inactivated codes
 
-After scanning a new release the manager copies the JSON of `SnomedRF2ScanResult` (or just the `invalidatedConcepts[].code` array) and pastes it into the *Concept usage* page. The page extracts the codes, posts to `POST /snomed/concept-usage`, and renders a table of every CodeSystem supplement, ValueSet rule, and stored expansion that still references one of those codes, with links straight to the affected edit page. The manager can then fix each one before pushing the release to Snowstorm.
+After scanning a new release the manager copies the JSON of `SnomedRF2ScanResult` (or just the `invalidatedConcepts[].conceptId` array) and pastes it into the *Concept usage* page. The page extracts the codes, posts to `POST /snomed/concept-usage`, and renders a table of every CodeSystem supplement, ValueSet rule, and stored expansion that still references one of those codes, with links straight to the affected edit page. The manager can then fix each one before pushing the release to Snowstorm.
 
 ### Scenario 4: Bulk-store national extensions for offline reference
 

--- a/docs/features/snomed-rf2-dry-run-scan.md
+++ b/docs/features/snomed-rf2-dry-run-scan.md
@@ -88,11 +88,11 @@ All endpoints are under `/snomed`.
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| `POST` | `/snomed/imports/scan` | `SNOMED_VIEW` | multipart upload (`file` + `request` JSON), kicks off async dry-run scan, returns a `LorqueProcess` |
-| `GET`  | `/snomed/imports/scan/result/{lorqueProcessId}` | `SNOMED_VIEW` | parsed `SnomedRF2ScanEnvelope` (`{json, markdown}`) once the scan completes |
-| `POST` | `/snomed/imports/scan/{cacheId}/proceed` | `SNOMED_EDIT` | submits the cached zip to Snowstorm without re-upload; returns `{jobId}` |
-| `POST` | `/snomed/concept-usage` | `SNOMED_VIEW` | body `{codes: List<String>}` → returns `List<SnomedConceptUsage>` |
-| `POST` | `/snomed/imports` | `SNOMED_EDIT` | (existing) direct Snowstorm import — bypasses the scan |
+| `POST` | `/snomed/imports/scan` | `SNOMED_READ` | multipart upload (`file` + `request` JSON), kicks off async dry-run scan, returns a `LorqueProcess` |
+| `GET`  | `/snomed/imports/scan/result/{lorqueProcessId}` | `SNOMED_READ` | parsed `SnomedRF2ScanEnvelope` (`{json, markdown}`) once the scan completes |
+| `POST` | `/snomed/imports/scan/{cacheId}/proceed` | `SNOMED_WRITE` | submits the cached zip to Snowstorm without re-upload; returns `{jobId}` |
+| `POST` | `/snomed/concept-usage` | `SNOMED_READ` | body `{codes: List<String>}` → returns `List<SnomedConceptUsage>` |
+| `POST` | `/snomed/imports` | `SNOMED_WRITE` | (existing) direct Snowstorm import — bypasses the scan |
 
 ### `SnomedImportRequest` (request part of `/imports/scan`)
 
@@ -388,4 +388,3 @@ Genuine async failures that aren't `HttpClientError` (network timeout, NPE in th
 
 - [Email Import Notifications](email-import-notifications.md) — SNOMED imports trigger email summaries when SMTP is configured.
 - [SNOMED Server Architecture](architecture.md) — overall server module layout.
-- Convention: feature documentation template — [`docs/conventions/feature-documentation.md`](../../../docs/conventions/feature-documentation.md).

--- a/docs/features/task-access-control.md
+++ b/docs/features/task-access-control.md
@@ -13,7 +13,7 @@ Task access control provides privilege-based visibility and filtering of tasks i
 
 **Key capabilities:**
 
-- Automatic virtual privilege derivation at login (resource edit/publish privileges grant Task privileges)
+- Automatic virtual privilege derivation at login (resource `triage`/`write`/`maintain` privileges grant Task privileges)
 - Privilege-based task filtering at the database level with OR logic (own tasks OR publisher access)
 - Resource-level access control using context items
 - Unseen changes tracking per user
@@ -28,16 +28,18 @@ Task access control is automatically enabled and requires no configuration. It i
 
 Task access is controlled through **virtual privilege derivation**. When a user logs in, their resource privileges are automatically translated into Task privileges:
 
-**Privilege derivation at login:**
+**Privilege derivation at login** (mirrors the GitHub-based action hierarchy — a higher action implies the lower Task actions):
+- Any `*.*.triage` privilege (e.g., `icd-10.CodeSystem.triage`) → automatically derives `code-system#icd-10.Task.read` (task visibility only)
 - Any `*.*.write` privilege (e.g., `icd-10.CodeSystem.write`) → automatically derives `code-system#icd-10.Task.read` and `code-system#icd-10.Task.write`
 - Any `*.*.maintain` privilege (e.g., `*.ValueSet.maintain`) → automatically derives `value-set#*.Task.read`, `value-set#*.Task.write`, and `value-set#*.Task.maintain`
-- View-only privileges (e.g., `*.CodeSystem.read`) → no Task privileges, task list is hidden
+- Read-only privileges (e.g., `*.CodeSystem.read`) → no Task privileges, task list is hidden
 
 **Task visibility rules:**
 
 | User Privilege | Task List Accessible? | Derived Task Privileges | Tasks Visible |
 |----------------|----------------------|------------------------|---------------|
 | `*.CodeSystem.read` only | ❌ No | None | None (no Task privileges derived) |
+| `icd-10.CodeSystem.triage` | ✅ Yes | `code-system#icd-10.Task.read` | Tasks created by OR assigned to user (read-only) |
 | `icd-10.CodeSystem.write` | ✅ Yes | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write` | Tasks created by OR assigned to user |
 | `icd-10.CodeSystem.maintain` | ✅ Yes | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain` | Tasks created by OR assigned to user, PLUS all tasks with context `code-system\|icd-10` |
 | `*.CodeSystem.maintain` | ✅ Yes | `code-system#*.Task.read`, `code-system#*.Task.write`, `code-system#*.Task.maintain` | Tasks created by OR assigned to user, PLUS all CodeSystem tasks |
@@ -48,9 +50,9 @@ Task access is controlled through **virtual privilege derivation**. When a user 
 Default roles in TermX:
 
 - **admin**: `*.*.*` (all privileges)
-- **publisher**: `*.*.maintain` (publish on all resources)
-- **editor**: `*.*.write` (edit on all resources)
-- **viewer**: `*.*.read` (view-only on all resources)
+- **publisher**: `*.*.maintain` (maintain — publish-level access — on all resources)
+- **editor**: `*.*.write` (write on all resources)
+- **viewer**: `*.*.read` (read-only on all resources)
 
 See [Mock Authentication](mock-auth.md) for testing with mock user profiles.
 
@@ -116,12 +118,12 @@ Example: A user with privilege `icd-10.CodeSystem.write` can see tasks with cont
 **Context:** Read-only user (reports/auditing role) should not see task management interface.
 
 **Steps:**
-1. Viewer logs in with only `*.*.read` privileges (no edit or publish on any resource)
+1. Viewer logs in with only `*.*.read` privileges (no triage, write, or maintain on any resource)
 2. System does NOT derive any Task privileges (no resource-specific Task privileges)
 3. Query task list - receives 403 Forbidden (gate check fails - no Task.read privilege)
 4. Task menu items hidden in UI (no Task privileges)
 
-**Outcome:** Viewer cannot access task system, maintaining separation of concerns. The resource-specific privilege derivation ensures task access is automatically tied to edit/publish privileges on actual resources.
+**Outcome:** Viewer cannot access task system, maintaining separation of concerns. The resource-specific privilege derivation ensures task access is automatically tied to `triage`/`write`/`maintain` privileges on actual resources.
 
 ### Scenario 5: Resource-Specific Task Filtering
 
@@ -290,7 +292,14 @@ Privilege strings follow: `<resourceId>.<ResourceType>.<action>`
 |-----------|----------|----------|
 | resourceId | `icd-10`, `disorders`, `snomed-ct` | `*` = all resources |
 | ResourceType | `CodeSystem`, `ValueSet`, `MapSet`, `Task` | `*` = all types |
-| action | `view`, `edit`, `publish` | `*` = all actions |
+| action | `read`, `triage`, `write`, `maintain` | `*` = all actions |
+
+> **GitHub-based action model.** The action vocabulary mirrors GitHub's repository
+> permission levels — `read` → `triage` → `write` → `maintain` (and `admin`, expressed as
+> the `*.*.*` wildcard / the `Admin` resource type). Each higher level implies the lower ones.
+> The legacy `view` / `edit` / `publish` actions were renamed to `read` / `write` / `maintain`
+> in the Phase B migration (`02-privilege-actions-rename.sql`); `triage` was added as a new
+> intermediate action.
 
 **Resource-specific Task privilege derivation:**
 
@@ -298,6 +307,7 @@ Resource privileges are automatically translated to resource-specific Task privi
 
 | Resource Privilege | Derived Task Privileges | Effect |
 |--------------------|------------------------|--------|
+| `icd-10.CodeSystem.triage` | `code-system#icd-10.Task.read` | Can access task list (read-only), see own ICD-10 tasks |
 | `icd-10.CodeSystem.write` | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write` | Can access task list, see own ICD-10 tasks |
 | `icd-10.CodeSystem.maintain` | `code-system#icd-10.Task.read`, `code-system#icd-10.Task.write`, `code-system#icd-10.Task.maintain` | Can access task list, see own tasks + all ICD-10 CodeSystem tasks |
 | `*.CodeSystem.write` | `code-system#*.Task.read`, `code-system#*.Task.write` | Can access task list, see own tasks for any CodeSystem |
@@ -336,7 +346,7 @@ These parameters are mapped from `TaskQueryParams` by the controller after apply
 flowchart TD
     Login[User Login] --> SessionProvider[SessionProvider]
     SessionProvider --> DerivePrivs[deriveTaskPrivileges]
-    DerivePrivs -->|*.*.write or *.*.maintain| AddTaskPrivs[Add *.Task.read/edit/publish]
+    DerivePrivs -->|*.*.triage / write / maintain| AddTaskPrivs[Add *.Task.read/write/maintain]
     AddTaskPrivs --> SessionInfo[SessionInfo with derived privileges]
     
     Request[API Request] --> Auth[@Authorized Task.read]
@@ -348,7 +358,7 @@ flowchart TD
     CheckAdmin -->|No| BuildFilter[Build TaskVisibilityFilter]
     
     BuildFilter --> SetUsername[username = session.username]
-    BuildFilter --> GetPublisher[publisherContexts = getPermittedContexts publish]
+    BuildFilter --> GetPublisher[publisherContexts = getPermittedContexts maintain]
     
     SetUsername --> ApplyFilter[Apply Visibility Filter]
     GetPublisher --> ApplyFilter
@@ -364,7 +374,7 @@ flowchart TD
 **Privilege resolution flow:**
 
 1. **Login**: SessionFilter calls `deriveTaskPrivileges()` - resource privileges derive resource-specific Task privileges
-2. **Request arrives**: `@Authorized(privilege = Privilege.T_VIEW)` checks for any Task.read privilege (gate check)
+2. **Request arrives**: `@Authorized(privilege = Privilege.T_READ)` checks for any Task.read privilege (gate check)
 3. **Controller logic**:
    - If admin (`*.*.*`): no filter
    - Otherwise: build `TaskVisibilityFilter` with username + publisher contexts extracted from hash-format privileges
@@ -429,10 +439,12 @@ private void deriveTaskPrivileges(SessionInfo session) {
         String contextType = resourceTypeToContextType.get(resourceType);
         if (contextType == null) continue;
         
-        if ("edit".equals(action)) {
+        if ("triage".equals(action)) {
+            derived.add(contextType + "#" + resourceId + ".Task.read");
+        } else if ("write".equals(action)) {
             derived.add(contextType + "#" + resourceId + ".Task.read");
             derived.add(contextType + "#" + resourceId + ".Task.write");
-        } else if ("publish".equals(action)) {
+        } else if ("maintain".equals(action)) {
             derived.add(contextType + "#" + resourceId + ".Task.read");
             derived.add(contextType + "#" + resourceId + ".Task.write");
             derived.add(contextType + "#" + resourceId + ".Task.maintain");
@@ -446,7 +458,7 @@ private void deriveTaskPrivileges(SessionInfo session) {
 **TaskController filtering logic:**
 
 ```java
-@Authorized(privilege = Privilege.T_VIEW)  // Gate check
+@Authorized(privilege = Privilege.T_READ)  // Gate check
 @Get(uri = "/tasks{?params*}")
 public QueryResult<Task> queryTasks(TaskQueryParams params) {
     SessionInfo session = SessionStore.require();
@@ -455,7 +467,7 @@ public QueryResult<Task> queryTasks(TaskQueryParams params) {
         // Build visibility filter with OR semantics
         TaskVisibilityFilter filter = new TaskVisibilityFilter();
         filter.setUsername(session.getUsername());
-        filter.setPublisherContexts(getPermittedContexts(session, "publish"));
+        filter.setPublisherContexts(getPermittedContexts(session, "maintain"));
         params.setVisibilityFilter(filter);
     }
     return taskService.queryTasks(params);
@@ -510,10 +522,10 @@ Task context items link tasks to resources:
 
 | Context Type | Resource | Privilege Pattern |
 |--------------|----------|-------------------|
-| `code-system` | CodeSystem | `<resourceId>.CodeSystem.write/publish` |
-| `value-set` | ValueSet | `<resourceId>.ValueSet.write/publish` |
-| `map-set` | MapSet | `<resourceId>.MapSet.write/publish` |
-| `wiki` | Wiki space | `<resourceId>.Wiki.write/publish` |
+| `code-system` | CodeSystem | `<resourceId>.CodeSystem.write/maintain` |
+| `value-set` | ValueSet | `<resourceId>.ValueSet.write/maintain` |
+| `map-set` | MapSet | `<resourceId>.MapSet.write/maintain` |
+| `wiki` | Wiki space | `<resourceId>.Wiki.write/maintain` |
 
 The system extracts resource IDs from task context and checks user privileges against those specific resources.
 

--- a/docs/features/task-management.md
+++ b/docs/features/task-management.md
@@ -560,7 +560,7 @@ modules:
 
 | Module | Path | Description |
 |--------|------|-------------|
-| task | `task/src/main/java/com/kodality/termx/task/` | Public API: controller, service, models, privileges |
+| task | `task/src/main/java/org/termx/task/` | Public API: controller, service, models, privileges |
 | task-taskforge | `task-taskforge/src/main/java/org/termx/taskforge/` | Implementation: services, repositories, mapper |
 | task-taskforge | `task-taskforge/src/main/resources/taskforge/changelog/` | Liquibase migrations |
 

--- a/docs/features/terminology-server-ecosystem-export.md
+++ b/docs/features/terminology-server-ecosystem-export.md
@@ -15,9 +15,9 @@ This feature allows you to export your TermX terminology servers in the **FHIR T
 
 ### Export Servers
 
-**GET** `/api/terminology-servers/export/ecosystem`
+**GET** `/servers/export/ecosystem`
 
-**Authorization:** `TerminologyServer.read` privilege required
+**Authorization:** `Server.read` privilege required
 
 **Query Parameters:**
 - `download` (optional, boolean) - If `true`, returns response as downloadable file
@@ -31,20 +31,20 @@ This feature allows you to export your TermX terminology servers in the **FHIR T
 ### View Export in Browser
 
 ```bash
-curl http://localhost:8200/api/terminology-servers/export/ecosystem
+curl http://localhost:8200/servers/export/ecosystem
 ```
 
 ### Download as File
 
 ```bash
-curl "http://localhost:8200/api/terminology-servers/export/ecosystem?download=true" -o termx-servers.json
+curl "http://localhost:8200/servers/export/ecosystem?download=true" -o termx-servers.json
 ```
 
 ### Using in Scripts
 
 ```bash
 # Export and save
-EXPORT_URL="http://localhost:8200/api/terminology-servers/export/ecosystem?download=true"
+EXPORT_URL="http://localhost:8200/servers/export/ecosystem?download=true"
 curl "$EXPORT_URL" -o termx-ecosystem-registry.json
 
 # Verify the file
@@ -64,14 +64,16 @@ The export follows the FHIR Ecosystem server registry specification:
     "name": "Terminoloogiaserver",
     "url": "https://server.example.org",
     "open": true,
-    "fhirVersions": [{
-      "version": "R4",
-      "url": "https://server.example.org/fhir"
-    }],
     "authoritative": [],
     "authoritative-valuesets": [],
-    "candidate": [],
-    "exclusions": []
+    "authoritative-conceptmaps": [],
+    "authoritative-structuredefinitions": [],
+    "authoritative-structuremaps": [],
+    "exclusions": [],
+    "fhirVersions": [{
+      "version": "R5",
+      "url": "https://server.example.org"
+    }]
   }]
 }
 ```
@@ -107,7 +109,7 @@ Export your servers and register them with the HL7 FHIR Terminology Ecosystem:
 
 ```bash
 # Export your servers
-curl "http://localhost:8200/api/terminology-servers/export/ecosystem?download=true" -o my-servers.json
+curl "http://localhost:8200/servers/export/ecosystem?download=true" -o my-servers.json
 
 # Host the file at a public URL
 # Then submit the URL to HL7 for inclusion in the master registry
@@ -119,7 +121,7 @@ Export and share your server list with partner organizations:
 
 ```bash
 # Export
-curl "http://localhost:8200/api/terminology-servers/export/ecosystem?download=true" -o servers.json
+curl "http://localhost:8200/servers/export/ecosystem?download=true" -o servers.json
 
 # Share the JSON file with partners
 # They can import it or use it for discovery
@@ -133,7 +135,7 @@ Create regular backups of your server configuration:
 # Automated backup script
 #!/bin/bash
 DATE=$(date +%Y%m%d)
-curl "http://localhost:8200/api/terminology-servers/export/ecosystem?download=true" \
+curl "http://localhost:8200/servers/export/ecosystem?download=true" \
   -o "backups/termx-servers-$DATE.json"
 ```
 
@@ -143,16 +145,19 @@ Generate documentation about available servers:
 
 ```bash
 # Export and format
-curl "http://localhost:8200/api/terminology-servers/export/ecosystem" | jq '.'
+curl "http://localhost:8200/servers/export/ecosystem" | jq '.'
 
 # Extract server names
-curl "http://localhost:8200/api/terminology-servers/export/ecosystem" | \
+curl "http://localhost:8200/servers/export/ecosystem" | \
   jq -r '.servers[] | .name'
 ```
 
-## Web UI Access (Future Enhancement)
+## Web UI Access
 
-In the admin interface at `http://localhost:4200/terminology-servers`, you can add an **Export** button that calls this endpoint and downloads the file.
+In the admin interface at `http://localhost:4200/terminology-servers`, the "..." menu on the
+server list page provides **Export to FHIR Ecosystem format** (and **Import from FHIR Ecosystem
+file**), which call these endpoints. See
+[`fhir-terminology-ecosystem-fields.md`](fhir-terminology-ecosystem-fields.md) for the UI reference.
 
 ## Technical Details
 
@@ -178,11 +183,11 @@ In the admin interface at `http://localhost:4200/terminology-servers`, you can a
 **Name Extraction:**
 - Prefers English name (`en`)
 - Falls back to first available language
-- Defaults to "Unknown Server" if no name
+- `name` is `null` (omitted) when the server has no name
 
 **FHIR Endpoint:**
-- Appends `/fhir` to root URL
-- Handles trailing slashes correctly
+- When `fhirVersions` is not configured, a single default entry is emitted with
+  `version: "R5"` and `url` set to the server's root URL verbatim (no `/fhir` is appended)
 
 ## Limitations
 
@@ -200,32 +205,12 @@ Still open / possible future work:
 
 ## Future Enhancements
 
-### Phase 1: Enhanced Metadata
-
-Add fields to `TerminologyServer` model:
-```java
-private List<String> authoritativeCodeSystems;
-private List<String> authoritativeValueSets;
-private List<String> fhirVersions;
-private List<String> usageTags;
-```
-
-### Phase 2: Auto-Discovery
+### Auto-Discovery
 
 Automatically populate authoritative lists by:
 - Querying CodeSystem resources on the server
 - Querying ValueSet resources on the server
 - Extracting canonical URLs
-
-### Phase 3: Multi-Version Support
-
-Support multiple FHIR versions per server:
-```json
-"fhirVersions": [
-  {"version": "R4", "url": "https://server/r4"},
-  {"version": "R5", "url": "https://server/r5"}
-]
-```
 
 ## Security Considerations
 
@@ -235,7 +220,7 @@ Support multiple FHIR versions per server:
 - Only `access_info` text is included (no credentials)
 
 **Access Control:**
-- Requires `TerminologyServer.read` privilege
+- Requires `Server.read` privilege
 - Admin users have access by default
 - Configure additional users in `mock/users.json`
 
@@ -245,7 +230,7 @@ Support multiple FHIR versions per server:
 
 **Solution:** Check that you have active servers configured:
 ```bash
-curl http://localhost:8200/api/terminology-servers
+curl http://localhost:8200/servers
 ```
 
 ---
@@ -256,12 +241,12 @@ curl http://localhost:8200/api/terminology-servers
 ```yaml
 auth:
   mock:
-    default-user: admin  # Required for TerminologyServer.read
+    default-user: admin  # Required for Server.read
 ```
 
 ---
 
-**Issue:** Names show as "Unknown Server"
+**Issue:** Server `name` is `null` / missing in the export
 
 **Solution:** Add a name to your server in the TermX admin UI at `http://localhost:4200/terminology-servers`
 
@@ -269,7 +254,7 @@ auth:
 
 - [FHIR Terminology Ecosystem IG](https://build.fhir.org/ig/HL7/fhir-tx-ecosystem-ig/ecosystem.html)
 - [FHIR Terminology Ecosystem Integration](fhir-terminology-ecosystem-registry-proxy.md) - Discovery and Resolution API
-- [Terminology Server Management](../README.md) - Managing internal servers
+- [Terminology Server Management](../../README.md) - Managing internal servers
 
 ## Example Output
 
@@ -283,16 +268,18 @@ auth:
       "name": "Terminoloogiaserver",
       "url": "https://server.example.org",
       "open": true,
-      "fhirVersions": [
-        {
-          "version": "R4",
-          "url": "https://server.example.org/fhir"
-        }
-      ],
       "authoritative": [],
       "authoritative-valuesets": [],
-      "candidate": [],
-      "exclusions": []
+      "authoritative-conceptmaps": [],
+      "authoritative-structuredefinitions": [],
+      "authoritative-structuremaps": [],
+      "exclusions": [],
+      "fhirVersions": [
+        {
+          "version": "R5",
+          "url": "https://server.example.org"
+        }
+      ]
     }
   ]
 }
@@ -306,4 +293,4 @@ auth:
 ✅ Secure (no credentials exported)  
 ✅ Ready for HL7 ecosystem registration  
 
-**Available Now:** `GET /api/terminology-servers/export/ecosystem`
+**Available Now:** `GET /servers/export/ecosystem`

--- a/docs/features/value-set-expand.md
+++ b/docs/features/value-set-expand.md
@@ -8,16 +8,17 @@
 
 ## 1. Description
 
-`POST /fhir/ValueSet/$expand` (and the instance-level `POST /fhir/ValueSet/{id}/$expand`) returns a `ValueSet` resource whose `expansion.contains` lists the codes selected by the value set. TermX accepts four forms of input, resolved in this priority order:
+`POST /fhir/ValueSet/$expand` (and the instance-level `POST /fhir/ValueSet/{id}/$expand`) returns a `ValueSet` resource whose `expansion.contains` lists the codes selected by the value set. TermX accepts five forms of input, resolved in this priority order:
 
 | # | Path | How the client identifies the VS | Where the concepts come from |
 |---|---|---|---|
-| 1 | **Inline-VS** | `valueSet` parameter carries a `ValueSet` resource constructed by the client | `ValueSetVersionConceptRepository.expandFromJson(...)` — Postgres function `value_set_expand_jsonb` resolves `compose.include[].system + filter + concept` directly |
-| 2 | **SNOMED implicit-VS** | `url` is `http://snomed.info/sct[/<edition>/version/<date>]?fhir_vs[=…]` | `SnomedValueSetExpandProvider.ruleExpand(...)` — calls Snowstorm via `SnomedService.searchConcepts(ecl=…, branch=…)` |
-| 3 | **Stored-VS** | `url` matches a `ValueSet.uri` already stored in TermX, or the operation runs at instance level (`/ValueSet/{id}/$expand`) | `ValueSetVersionConceptService.expand(...)` — snapshot persisted by TermX (re-uses cache when current) |
-| 4 | **Implicit VS over a stored CodeSystem** | `url` matches a `CodeSystem.uri`; no matching stored VS exists | Delegates to `ConceptService.query(codeSystem=…, codeSystemVersion=…, textContains=filter, limit=count, offset=offset, displayLanguage=…)` — same path the UI's concept-list endpoint uses |
+| 1 | **Inline-VS** | `valueSet` parameter carries a `ValueSet` resource constructed by the client | `ValueSetVersionConceptRepository.expandFromJson(...)` — Postgres function `value_set_expand(text)` resolves `compose.include[].system + filter + concept` directly |
+| 2 | **SNOMED implicit-VS** | `url` is `http://snomed.info/sct[/<edition>/version/<date>]?fhir_vs[=…]` | `SnomedValueSetExpandProvider.ruleExpandPaged(...)` — calls Snowstorm via `SnomedService.searchConceptsPage(ecl=…, branch=…)` |
+| 3 | **tx-resource inline VS** | `url` names a `ValueSet` supplied inline as a validator tx-resource (`ValueSetExpandOperation.java:153-166`); resolved after SNOMED but before the stored-VS lookup. A pinned `valueSetVersion` must match exactly (else 404); otherwise the latest supplied version is used | `expandInline(...)` — same inline `$expand` path as row 1 |
+| 4 | **Stored-VS** | `url` matches a `ValueSet.uri` already stored in TermX, or the operation runs at instance level (`/ValueSet/{id}/$expand`) | `ValueSetVersionConceptService.expand(...)` — snapshot persisted by TermX (re-uses cache when current) |
+| 5 | **Implicit VS over a stored CodeSystem** | `url` matches a `CodeSystem.uri`; no matching stored VS exists | Delegates to `ConceptService.query(codeSystem=…, codeSystemVersion=…, textContains=filter, limit=count, offset=offset, displayLanguage=…)` — same path the UI's concept-list endpoint uses |
 
-A request that resolves none of the four returns `404 NOTFOUND`.
+A request that resolves none of these five returns `404 NOTFOUND`.
 
 All paths apply the same downstream parameter set: `offset`, `count`, `filter`, `displayLanguage`, `defaultLanguage`, `includeDesignations`, `activeOnly`, `excludeNested`. Paging is applied **after** filtering, per the FHIR spec.
 
@@ -43,8 +44,8 @@ The `snomed-module` CodeSystem must contain entries with `moduleId` and `branchP
 | `url` | `uri` | Required unless `valueSet` is sent. Resolved in order: stored `ValueSet.uri` → SNOMED canonical (see [§5](#5-snomed-fhir_vs-url-family)) → stored `CodeSystem.uri` (see [§6](#6-implicit-valueset-over-a-stored-codesystem)). |
 | `valueSetVersion` | `string` | Selects a specific version. On stored-VS: picks `ValueSet.version`. On implicit-CS: forwarded as `codeSystemVersion`. Pipe-version syntax in `url` (`<canonical>\|<version>`) is also accepted on implicit-CS; `valueSetVersion` wins when both are supplied. |
 | `valueSet` | `ValueSet` resource | Inline path. Mutually exclusive with `url` (inline takes precedence when both are present). |
-| `offset` | `integer` | Skip the first N concepts. `offset >= expansion.total` → empty `contains`. Honoured on all four paths. Pushed down to the DB on the implicit-CS path (`LIMIT/OFFSET` on the concept query). |
-| `count` | `integer` | Keep at most N concepts. Honoured on all four paths. Pushed down to the DB on the implicit-CS path. |
+| `offset` | `integer` | Skip the first N concepts. `offset >= expansion.total` → empty `contains`. Honoured on all five paths. Pushed down to the DB on the implicit-CS path (`LIMIT/OFFSET` on the concept query). |
+| `count` | `integer` | Keep at most N concepts. Honoured on all five paths. Pushed down to the DB on the implicit-CS path. |
 | `filter` | `string` | Case-insensitive substring match against `concept.code` and `concept.display`. Applied **before** paging. On the implicit-CS path it maps to `ConceptQueryParams.textContains` (DB-side); on stored-VS, inline-VS, and SNOMED it's applied client-side after the source returns. |
 | `displayLanguage` | `code` / `string` | Preferred designation language for `expansion.contains[].display`. On the implicit-CS path it's threaded into the concept query so the right designation comes back; on other paths the request-time language wins over the version-time language. |
 | `defaultLanguage` | `code` / `string` | Fallback when `displayLanguage` is unset. |
@@ -56,7 +57,7 @@ The `snomed-module` CodeSystem must contain entries with `moduleId` and `branchP
 
 ### Expansion envelope: what clients can rely on
 
-A response from any of the four paths has these guarantees (pinned by `ValueSetExpandOperationTest`):
+A response from any of the five paths has these guarantees (pinned by `ValueSetExpandOperationTest`):
 
 | Field | Value |
 |---|---|
@@ -131,15 +132,15 @@ GET /fhir/ValueSet/$expand?url=http://loinc.org/answer-list&valueSetVersion=2.82
 
 ## 5. SNOMED `?fhir_vs` URL family
 
-Per the [HL7 UTG SNOMED CT page](https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html), the SNOMED canonical URL supports five implicit-ValueSet patterns. TermX recognises all five and translates the URL into a `ValueSetVersionRule` filter that `SnomedValueSetExpandProvider.composeEcl()` further translates into ECL:
+Per the [HL7 UTG SNOMED CT page](https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html), the SNOMED canonical URL supports five implicit-ValueSet patterns. TermX maps each URL to a `ValueSetVersionRule` filter, but only **three** of the synthesised operators are actually implemented in `SnomedValueSetExpandProvider.composeEcl()` (`is-a`, `in`). The other two synthesise `operator=ecl` — an operator that is **not** in `ValueSetRuleFilterOperator.ALL` and that `composeEcl` has no `switch` case for, so its `default` branch throws `ApiError.SN301` at runtime. Those two paths (`?fhir_vs` all-concepts and `?fhir_vs=ecl/…`) are therefore currently **unimplemented**:
 
 | Input URL fragment | Synthesised filter | ECL emitted by `composeEcl` | Meaning |
 |---|---|---|---|
-| `?fhir_vs` | `operator=ecl, value="*"` | `*` | All concepts in the edition/version. |
+| `?fhir_vs` | `operator=ecl, value="*"` | **Unimplemented** — `composeEcl` has no `ecl` case, so its `default` branch throws `ApiError.SN301`. | Intended: all concepts in the edition/version. Currently unsupported (throws at runtime). |
 | `?fhir_vs=isa/<sctid>` | `operator=is-a, value=<sctid>` | `<<<sctid>` | Descendants of `<sctid>` **plus the concept itself** (per IG). |
 | `?fhir_vs=refset` | `operator=is-a, value=900000000000455006` | `<<900000000000455006` | All concepts under `Reference set foundation` — i.e. the catalog of refsets. |
 | `?fhir_vs=refset/<sctid>` | `operator=in, value=<sctid>` | `^<sctid>` | Active members of refset `<sctid>`. |
-| `?fhir_vs=ecl/<URL-encoded>` | `operator=ecl, value=<URL-decoded>` | `<expr>` | Concepts matching the ECL expression. URI-decoded before being forwarded. |
+| `?fhir_vs=ecl/<URL-encoded>` | `operator=ecl, value=<URL-decoded>` | **Unimplemented** — `composeEcl` has no `ecl` case, so its `default` branch throws `ApiError.SN301`. | Intended: concepts matching the ECL expression (URI-decoded first). Currently unsupported (throws at runtime). |
 
 Both base canonicals are accepted:
 
@@ -167,7 +168,7 @@ The response is built from the `QueryResult<Concept>`:
 - `expansion.contains[].code` ← `concept.code`
 - `expansion.contains[].display` ← `ConceptUtil.getDisplay(concept.versions[0].designations, displayLanguage, [])` — same helper `CodeSystemLookupOperation` uses
 
-**Why this route and not the SQL function?** The `value_set_expand_jsonb` SQL function is built for arbitrary compose rules (filters, exclusions, recursion). For the implicit-CS case the synthesised compose has only `{system, version}` — no filter complexity — and the SQL function's `cs` CTE doesn't fetch designations for system-only includes (LOINC bug observed on dev.termx.org). `ConceptService.query` fetches designations by default, pushes `limit`/`offset` into the DB, and reports the pre-paging total — three properties this path needs and the SQL function doesn't provide for system-only includes.
+**Why this route and not the SQL function?** The `value_set_expand(text)` SQL function is built for arbitrary compose rules (filters, exclusions, recursion). For the implicit-CS case the synthesised compose has only `{system, version}` — no filter complexity — and the SQL function's `cs` CTE doesn't fetch designations for system-only includes (LOINC bug observed on dev.termx.org). `ConceptService.query` fetches designations by default, pushes `limit`/`offset` into the DB, and reports the pre-paging total — three properties this path needs and the SQL function doesn't provide for system-only includes.
 
 ### URL syntax tolerated
 
@@ -183,7 +184,7 @@ Non-SNOMED canonicals with a **valued** `?fhir_vs=<pattern>` (e.g. `http://loinc
 
 ## 7. Test coverage
 
-Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy` — 25 specs.
+Locked in by `terminology/src/test/groovy/org/termx/terminology/fhir/valueset/operations/ValueSetExpandOperationTest.groovy` — 32 specs.
 
 **Stored-VS** (5 specs)
 
@@ -284,8 +285,8 @@ could be extended to draft once authoring semantics are confirmed.
 
 ## 9. Limitations & known gaps
 
-- **SNOMED "all concepts" materialises the full result** before client-side paging. `SnomedValueSetExpandProvider.filterConcepts()` uses `SnomedConceptSearchParams.setAll(true)`, which is fine for hundreds of concepts but expensive for the international edition (~350k). The fix is to push `offset`/`count` down into `SnomedService.searchConcepts`; left as a separate optimisation.
+- **SNOMED expansion materialises the full result on the fallback path only.** The SNOMED implicit-VS single-filter path (the `?fhir_vs[=…]` shape) now pages at the source via `SnomedValueSetExpandProvider.ruleExpandPaged(...)` (`ValueSetExpandOperation.java:2397`), pushing `offset`/`count`/`term` down to Snowstorm. `setAll(true)` survives only on the richer fallback `filterConcepts()` (reached through `ruleExpand(...)` for rules that aren't the single-filter shape), which loops Snowstorm at limit=9999 until the whole ECL result is in heap — fine for hundreds of concepts, expensive for the international edition (~350k). Pushing paging into that fallback too is left as a separate optimisation.
 - **`filter` on the SNOMED path is client-side**. Snowstorm's ECL doesn't carry a free-text filter parameter, so TermX applies the substring match after the provider returns. Functionally correct, less efficient than letting Snowstorm filter.
 - **Non-SNOMED `?fhir_vs=<pattern>` URLs are not interpreted.** The full `?fhir_vs=isa/…`, `?fhir_vs=refset[/…]`, `?fhir_vs=ecl/…` family is SNOMED-only; the bare `?fhir_vs` suffix is leniently stripped on any canonical, but non-SNOMED canonicals with a valued `?fhir_vs=…` 404. Equivalent semantics on LOINC etc. would need a per-CodeSystem ECL-like evaluator that TermX doesn't currently embed.
 - **`activeOnly` is honoured only on the stored-VS / inline-VS paths.** For SNOMED, "active" semantics depend on Snowstorm and the ECL expression — most patterns (`isa/`, `refset/`) already return active concepts by default.
-- **Latent: SQL function `value_set_expand_jsonb` drops `display` on system-only includes.** A client posting an inline ValueSet whose `compose.include[]` has only `{system, version}` (no `concept[]`) and going through the inline-VS path will get codes back without displays. The implicit-CS path no longer goes through this function (it routes through `ConceptService.query` instead) so the user-visible bug is fixed for that case. Clients hitting the inline-VS path with system-only includes should either include explicit `concept[]` entries or fetch displays out-of-band; a SQL-level fix is tracked separately.
+- **Latent: SQL function `value_set_expand(text)` drops `display` on system-only includes.** A client posting an inline ValueSet whose `compose.include[]` has only `{system, version}` (no `concept[]`) and going through the inline-VS path will get codes back without displays. The implicit-CS path no longer goes through this function (it routes through `ConceptService.query` instead) so the user-visible bug is fixed for that case. Clients hitting the inline-VS path with system-only includes should either include explicit `concept[]` entries or fetch displays out-of-band; a SQL-level fix is tracked separately.

--- a/docs/features/valueset-excel-export-optimize.md
+++ b/docs/features/valueset-excel-export-optimize.md
@@ -17,7 +17,7 @@ ValueSet Excel export has been optimized to handle large datasets efficiently. T
 
 - **Before optimization**: 10k concept export took 5-10 minutes with thousands of DB queries
 - **After optimization**: Same export takes 10-30 seconds with < 10 DB queries
-- **Memory**: Constant O(1) usage regardless of valueset size
+- **Memory**: Bounded only at the POI write stage (`SXSSFWorkbook(100)` keeps ~100 rows in memory); the full row list is still materialized in heap beforehand
 
 ## Configuration
 
@@ -120,17 +120,17 @@ Export endpoints are unchanged. Optimizations are transparent to API consumers.
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/value-sets/{id}/versions/{version}/expansion-export{?params*}` | `ValueSet.read` | Initiate export, returns process ID |
-| GET | `/expansion-export-csv/result/{processId}` | `ValueSet.read` | Download CSV |
-| GET | `/expansion-export-xlsx/result/{processId}` | `ValueSet.read` | Download Excel |
+| GET | `/value-sets/{id}/versions/{version}/expansion-export{?params*}` | `ValueSet.triage` | Initiate export, returns process ID |
+| GET | `/expansion-export-csv/result/{processId}` | `ValueSet.triage` | Download CSV |
+| GET | `/expansion-export-xlsx/result/{processId}` | `ValueSet.triage` | Download Excel |
 
 ### CodeSystem Export
 
 | Method | Path | Privilege | Description |
 |--------|------|-----------|-------------|
-| GET | `/code-systems/{id}/versions/{version}/concepts-export{?params*}` | `CodeSystem.read` | Initiate export |
-| GET | `/concepts-export-csv/result/{processId}` | `CodeSystem.read` | Download CSV |
-| GET | `/concepts-export-xlsx/result/{processId}` | `CodeSystem.read` | Download Excel |
+| GET | `/code-systems/{id}/versions/{version}/concepts/export{?params*}` | `CodeSystem.triage` | Initiate export |
+| GET | `/concepts/export-csv/result/{processId}` | `CodeSystem.triage` | Download CSV |
+| GET | `/concepts/export-xlsx/result/{processId}` | `CodeSystem.triage` | Download Excel |
 
 ## Testing
 
@@ -183,61 +183,57 @@ Download exported file and verify:
 
 ### Optimization Data Structures
 
-**CodingReference:**
+**Coding-property pairs:**
 
-Unique identifier for concepts referenced in property values.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| codeSystem | String | Code system identifier |
-| code | String | Concept code |
-
-Used as key in display name cache map.
+Coding property values referenced by the expansion concepts are collected as a
+de-duplicated `List<Pair<String, String>>` of `(codeSystem, code)` pairs
+(`ValueSetExportService.collectCodingPropertyPairs`).
 
 **Example:**
 
 ```java
-CodingReference {
-  codeSystem: "snomed-ct",
-  code: "73211009"
-}
+List<Pair<String, String>> codingPairs = List.of(
+  Pair.of("snomed-ct", "73211009"),
+  Pair.of("icd-10", "E10")
+);
 ```
 
-**Display Map:**
+**Concept map:**
 
-Pre-loaded cache mapping coding references to display names.
+Pre-loaded cache returned by `ConceptService.batchLoad`, keyed by
+`codeSystem + "|" + code` and holding the fully decorated `Concept`.
 
 ```java
-Map<CodingReference, String> displayMap = {
-  CodingReference("snomed-ct", "73211009") -> "Diabetes mellitus",
-  CodingReference("icd-10", "E10") -> "Type 1 diabetes mellitus"
-}
+Map<String, Concept> conceptMap = conceptService.batchLoad(codingPairs);
+// conceptMap.get("snomed-ct|73211009") -> Concept("Diabetes mellitus")
+// conceptMap.get("icd-10|E10")         -> Concept("Type 1 diabetes mellitus")
 ```
 
-Eliminates N+1 queries by loading all displays upfront in 1-2 batch queries instead of thousands of individual queries.
+Eliminates N+1 queries by loading all referenced concepts upfront (one batch query
+per code system) instead of thousands of individual queries.
 
 ### Export Data Flow
 
 **Input:** List of ValueSet expansion concepts
 
 **Phase 1 - Pre-processing:**
-1. Extract all coding references from property values
-2. Batch load display names for all references (Map<CodingReference, String>)
-3. Scan first 1000 concepts to determine headers
+1. Extract all coding-property `(codeSystem, code)` pairs from property values
+2. Batch load referenced concepts (`ConceptService.batchLoad` → `Map<String, Concept>` keyed by `codeSystem|code`)
+3. Compose headers from the expansion concepts
 
-**Phase 2 - Streaming:**
-1. For each concept (streamed one at a time):
-   - Compose row using pre-loaded display map
-   - Write row to streaming Excel workbook
-   - Row data immediately flushed to disk (not kept in memory)
-2. Finalize workbook and return binary data
+**Phase 2 - Row composition + write:**
+1. Compose all rows into an in-heap `List<Object[]>` (using the pre-loaded display map)
+2. Hand the row list to `XlsxUtil.composeXlsx`, which writes through Apache POI's `SXSSFWorkbook(100)` — only ~100 rows are held in the POI write window at a time, older rows flush to a temp file
+3. Finalize workbook and return binary data
 
 **Memory profile:**
 
 - Display map: ~1-5 MB (depends on referenced concepts)
-- Streaming buffer: ~10 MB (100 rows)
+- Materialized row list: grows with valueset size (held fully in heap)
+- POI write window: ~100 rows bounded at the write stage only
 - Header set: < 1 MB
-- **Total: ~15-20 MB constant** regardless of valueset size
+
+The POI write window bounds memory only during Excel serialization; end-to-end memory is not constant because the full row list is materialized first.
 
 ### Performance Metrics
 
@@ -335,14 +331,11 @@ conceptService.load(codeSystem, code)  // Individual query
 
 ```java
 // Before processing any rows
-Set<CodingReference> codingRefs = concepts.stream()
-    .flatMap(c -> extractCodingReferences(c))
-    .collect(Collectors.toSet());
-
-Map<CodingReference, String> displayMap = conceptService.batchLoadDisplays(codingRefs);
+List<Pair<String, String>> codingPairs = collectCodingPropertyPairs(concepts);
+Map<String, Concept> conceptMap = conceptService.batchLoad(codingPairs);
 
 // During row composition
-String display = displayMap.get(new CodingReference(codeSystem, code));
+Concept concept = conceptMap.get(codeSystem + "|" + code);
 ```
 
 **2. Streaming Excel Generation**
@@ -385,36 +378,35 @@ concepts.stream().limit(1000).forEach(concept -> {
 
 | File | Description |
 |------|-------------|
-| `terminology/src/main/java/com/kodality/termx/terminology/terminology/valueset/expansion/ValueSetExportService.java` | ValueSet export with optimizations |
-| `terminology/src/main/java/com/kodality/termx/terminology/terminology/codesystem/concept/ConceptExportService.java` | CodeSystem export with same optimizations |
-| `terminology/src/main/java/com/kodality/termx/terminology/terminology/codesystem/concept/ConceptService.java` | Batch concept loading method |
-| `termx-core/src/main/java/com/kodality/termx/core/utils/XlsxUtil.java` | Streaming Excel generation utility |
+| `terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetExportService.java` | ValueSet export with optimizations |
+| `terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptExportService.java` | CodeSystem export with same optimizations |
+| `terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptService.java` | Batch concept loading method |
+| `termx-core/src/main/java/org/termx/core/utils/XlsxUtil.java` | Streaming Excel generation utility |
 
 ### Batch Concept Loading
 
-**New method in ConceptService:**
+**Method in ConceptService:**
 
 ```java
-public Map<CodingReference, String> batchLoadDisplays(Set<CodingReference> references) {
-  // Group by code system
-  Map<String, List<String>> byCodeSystem = references.stream()
-    .collect(Collectors.groupingBy(
-      CodingReference::getCodeSystem,
-      Collectors.mapping(CodingReference::getCode, Collectors.toList())
-    ));
-  
-  Map<CodingReference, String> result = new HashMap<>();
-  
-  // Load all concepts for each code system in single query
-  byCodeSystem.forEach((codeSystem, codes) -> {
-    List<Concept> concepts = conceptRepository.loadBatch(codeSystem, codes);
-    concepts.forEach(c -> {
-      String display = ConceptUtil.getDisplay(c.getLastVersion(), language);
-      result.put(new CodingReference(codeSystem, c.getCode()), display);
-    });
-  });
-  
-  return result;
+public Map<String, Concept> batchLoad(List<Pair<String, String>> codeSystemCodePairs) {
+  if (CollectionUtils.isEmpty(codeSystemCodePairs)) {
+    return Map.of();
+  }
+
+  // Group codes by code system
+  Map<String, List<String>> codeSystemToCodes = codeSystemCodePairs.stream()
+      .collect(Collectors.groupingBy(
+          Pair::getLeft,
+          Collectors.mapping(Pair::getRight, Collectors.toList())
+      ));
+
+  // Load all concepts for every code system in a single batch, then decorate
+  List<Concept> concepts = repository.batchLoad(codeSystemToCodes);
+  List<Concept> decorated = decorate(concepts, null, new ConceptQueryParams());
+
+  // Keyed by "codeSystem|code"
+  return decorated.stream()
+      .collect(Collectors.toMap(c -> c.getCodeSystem() + "|" + c.getCode(), c -> c));
 }
 ```
 

--- a/docs/fhir-tx-conformance-todo.md
+++ b/docs/fhir-tx-conformance-todo.md
@@ -80,7 +80,7 @@ Each problem `Pn` below is independent and self-contained: **Symptom** (the tx d
 
 The tx-ecosystem compares the *whole* response exactly (after scrubbing volatile ids/timestamps and `$external:N$`-tagged free text). So a test only flips green when params + every issue's `severity` / FHIR `code` / `tx-issue-type` coding / `location` + counts all match. That is why the remaining work is per-case rather than structural.
 
-Current per-suite gaps (pass/total): `version 144/206`, `permutations 23/56`, `validation 23/54`, `language 4/26`, `overload 10/29`, `parameters 17/35`, `language2 12/25`, `extensions 0/11`, `deprecated 0/11`, `notSelectable 40/50`, `inactive 3/12`, `default-valueset-version 4/12`, `simple-cases 11/18`, `errors 0/7`, `search 0/6`, `exclude 3/8`, `fragment 3/7`, `regex-bad 0/4`, `big 2/5`, `other 0/3`, `case 4/6`, `metadata 0/2`, `translate 0/2`, `tho 0/2`, `batch 0/2`.
+Current per-suite gaps (pass/total) — **stale snapshot (~303 total), superseded by the `400/402` headline at the top of this file; kept only for the per-suite shape, not the counts:** `version 144/206`, `permutations 23/56`, `validation 23/54`, `language 4/26`, `overload 10/29`, `parameters 17/35`, `language2 12/25`, `extensions 0/11`, `deprecated 0/11`, `notSelectable 40/50`, `inactive 3/12`, `default-valueset-version 4/12`, `simple-cases 11/18`, `errors 0/7`, `search 0/6`, `exclude 3/8`, `fragment 3/7`, `regex-bad 0/4`, `big 2/5`, `other 0/3`, `case 4/6`, `metadata 2/2 (DONE — CapabilityStatement/TerminologyCapabilities, PR #367)`, `translate 0/2`, `tho 0/2`, `batch 0/2`.
 
 ---
 

--- a/docs/rest-client/README.md
+++ b/docs/rest-client/README.md
@@ -9,6 +9,7 @@ examples you can share with integrators to verify a server behaves correctly.
 | File | What it covers |
 |------|----------------|
 | [`fhir-terminology-supplement.http`](fhir-terminology-supplement.http) | A base CodeSystem + Estonian/Russian **supplements**, **stored ("static") ValueSets** referencing them via the `valueset-supplement` extension, expanded with `displayLanguage`; `$validate-code`; and **inline** `$expand`. |
+| [`fhir-terminology-expand-designations.http`](fhir-terminology-expand-designations.http) | `$expand` **designation + property** controls — `includeDesignations`, `designation` filtering by language/use, `displayLanguage` display selection, and requesting concept `property` values into `contains[]`. |
 
 ## Using a suite
 

--- a/docs/ucum-supplement-ts-api-followup.md
+++ b/docs/ucum-supplement-ts-api-followup.md
@@ -4,7 +4,7 @@
 
 This note records the supplement-related work that has already been implemented around UCUM TS concept APIs and the remaining constraints that still matter.
 
-It continues the broader supplement overview in [`docs/code-system-supplements-analysis.md`](/job/helex/htx/termx-server/docs/code-system-supplements-analysis.md).
+It continues the broader supplement overview in [`docs/code-system-supplements-analysis.md`](../docs/code-system-supplements-analysis.md).
 
 ## Implemented Outcome
 
@@ -29,11 +29,11 @@ Instead:
 
 Relevant file:
 
-- [`ConceptQueryParams.java`](/job/helex/htx/termx-server/termx-api/src/main/java/org/termx/ts/codesystem/ConceptQueryParams.java)
+- [`ConceptQueryParams.java`](../termx-api/src/main/java/org/termx/ts/codesystem/ConceptQueryParams.java)
 
 Runtime supplement enrichment is centralized in:
 
-- [`ConceptSupplementService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java)
+- [`ConceptSupplementService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptSupplementService.java)
 
 Current behavior:
 
@@ -45,16 +45,16 @@ Current behavior:
 
 The enrichment is used by:
 
-- [`ConceptService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptService.java)
-- [`ConceptController.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptController.java)
-- [`CodeSystemController.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java)
+- [`ConceptService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptService.java)
+- [`ConceptController.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptController.java)
+- [`CodeSystemController.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/CodeSystemController.java)
 
 ### FHIR alignment
 
 FHIR operations now rely on the same concept enrichment model instead of duplicating supplement-loading logic:
 
-- [`CodeSystemLookupOperation.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java)
-- [`CodeSystemValidateCodeOperation.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java)
+- [`CodeSystemLookupOperation.java`](../terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemLookupOperation.java)
+- [`CodeSystemValidateCodeOperation.java`](../terminology/src/main/java/org/termx/terminology/fhir/codesystem/operations/CodeSystemValidateCodeOperation.java)
 
 This means:
 
@@ -66,8 +66,8 @@ This means:
 
 UCUM-specific supplement-aware concept search is implemented in:
 
-- [`UcumConceptResolver.java`](/job/helex/htx/termx-server/ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java)
-- [`UcumSupplementDesignationService.java`](/job/helex/htx/termx-server/ucum/src/main/java/org/termx/ucum/ts/UcumSupplementDesignationService.java)
+- [`UcumConceptResolver.java`](../ucum/src/main/java/org/termx/ucum/ts/UcumConceptResolver.java)
+- [`UcumSupplementDesignationService.java`](../ucum/src/main/java/org/termx/ucum/ts/UcumSupplementDesignationService.java)
 
 Current behavior:
 
@@ -81,8 +81,8 @@ Current behavior:
 
 UCUM supplement-related search caches are invalidated through:
 
-- [`UcumSearchCacheInvalidator.java`](/job/helex/htx/termx-server/termx-core/src/main/java/org/termx/core/ts/UcumSearchCacheInvalidator.java)
-- [`UcumSearchCacheInvalidatorImpl.java`](/job/helex/htx/termx-server/ucum/src/main/java/org/termx/ucum/ts/UcumSearchCacheInvalidatorImpl.java)
+- [`UcumSearchCacheInvalidator.java`](../termx-core/src/main/java/org/termx/core/ts/UcumSearchCacheInvalidator.java)
+- [`UcumSearchCacheInvalidatorImpl.java`](../ucum/src/main/java/org/termx/ucum/ts/UcumSearchCacheInvalidatorImpl.java)
 
 The resolver cache:
 
@@ -92,20 +92,20 @@ The resolver cache:
 
 Relevant files:
 
-- [`CodeSystemSupplementService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java)
-- [`CodeSystemEntityVersionService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionService.java)
-- [`CodeSystemVersionService.java`](/job/helex/htx/termx-server/terminology/src/main/java/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionService.java)
-- [`UcumServiceImpl.java`](/job/helex/htx/termx-server/ucum/src/main/java/org/termx/ucum/service/UcumServiceImpl.java)
+- [`CodeSystemSupplementService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemSupplementService.java)
+- [`CodeSystemEntityVersionService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/entity/CodeSystemEntityVersionService.java)
+- [`CodeSystemVersionService.java`](../terminology/src/main/java/org/termx/terminology/terminology/codesystem/version/CodeSystemVersionService.java)
+- [`UcumServiceImpl.java`](../ucum/src/main/java/org/termx/ucum/service/UcumServiceImpl.java)
 
 ## Web Changes
 
 UCUM supplement-aware concept loading is now used in the main display/search paths:
 
-- [`concept-supplement-util.ts`](/job/helex/htx/termx-web/app/src/app/resources/_lib/code-system/util/concept-supplement-util.ts)
-- [`localized-concept-name-pipe.ts`](/job/helex/htx/termx-web/app/src/app/resources/_lib/code-system/pipe/localized-concept-name-pipe.ts)
-- [`code-system-coding-reference.service.ts`](/job/helex/htx/termx-web/app/src/app/resources/code-system/services/code-system-coding-reference.service.ts)
-- [`concept-search.component.ts`](/job/helex/htx/termx-web/app/src/app/resources/_lib/code-system/containers/concept-search.component.ts)
-- [`concept-drawer-search.component.ts`](/job/helex/htx/termx-web/app/src/app/resources/_lib/code-system/containers/concept-drawer-search.component.ts)
+- `termx-web/app/src/app/resources/_lib/code-system/util/concept-supplement-util.ts`
+- `termx-web/app/src/app/resources/_lib/code-system/pipe/localized-concept-name-pipe.ts`
+- `termx-web/app/src/app/resources/code-system/services/code-system-coding-reference.service.ts`
+- `termx-web/app/src/app/resources/_lib/code-system/containers/concept-search.component.ts`
+- `termx-web/app/src/app/resources/_lib/code-system/containers/concept-drawer-search.component.ts`
 
 Current policy:
 


### PR DESCRIPTION
## Summary

Critically validated **every** feature/reference doc under `docs/` against the actual source code (six parallel validators, then fixes verified against `file:line`) and corrected the drift. Also folds in the GitHub-based permission-scheme update and broken-link fixes from this review pass. **Docs-only** — no source code changed.

24 files: `README.md` + 23 docs.

## ⚠️ One real code bug found (not fixed here — needs a separate PR)

The SNOMED `$expand` implicit-VS paths **`?fhir_vs`** (all) and **`?fhir_vs=ecl/<expr>`** throw `ApiError.SN301` at runtime: `SnomedValueSetExpandProvider.composeEcl` has no `ecl` case and `"ecl"` isn't in `ValueSetRuleFilterOperator.ALL`, yet `ruleExpandPaged` calls `composeEcl` unconditionally. Unit tests miss it because they assert against a **mocked** provider. This PR corrects the *doc* to mark those paths unimplemented; the code fix should be tracked on its own.

## What was corrected

**Permissions / task access**
- `task-access-control.md` migrated to the GitHub-based action vocabulary (`read`/`triage`/`write`/`maintain`) — action table, derivation logic, code sample, mermaid, `T_READ`, resource→privilege mapping.
- `mock-auth.md` privilege table regenerated from `mock/users.json` (wildcards + `triage`, adds `editor2`).
- Doc privileges corrected: LOINC import/slot-mapping → `*.CodeSystem.write`; SNOMED labels → `SNOMED_READ/WRITE`; Excel exports → `*.triage`; server ecosystem export → `Server.read`.

**Config / deployment**
- `deployment-configuration.md`: `max-request-size` is **600 MB** (was 1.5 GB, 3 places); removed **phantom** `termx.terminology-archive.*` rows; corrected `termx.conformance.*` prefix.
- Removed the phantom `termx.snomed.delta-generator.timeout-seconds` property.

**Endpoints / APIs**
- Server ecosystem route is `/servers/...` (no `/api` context path); CodeSystem export paths `/concepts/export[-csv|-xlsx]`; real `conceptService.batchLoad(List<Pair>)` (no `CodingReference`/`batchLoadDisplays`); SQL function `value_set_expand(text)` (not `*_jsonb`).

**Behavior**
- Excel export memory bounded at the POI write window only (not O(1) end-to-end).
- Email: `sys.snomed_import_tracking`; real `JobLogService.finish(...)` signature; subject `"[TermX] <job> (<source>) - Completed"`; SMTP `javamail.*` keys; default sender `noreply@termx.dev`.
- CodeSystem import: XLSX requires a `concepts` sheet (TE740); association targets `#`-separated and not type-filtered; TE707 message; `saveConcepts` 5-arg; specs v1.1.0.
- `fhir-summary-parameter.md`: three `termx.fhir.*.search.default-summary` keys (default `true`), not "always on".
- `architecture.md`: correct CI workflows; spotbugs/pmd **do** run in CI.

**Housekeeping**
- Global `com.kodality.termx` → `org.termx` package-path rename across docs.
- Rewrote broken Jenkins `/job/helex/...` links to repo-relative; fixed 3 dangling links.

Docs verified clean and unchanged: `fhir-etag-revalidation.md`, `ecosystem-management.md`, `structure-definition-versioning-and-import.md`, `reexpand-stale-snapshots.md`, `value-set-rule-expansion-preview.md`, `fhir-terminology-ecosystem-registry-proxy.md`.