### PR TITLE
fix(snomed): expand SNOMED implicit ?fhir_vs and ?fhir_vs=ecl/… paths

### DIFF
--- a/docs/features/value-set-expand.md
+++ b/docs/features/value-set-expand.md
@@ -132,15 +132,15 @@ GET /fhir/ValueSet/$expand?url=http://loinc.org/answer-list&valueSetVersion=2.82
 
 ## 5. SNOMED `?fhir_vs` URL family
 
-Per the [HL7 UTG SNOMED CT page](https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html), the SNOMED canonical URL supports five implicit-ValueSet patterns. TermX maps each URL to a `ValueSetVersionRule` filter, but only **three** of the synthesised operators are actually implemented in `SnomedValueSetExpandProvider.composeEcl()` (`is-a`, `in`). The other two synthesise `operator=ecl` — an operator that is **not** in `ValueSetRuleFilterOperator.ALL` and that `composeEcl` has no `switch` case for, so its `default` branch throws `ApiError.SN301` at runtime. Those two paths (`?fhir_vs` all-concepts and `?fhir_vs=ecl/…`) are therefore currently **unimplemented**:
+Per the [HL7 UTG SNOMED CT page](https://build.fhir.org/ig/HL7/UTG/en/SNOMEDCT.html), the SNOMED canonical URL supports five implicit-ValueSet patterns. TermX maps each URL to a `ValueSetVersionRule` filter, which `SnomedValueSetExpandProvider.composeEcl()` compiles to ECL. The `?fhir_vs` (all concepts) and `?fhir_vs=ecl/…` patterns synthesise a `operator=ecl` filter whose value is already a complete ECL expression (`*` or the raw ECL); `composeEcl` passes it through verbatim.
 
 | Input URL fragment | Synthesised filter | ECL emitted by `composeEcl` | Meaning |
 |---|---|---|---|
-| `?fhir_vs` | `operator=ecl, value="*"` | **Unimplemented** — `composeEcl` has no `ecl` case, so its `default` branch throws `ApiError.SN301`. | Intended: all concepts in the edition/version. Currently unsupported (throws at runtime). |
+| `?fhir_vs` | `operator=ecl, value="*"` | `*` | All concepts in the edition/version. |
 | `?fhir_vs=isa/<sctid>` | `operator=is-a, value=<sctid>` | `<<<sctid>` | Descendants of `<sctid>` **plus the concept itself** (per IG). |
 | `?fhir_vs=refset` | `operator=is-a, value=900000000000455006` | `<<900000000000455006` | All concepts under `Reference set foundation` — i.e. the catalog of refsets. |
 | `?fhir_vs=refset/<sctid>` | `operator=in, value=<sctid>` | `^<sctid>` | Active members of refset `<sctid>`. |
-| `?fhir_vs=ecl/<URL-encoded>` | `operator=ecl, value=<URL-decoded>` | **Unimplemented** — `composeEcl` has no `ecl` case, so its `default` branch throws `ApiError.SN301`. | Intended: concepts matching the ECL expression (URI-decoded first). Currently unsupported (throws at runtime). |
+| `?fhir_vs=ecl/<URL-encoded>` | `operator=ecl, value=<URL-decoded>` | `<expr>` | Concepts matching the ECL expression (URI-decoded first). |
 
 Both base canonicals are accepted:
 

--- a/snomed/src/main/java/org/termx/snomed/ts/SnomedValueSetExpandProvider.java
+++ b/snomed/src/main/java/org/termx/snomed/ts/SnomedValueSetExpandProvider.java
@@ -42,6 +42,10 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
   private static final String SNOMED_CHILD_OF = "child-of";
   private static final String SNOMED_GENERALIZES = "generalizes";
   private static final String SNOMED_IN = "in";
+  // Synthetic operator produced by the SNOMED implicit-VS routing in ValueSetExpandOperation
+  // for `?fhir_vs` (value="*", all concepts) and `?fhir_vs=ecl/<expr>` (value=the raw ECL).
+  // It is not a real FHIR filter operator; the value is already a complete ECL expression.
+  private static final String SNOMED_ECL = "ecl";
 
   // Snowstorm caps single-page `limit` at 10_000 (Elasticsearch from+size).
   // A null `count` from the caller means "no client-side cap"; honour Snowstorm's
@@ -223,6 +227,11 @@ public class SnomedValueSetExpandProvider extends ValueSetExternalExpandProvider
 
   private String composeEcl(ValueSetRuleFilter f) {
     String operator = f.getOperator() == null ? "" : f.getOperator();
+    // The `ecl` operator carries a complete ECL expression already (`*` or a raw ECL); pass it
+    // through verbatim — no constraint prefix.
+    if (SNOMED_ECL.equals(operator)) {
+      return String.valueOf(f.getValue());
+    }
     // Map the FHIR filter operator to its ECL constraint operator. Operators with no ECL
     // equivalent (is-not-a, descendent-leaf, regex, =, in-on-property, not-in, exists) are rejected
     // rather than silently emitting a bare, unconstrained value.

--- a/snomed/src/test/groovy/org/termx/snomed/ts/SnomedValueSetExpandProviderSpec.groovy
+++ b/snomed/src/test/groovy/org/termx/snomed/ts/SnomedValueSetExpandProviderSpec.groovy
@@ -26,6 +26,7 @@ import spock.lang.Specification
  *   <li>{@code child-of}      → {@code <!value}  (direct children)</li>
  *   <li>{@code generalizes}   → {@code >>value}  (ancestor-or-self)</li>
  *   <li>{@code in}            → {@code ^value}    (members of the reference set)</li>
+ *   <li>{@code ecl}           → {@code value}     (synthetic operator; value is already ECL, e.g. {@code *})</li>
  * </ul>
  * Operators with no ECL equivalent are rejected with {@code SN301} rather than silently emitting a
  * bare value (issue #197).
@@ -57,6 +58,44 @@ class SnomedValueSetExpandProviderSpec extends Specification {
     "child-of"      || "<!73211009"
     "generalizes"   || ">>73211009"
     "in"            || "^73211009"
+  }
+
+  def "the synthetic `ecl` operator passes its value through as the ECL verbatim"() {
+    given: "the two shapes ValueSetExpandOperation synthesises for `?fhir_vs` and `?fhir_vs=ecl/<expr>`"
+    def rule = ruleWith(filter("ecl", value))
+
+    when:
+    provider.ruleExpandPaged(rule, new ValueSetVersion(), "en", null, 0, 10)
+
+    then: "composeEcl emits the value unchanged — no SN301, no constraint prefix"
+    1 * snomedService.searchConceptsPage({ SnomedConceptSearchParams p -> p.ecl == value }) >>
+        new SnomedSearchResult<SnomedConcept>().setItems([]).setTotal(0)
+
+    where:
+    value          | _
+    "*"            | _   // ?fhir_vs — all concepts
+    "<< 363787002" | _   // ?fhir_vs=ecl/<expr> — raw ECL
+  }
+
+  def "the `ecl` operator is also honoured on the non-paged (ruleExpand) path and maps concepts"() {
+    // composeEcl is reached from two call sites — ruleExpandPaged (above) and
+    // filterConcepts via ruleExpand. Exercise the second one too, and assert the
+    // whole compile→search→map flow, so `?fhir_vs` can't regress on either path.
+    given: "the all-concepts shape `?fhir_vs` → operator ecl, value *"
+    def rule = ruleWith(filter("ecl", "*"))
+
+    when:
+    def result = provider.ruleExpand(rule, new ValueSetVersion(), "en")
+
+    then: "filterConcepts compiles the verbatim ECL `*` (no SN301) and the concept surfaces"
+    1 * snomedService.searchConcepts({ SnomedConceptSearchParams p -> p.ecl == "*" && p.all }) >>
+        [new SnomedConcept().setConceptId("404684003").setActive(true)]
+    1 * snomedService.loadDescriptions(_, ["404684003"]) >> [
+        new SnomedDescription().setConceptId("404684003").setDescriptionId("d1").setLang("en")
+            .setTerm("Clinical finding").setTypeId("900000000000013009").setActive(true).setAcceptabilityMap([:])
+    ]
+    result*.concept*.code == ["404684003"]
+    result.first().display.name == "Clinical finding"
   }
 
   def "the free-text filter and paging are pushed down to Snowstorm"() {


### PR DESCRIPTION
## Problem

The SNOMED implicit-ValueSet `$expand` URLs `?fhir_vs` (all concepts) and `?fhir_vs=ecl/<expr>` threw `ApiError.SN301` at runtime instead of expanding.

`ValueSetExpandOperation` synthesises an `operator=ecl` filter for both patterns, but `SnomedValueSetExpandProvider.composeEcl` had no `ecl` case — its `switch` `default` rejected the operator with SN301 *before* any Snowstorm request was built. (`ruleExpandPaged` and `filterConcepts` both call `composeEcl` unconditionally.)

## Fix

Add an `ecl` case to `composeEcl` that passes the value through verbatim — the value is already a complete ECL expression (`*` for `?fhir_vs`, or the raw ECL for `?fhir_vs=ecl/…`). The change is structurally a no-op for every other operator: the new guard is false for is-a/descendent-of/child-of/generalizes/in, which fall through to the identical `switch`.

## Tests

The existing `ValueSetExpandOperationTest` cases missed this because they mock the SNOMED provider, so `composeEcl` never ran. Added real (non-mocked, only `SnomedService` stubbed) coverage in `SnomedValueSetExpandProviderSpec` for **both** `composeEcl` call sites:

- paged `ruleExpandPaged` — data-driven over `value="*"` → ECL `*` and `value="<< 363787002"` → ECL `<< 363787002`, asserting the ECL reaches Snowstorm unchanged with no SN301;
- non-paged `ruleExpand` → `filterConcepts` — the full compile→search→map flow for `*`.

`SnomedValueSetExpandProviderSpec` now runs 17 tests, 0 failures.

## Verification

- Full `:snomed:test` suite green (33 tests).
- Verified end-to-end against a live server + Snowstorm (`MAIN/SNOMEDCT-EE`): `?fhir_vs=ecl/<< 73211009` → ValueSet total 120; `?fhir_vs` → ValueSet total 382084. Both previously returned SN301.
- Full tx-ecosystem conformance run confirmed **zero** change to the score (554/600 with and without this change — the SNOMED implicit-VS path isn't exercised by the suite), i.e. no regression.

Reverts the `docs/features/value-set-expand.md` §5 note that had marked these two paths "unimplemented".