### PR TITLE
feat(terminology): port TEHIK fork Tier 1 fixes (KL-94/96/98/104/118)

### DIFF
--- a/implementation-guide/build.gradle.kts
+++ b/implementation-guide/build.gradle.kts
@@ -20,4 +20,11 @@ dependencies {
     implementation("io.micronaut:micronaut-management")
     implementation("io.micronaut:micronaut-http-server")
     implementation("io.reactivex.rxjava2:rxjava:2.2.21")
+
+    testImplementation("org.spockframework:spock-core") {
+        exclude(group = "org.codehaus.groovy", module = "groovy-all")
+    }
+    testImplementation("io.micronaut.test:micronaut-test-spock")
+    testRuntimeOnly("net.bytebuddy:byte-buddy:1.17.0")
+    testRuntimeOnly("org.objenesis:objenesis:3.3")
 }

--- a/implementation-guide/src/main/java/org/termx/implementationguide/ApiError.java
+++ b/implementation-guide/src/main/java/org/termx/implementationguide/ApiError.java
@@ -10,7 +10,8 @@ public enum ApiError {
   IG101("IG101", "Could not create not draft version."),
   IG102("IG102", "Version '{{version}}' already exists."),
   IG103("IG103", "Id is not allowed to contain '{{symbols}}'"),
-  IG104("IG104", "Version '{{version}}' of implementation guide '{{ig}}' doesn't exist.");
+  IG104("IG104", "Version '{{version}}' of implementation guide '{{ig}}' doesn't exist."),
+  IG105("IG105", "Resource ID does not match regex: [A-Za-z0-9\\-\\.]{1,64}");
 
 
 

--- a/implementation-guide/src/main/java/org/termx/implementationguide/ig/ImplementationGuideService.java
+++ b/implementation-guide/src/main/java/org/termx/implementationguide/ig/ImplementationGuideService.java
@@ -7,6 +7,7 @@ import org.termx.implementationguide.ig.version.ImplementationGuideVersion;
 import org.termx.implementationguide.ig.version.ImplementationGuideVersionQueryParams;
 import org.termx.implementationguide.ig.version.ImplementationGuideVersionService;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.Optional;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Singleton
 @RequiredArgsConstructor
 public class ImplementationGuideService {
+  private static final Pattern ID_REGEX = Pattern.compile("[A-Za-z0-9\\-.]{1,64}");
+
   private final ImplementationGuideRepository repository;
   private final ImplementationGuideVersionService versionService;
 
@@ -61,6 +64,9 @@ public class ImplementationGuideService {
   private void validateId(String id) {
     if (id.contains(BaseFhirMapper.SEPARATOR)) {
       throw ApiError.IG103.toApiException(Map.of("symbols", BaseFhirMapper.SEPARATOR));
+    }
+    if (!ID_REGEX.matcher(id).matches()) {
+      throw ApiError.IG105.toApiException();
     }
   }
 

--- a/implementation-guide/src/test/groovy/org/termx/implementationguide/ig/ImplementationGuideServiceIdValidationSpec.groovy
+++ b/implementation-guide/src/test/groovy/org/termx/implementationguide/ig/ImplementationGuideServiceIdValidationSpec.groovy
@@ -1,0 +1,33 @@
+package org.termx.implementationguide.ig
+
+import com.kodality.commons.exception.ApiException
+import org.termx.implementationguide.ig.version.ImplementationGuideVersionService
+import spock.lang.Specification
+
+/**
+ * Migrated from tehik fork KL-104: changeId() must reject a resource id that does not match
+ * the FHIR id regex [A-Za-z0-9\-.]{1,64} (IG105).
+ */
+class ImplementationGuideServiceIdValidationSpec extends Specification {
+  def repository = Mock(ImplementationGuideRepository)
+  def versionService = Mock(ImplementationGuideVersionService)
+  def service = new ImplementationGuideService(repository, versionService)
+
+  def "changeId rejects a new id violating the resource-id regex"() {
+    when:
+    service.changeId("old-id", "bad id")
+
+    then:
+    def e = thrown(ApiException)
+    e.issues*.code.contains("IG105")
+    0 * repository.changeId(_, _)
+  }
+
+  def "changeId accepts a valid new id"() {
+    when:
+    service.changeId("old-id", "valid-id.1")
+
+    then:
+    1 * repository.changeId("old-id", "valid-id.1")
+  }
+}

--- a/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
+++ b/snomed/src/main/java/org/termx/snomed/integration/SnomedController.java
@@ -482,8 +482,15 @@ public class SnomedController {
     SnomedDescriptionItemResponse response = snowstormClient.findConceptDescriptions(params).join();
 
     AsyncHelper futures = new AsyncHelper();
-    response.getItems().forEach(item -> futures.add(
-        snowstormClient.loadConcept(item.getConcept().getConceptId()).thenApply(c -> item.getConcept().setDescriptions(c.getDescriptions()))));
+    response.getItems().forEach(item -> {
+      if (StringUtils.isNotEmpty(params.getBranch())) {
+        futures.add(snowstormClient.loadConcept(params.getBranch() + "/", item.getConcept().getConceptId())
+            .thenApply(c -> item.getConcept().setDescriptions(c.getDescriptions())));
+      } else {
+        futures.add(snowstormClient.loadConcept(item.getConcept().getConceptId())
+            .thenApply(c -> item.getConcept().setDescriptions(c.getDescriptions())));
+      }
+    });
     futures.joinAll();
 
     return response;

--- a/snomed/src/test/groovy/org/termx/snomed/integration/SnomedControllerBranchDescriptionsSpec.groovy
+++ b/snomed/src/test/groovy/org/termx/snomed/integration/SnomedControllerBranchDescriptionsSpec.groovy
@@ -1,0 +1,49 @@
+package org.termx.snomed.integration
+
+import org.termx.snomed.client.SnowstormClient
+import org.termx.snomed.concept.SnomedConcept
+import org.termx.snomed.decriptionitem.SnomedDescriptionItemResponse
+import org.termx.snomed.decriptionitem.SnomedDescriptionItemResponse.SnomedDescriptionItem
+import org.termx.snomed.decriptionitem.SnomedDescriptionItemSearchParams
+import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Migrated from tehik fork: findConceptDescriptions() must load the follow-up concept from the
+ * requested SNOMED branch (branch + "/") instead of the default branch, so descriptions come
+ * from the correct edition. Falls back to the default branch when none is set.
+ */
+class SnomedControllerBranchDescriptionsSpec extends Specification {
+  def client = Mock(SnowstormClient)
+  // findConceptDescriptions only collaborates with snowstormClient (2nd constructor arg)
+  def controller = new SnomedController(null, client, null, null, null, null, null, null, null, null, null, null, null, null)
+
+  private static SnomedDescriptionItemResponse responseWith(String conceptId) {
+    return new SnomedDescriptionItemResponse().setItems([
+        new SnomedDescriptionItem().setConcept(new SnomedConcept().setConceptId(conceptId))])
+  }
+
+  def "loads descriptions from the requested branch"() {
+    given:
+    client.findConceptDescriptions(_) >> CompletableFuture.completedFuture(responseWith("123"))
+    client.loadConcept(_) >> CompletableFuture.completedFuture(new SnomedConcept())
+
+    when:
+    controller.findConceptDescriptions(new SnomedDescriptionItemSearchParams().setBranch("MAIN/EE"))
+
+    then:
+    1 * client.loadConcept("MAIN/EE/", "123") >> CompletableFuture.completedFuture(new SnomedConcept())
+  }
+
+  def "falls back to the default branch when none is set"() {
+    given:
+    client.findConceptDescriptions(_) >> CompletableFuture.completedFuture(responseWith("123"))
+
+    when:
+    controller.findConceptDescriptions(new SnomedDescriptionItemSearchParams())
+
+    then:
+    1 * client.loadConcept("123") >> CompletableFuture.completedFuture(new SnomedConcept())
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/concept/ConceptRepository.java
@@ -242,8 +242,8 @@ public class ConceptRepository extends BaseRepository {
     if (StringUtils.isNotEmpty(params.getAssociationSourceRecursive()) || StringUtils.isNotEmpty(params.getAssociationTargetRecursive())) {
       String from = "from terminology.concept as cc " +
           "left join terminology.code_system_entity_version csev on csev.code_system_entity_id = cc.id and csev.sys_status = 'A' " +
-          "left join terminology.code_system_association csa_s on csa_s.source_code_system_entity_version_id = csev.id and csa_s.sys_status = 'A' " +
-          "left join terminology.code_system_association csa_t on csa_t.target_code_system_entity_version_id = csev.id and csa_t.sys_status = 'A' " +
+          "left join terminology.code_system_association csa_s on (csa_s.source_code_system_entity_version_id = csev.id or csa_s.source_code_system_entity_version_id = csev.base_entity_version_id) and csa_s.sys_status = 'A' " +
+          "left join terminology.code_system_association csa_t on (csa_t.target_code_system_entity_version_id = csev.id or csa_t.target_code_system_entity_version_id = csev.base_entity_version_id) and csa_t.sys_status = 'A' " +
           "left join terminology.code_system_entity_version c_s on c_s.id = csa_t.source_code_system_entity_version_id and c_s.sys_status = 'A' " +
           "left join terminology.code_system_entity_version c_t on c_t.id = csa_s.target_code_system_entity_version_id and c_t.sys_status = 'A'";
       String from1 =
@@ -444,11 +444,11 @@ public class ConceptRepository extends BaseRepository {
 
     if (CollectionUtils.isNotEmpty(
         Stream.of(params.getAssociationRoot(), params.getAssociationSource(), params.getAssociationType()).filter(Objects::nonNull).toList())) {
-      join += "left join terminology.code_system_association csa_s on csa_s.source_code_system_entity_version_id = csev.id and csa_s.sys_status = 'A' ";
+      join += "left join terminology.code_system_association csa_s on (csa_s.source_code_system_entity_version_id = csev.id or csa_s.source_code_system_entity_version_id = csev.base_entity_version_id) and csa_s.sys_status = 'A' ";
     }
 
     if (CollectionUtils.isNotEmpty(Stream.of(params.getAssociationLeaf(), params.getAssociationTarget()).filter(Objects::nonNull).toList())) {
-      join += "left join terminology.code_system_association csa_t on csa_t.target_code_system_entity_version_id = csev.id and csa_t.sys_status = 'A' ";
+      join += "left join terminology.code_system_association csa_t on (csa_t.target_code_system_entity_version_id = csev.id or csa_t.target_code_system_entity_version_id = csev.base_entity_version_id) and csa_t.sys_status = 'A' ";
     }
 
     if (CollectionUtils.isNotEmpty(Stream.of(params.getAssociationSource()).filter(Objects::nonNull).toList())) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetController.java
@@ -38,6 +38,8 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
@@ -110,6 +112,7 @@ public class MapSetController {
   @Authorized(Privilege.MS_MAINTAIN)
   @Delete(uri = "/{mapSet}")
   public HttpResponse<?> deleteMapSet(@PathVariable String mapSet) {
+    mapSet = parseCode(mapSet);
     mapSetService.cancel(mapSet);
     provenanceService.create(new Provenance("delete", "MapSet", mapSet));
     return HttpResponse.ok();
@@ -346,6 +349,10 @@ public class MapSetController {
       }
     }), VirtualThreadExecutor.get());
     return jobLogResponse;
+  }
+
+  private String parseCode(String code) {
+    return URLDecoder.decode(code, StandardCharsets.UTF_8);
   }
 
   @Getter

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/MapSetService.java
@@ -1,6 +1,7 @@
 package org.termx.terminology.terminology.mapset;
 
 import com.kodality.commons.model.QueryResult;
+import java.util.regex.Pattern;
 import org.termx.terminology.ApiError;
 import org.termx.core.fhir.BaseFhirMapper;
 import org.termx.core.utils.VersionSortUtil;
@@ -26,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Singleton
 @RequiredArgsConstructor
 public class MapSetService {
+  private static final Pattern ID_REGEX = Pattern.compile("[A-Za-z0-9\\-.]{1,64}");
+
   private final MapSetRepository repository;
   private final MapSetVersionService mapSetVersionService;
   private final MapSetPropertyService mapSetPropertyService;
@@ -102,6 +105,9 @@ public class MapSetService {
   private void validateId(String id) {
     if (id.contains(BaseFhirMapper.SEPARATOR)) {
       throw ApiError.TE113.toApiException(Map.of("symbols", BaseFhirMapper.SEPARATOR));
+    }
+    if (!ID_REGEX.matcher(id).matches()) {
+      throw ApiError.TE119.toApiException();
     }
   }
 

--- a/terminology/src/main/java/org/termx/terminology/terminology/mapset/version/MapSetVersionRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/mapset/version/MapSetVersionRepository.java
@@ -70,9 +70,9 @@ public class MapSetVersionRepository extends BaseRepository {
 
   public MapSetVersion loadPreviousVersion(String mapSet, String version) {
     String sql = "with current_version as (select release_date from terminology.map_set_version where map_set = ? and version = ? and sys_status = 'A') " +
-        select + "from terminology.map_set_version msv where msv.map_set = ? and msv.release_date < (select release_date from current_version) and msv.sys_status = 'A' " +
-        "order by msv.release_date desc";
-    return getBean(sql, bp, mapSet, version, mapSet);
+        select + "from terminology.map_set_version msv where msv.map_set = ? and msv.release_date <= (select release_date from current_version) and msv.version <> ? and msv.sys_status = 'A' " +
+        "order by msv.version desc, msv.release_date desc";
+    return getBean(sql, bp, mapSet, version, mapSet, version);
   }
 
   public QueryResult<MapSetVersion> query(MapSetVersionQueryParams params) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetController.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetController.java
@@ -41,6 +41,8 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Delete;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.PathVariable;
 import io.micronaut.http.annotation.Post;
@@ -111,6 +113,7 @@ public class ValueSetController {
   @Authorized(Privilege.VS_MAINTAIN)
   @Delete(uri = "/{valueSet}")
   public HttpResponse<?> deleteValueSet(@PathVariable String valueSet) {
+    valueSet = parseCode(valueSet);
     valueSetService.cancel(valueSet);
     provenanceService.create(new Provenance("delete", "ValueSet", valueSet));
     return HttpResponse.ok();
@@ -316,6 +319,10 @@ public class ValueSetController {
   @Get(uri = "/{valueSet}/provenances")
   public List<Provenance> queryProvenances(@PathVariable String valueSet, @Nullable @QueryValue String version) {
     return provenanceService.find(valueSet, version);
+  }
+
+  private String parseCode(String code) {
+    return URLDecoder.decode(code, StandardCharsets.UTF_8);
   }
 
   @Getter

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetService.java
@@ -1,6 +1,7 @@
 package org.termx.terminology.terminology.valueset;
 
 import com.kodality.commons.model.QueryResult;
+import java.util.regex.Pattern;
 import org.termx.terminology.ApiError;
 import org.termx.core.fhir.BaseFhirMapper;
 import org.termx.core.utils.VersionSortUtil;
@@ -24,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Singleton
 @RequiredArgsConstructor
 public class ValueSetService {
+  private static final Pattern ID_REGEX = Pattern.compile("[A-Za-z0-9\\-.]{1,64}");
+
   private final ValueSetRepository repository;
   private final ValueSetVersionService valueSetVersionService;
   private final ValueSetVersionRuleService valueSetVersionRuleService;
@@ -97,6 +100,9 @@ public class ValueSetService {
   private void validateId(String id) {
     if (id.contains(BaseFhirMapper.SEPARATOR)) {
       throw ApiError.TE113.toApiException(Map.of("symbols", BaseFhirMapper.SEPARATOR));
+    }
+    if (!ID_REGEX.matcher(id).matches()) {
+      throw ApiError.TE119.toApiException();
     }
   }
 

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/mapset/MapSetServiceIdValidationSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/mapset/MapSetServiceIdValidationSpec.groovy
@@ -1,0 +1,38 @@
+package org.termx.terminology.terminology.mapset
+
+import com.kodality.commons.exception.ApiException
+import org.termx.terminology.terminology.mapset.association.MapSetAssociationService
+import org.termx.terminology.terminology.mapset.property.MapSetPropertyService
+import org.termx.terminology.terminology.mapset.version.MapSetVersionService
+import org.termx.ts.mapset.MapSet
+import spock.lang.Specification
+
+/**
+ * Migrated from tehik fork KL-104: save() must reject a resource id that does not match
+ * the FHIR id regex [A-Za-z0-9\-.]{1,64}, mirroring CodeSystemService (TE119).
+ */
+class MapSetServiceIdValidationSpec extends Specification {
+  def repository = Mock(MapSetRepository)
+  def versionService = Mock(MapSetVersionService)
+  def propertyService = Mock(MapSetPropertyService)
+  def associationService = Mock(MapSetAssociationService)
+  def service = new MapSetService(repository, versionService, propertyService, associationService)
+
+  def "save rejects an id violating the resource-id regex"() {
+    when:
+    service.save(new MapSet().setId("bad id"))
+
+    then:
+    def e = thrown(ApiException)
+    e.issues*.code.contains("TE119")
+    0 * repository.save(_)
+  }
+
+  def "save accepts a valid id"() {
+    when:
+    service.save(new MapSet().setId("valid-id.1"))
+
+    then:
+    1 * repository.save(_)
+  }
+}

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetServiceIdValidationSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetServiceIdValidationSpec.groovy
@@ -1,0 +1,36 @@
+package org.termx.terminology.terminology.valueset
+
+import com.kodality.commons.exception.ApiException
+import org.termx.terminology.terminology.valueset.ruleset.ValueSetVersionRuleService
+import org.termx.terminology.terminology.valueset.version.ValueSetVersionService
+import org.termx.ts.valueset.ValueSet
+import spock.lang.Specification
+
+/**
+ * Migrated from tehik fork KL-104: save() must reject a resource id that does not match
+ * the FHIR id regex [A-Za-z0-9\-.]{1,64}, mirroring CodeSystemService (TE119).
+ */
+class ValueSetServiceIdValidationSpec extends Specification {
+  def repository = Mock(ValueSetRepository)
+  def versionService = Mock(ValueSetVersionService)
+  def ruleService = Mock(ValueSetVersionRuleService)
+  def service = new ValueSetService(repository, versionService, ruleService)
+
+  def "save rejects an id violating the resource-id regex"() {
+    when:
+    service.save(new ValueSet().setId("bad id"))
+
+    then:
+    def e = thrown(ApiException)
+    e.issues*.code.contains("TE119")
+    0 * repository.save(_)
+  }
+
+  def "save accepts a valid id"() {
+    when:
+    service.save(new ValueSet().setId("valid-id.1"))
+
+    then:
+    1 * repository.save(_)
+  }
+}

--- a/terminology/src/test/groovy/org/termx/ts/codesystem/CodeSystemVersionSelectionSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/ts/codesystem/CodeSystemVersionSelectionSpec.groovy
@@ -1,0 +1,40 @@
+package org.termx.ts.codesystem
+
+import org.termx.ts.PublicationStatus
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+/**
+ * Migrated from tehik fork KL-96: getFirstVersion()/getLastVersion() must break ties
+ * deterministically by version string when multiple versions share a release date.
+ */
+class CodeSystemVersionSelectionSpec extends Specification {
+
+  private static CodeSystemVersion version(String version, LocalDate releaseDate) {
+    return new CodeSystemVersion()
+        .setVersion(version)
+        .setReleaseDate(releaseDate)
+        .setStatus(PublicationStatus.active)
+  }
+
+  def "getFirstVersion breaks a release-date tie by lowest version string"() {
+    given:
+    def sameDate = LocalDate.parse("2024-01-01")
+    // input ordered so a release-date-only sort would wrongly return "2.0.0"
+    def cs = new CodeSystem().setVersions([version("2.0.0", sameDate), version("1.0.0", sameDate)])
+
+    expect:
+    cs.getFirstVersion().map { it.version }.orElse(null) == "1.0.0"
+  }
+
+  def "getLastVersion breaks a release-date tie by highest version string"() {
+    given:
+    def sameDate = LocalDate.parse("2024-01-01")
+    // input ordered so a release-date-only sort would wrongly return "1.0.0"
+    def cs = new CodeSystem().setVersions([version("1.0.0", sameDate), version("2.0.0", sameDate)])
+
+    expect:
+    cs.getLastVersion().map { it.version }.orElse(null) == "2.0.0"
+  }
+}

--- a/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystem.java
+++ b/termx-api/src/main/java/org/termx/ts/codesystem/CodeSystem.java
@@ -67,13 +67,16 @@ public class CodeSystem extends UniqueResource<CodeSystem> {
 
   @JsonIgnore
   public Optional<CodeSystemVersion> getFirstVersion() {
-    return this.getVersions().stream().min(Comparator.comparing(CodeSystemVersion::getReleaseDate));
+    return this.getVersions().stream()
+        .sorted(Comparator.comparing(CodeSystemVersion::getVersion))
+        .min(Comparator.comparing(CodeSystemVersion::getReleaseDate));
   }
 
   @JsonIgnore
   public Optional<CodeSystemVersion> getLastVersion() {
     return this.getVersions().stream()
         .filter(v -> !PublicationStatus.retired.equals(v.getStatus()))
+        .sorted(Comparator.comparing(CodeSystemVersion::getVersion).reversed())
         .max(Comparator.comparing(CodeSystemVersion::getReleaseDate));
   }
 

--- a/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/BaseFhirMapper.java
@@ -187,10 +187,10 @@ public abstract class BaseFhirMapper {
   }
 
   protected static LocalizedName fromFhirName(String name, String lang, Element extension) {
-    if (name == null) {
-      return null;
+    LocalizedName localizedName = new LocalizedName();
+    if (name != null) {
+      localizedName.add(Optional.ofNullable(lang).orElse(Language.en), name);
     }
-    LocalizedName localizedName =  new LocalizedName(Map.of(Optional.ofNullable(lang).orElse(Language.en), name));
     if (extension == null) {
       return localizedName;
     }

--- a/termx-core/src/test/groovy/org/termx/core/fhir/BaseFhirMapperNameSpec.groovy
+++ b/termx-core/src/test/groovy/org/termx/core/fhir/BaseFhirMapperNameSpec.groovy
@@ -1,0 +1,39 @@
+package org.termx.core.fhir
+
+import com.kodality.zmei.fhir.Element
+import com.kodality.zmei.fhir.Extension
+import spock.lang.Specification
+
+/**
+ * Migrated from tehik fork KL-118: fromFhirName() must retain FHIR translation
+ * extensions even when the primary name is null, instead of discarding them.
+ */
+class BaseFhirMapperNameSpec extends Specification {
+
+  private static Element elementWithTranslation(String lang, String content) {
+    def translation = new Extension("http://hl7.org/fhir/StructureDefinition/translation")
+    translation.addExtension(new Extension("lang").setValueCode(lang))
+    translation.addExtension(new Extension("content").setValueString(content))
+    def element = new Element()
+    element.addExtension(translation)
+    return element
+  }
+
+  def "keeps translations when the primary name is null"() {
+    when:
+    def result = BaseFhirMapper.fromFhirName(null, "en", elementWithTranslation("et", "Eesti nimi"))
+
+    then:
+    result != null
+    result.get("et") == "Eesti nimi"
+  }
+
+  def "combines the primary name with translations"() {
+    when:
+    def result = BaseFhirMapper.fromFhirName("English name", "en", elementWithTranslation("et", "Eesti nimi"))
+
+    then:
+    result.get("en") == "English name"
+    result.get("et") == "Eesti nimi"
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/SupplementAssociationIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/codesystem/SupplementAssociationIT.groovy
@@ -1,0 +1,110 @@
+package org.termx.terminology.codesystem
+
+import com.kodality.zmei.fhir.FhirMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
+import org.termx.terminology.terminology.codesystem.concept.ConceptRepository
+import org.termx.terminology.terminology.codesystem.entity.CodeSystemEntityVersionService
+import org.termx.terminology.terminology.codesystem.entity.CodeSystemSupplementService
+import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams
+import org.termx.ts.codesystem.CodeSystemSupplementRequest
+import org.termx.ts.codesystem.ConceptQueryParams
+
+/**
+ * KL-94 — an association defined on a BASE concept version must resolve when the query is scoped to a
+ * SUPPLEMENT entity version.
+ *
+ * <p>Model: a supplement does NOT get its own {@code concept} rows. A concept is supplemented by adding an
+ * extra {@code code_system_entity_version} on the BASE concept entity — carrying {@code base_entity_version_id}
+ * → the base version and linked (membership) to the supplement's code_system_version. Associations
+ * ({@code code_system_association}) live only on the BASE version;
+ * {@link CodeSystemSupplementService#supplementFromIds} copies the version but strips its associations.
+ *
+ * <p>{@link ConceptRepository} joins {@code code_system_association} on {@code csev.id} alone. Pinned to the
+ * SUPPLEMENT entity version (via {@code codeSystemEntityVersionId}), whose {@code id} is not the association's
+ * endpoint — its {@code base_entity_version_id} is — the association filter matches nothing. The fix also
+ * joins on {@code csev.base_entity_version_id}.
+ *
+ * <p>Pinning to the supplement version is deliberate: it keeps the base version (which carries the association
+ * directly on its own {@code csev.id}) out of scope so it cannot satisfy the filter and mask the defect.
+ */
+@MicronautTest(transactional = true)
+class SupplementAssociationIT extends TermxIntegTest {
+  @Inject CodeSystemFhirImportService csImport
+  @Inject CodeSystemSupplementService supplementService
+  @Inject CodeSystemEntityVersionService entityVersionService
+  @Inject ConceptRepository conceptRepository
+
+  static final String BASE_ID = "kl94-base"
+  static final String BASE_URL = "http://termx-test.local/CodeSystem/kl94-base"
+  static final String SUPP_ID = "kl94-supp"
+  static final String SUPP_URL = "http://termx-test.local/CodeSystem/kl94-supp"
+  static final String VERSION = "1.0.0"
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "an is-a association on the base version resolves when querying the supplement entity version"() {
+    given: "a base CS where child SA_CHILD is-a parent SA_PARENT"
+    csImport.importCodeSystem(baseCodeSystem(), BASE_ID)
+    def baseChildVersionId = versionId(BASE_ID, "SA_CHILD")
+
+    and: "a supplement CS of that base"
+    supplementService.supplement(BASE_ID, new CodeSystemSupplementRequest().setCodeSystem(SUPP_ID).setCodeSystemUri(SUPP_URL))
+
+    and: "SA_CHILD supplemented into it — a new entity version linked to the base version via base_entity_version_id"
+    def suppChildVersion = supplementService
+        .supplement(SUPP_ID, VERSION, new CodeSystemSupplementRequest().setIds([baseChildVersionId]))
+        .find { it.getCode() == "SA_CHILD" }
+
+    expect: "the supplement version is genuine — it points at the base version, not itself"
+    suppChildVersion != null
+    suppChildVersion.getBaseEntityVersionId() == baseChildVersionId
+
+    and: "control — pinned to the supplement version, the concept is queryable WITHOUT an association filter"
+    queryCodes(pinnedTo(suppChildVersion.getId())) == ["SA_CHILD"] as Set
+
+    when: "the same pinned query adds the is-a association filter"
+    def codes = queryCodes(pinnedTo(suppChildVersion.getId()).setAssociationType("is-a"))
+
+    then: "the association defined on the BASE version resolves through base_entity_version_id"
+    codes == ["SA_CHILD"] as Set
+  }
+
+  private Long versionId(String codeSystem, String code) {
+    entityVersionService.query(new CodeSystemEntityVersionQueryParams()
+        .setCodeSystem(codeSystem)
+        .setCode(code)
+        .setPermittedCodeSystems([codeSystem])
+        .tap { it.all() }).getData().find { it.getCode() == code }.getId()
+  }
+
+  private static ConceptQueryParams pinnedTo(Long suppVersionId) {
+    new ConceptQueryParams()
+        .setCodeSystem(BASE_ID)
+        .setPermittedCodeSystems([BASE_ID, SUPP_ID])
+        .setCodeSystemEntityVersionId(String.valueOf(suppVersionId))
+  }
+
+  private Set<String> queryCodes(ConceptQueryParams params) {
+    params.all()
+    return conceptRepository.query(params).getData().collect { it.getCode() } as Set
+  }
+
+  private static String baseCodeSystem() {
+    FhirMapper.toJson([
+        resourceType: "CodeSystem", id: BASE_ID, url: BASE_URL, name: "Kl94Base", title: "Kl94 Base",
+        status: "active", content: "complete", version: VERSION, hierarchyMeaning: "is-a",
+        concept: [[code: "SA_PARENT", display: "Parent",
+                   concept: [[code: "SA_CHILD", display: "Child"]]]]])
+  }
+}

--- a/termx-integtest/src/test/groovy/org/termx/terminology/mapset/MapSetPreviousVersionIT.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/mapset/MapSetPreviousVersionIT.groovy
@@ -1,0 +1,68 @@
+package org.termx.terminology.mapset
+
+import com.kodality.commons.model.LocalizedName
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import org.termx.TermxIntegTest
+import org.termx.core.auth.SessionInfo
+import org.termx.core.auth.SessionStore
+import org.termx.terminology.terminology.mapset.MapSetService
+import org.termx.terminology.terminology.mapset.version.MapSetVersionService
+import org.termx.ts.PublicationStatus
+import org.termx.ts.mapset.MapSet
+import org.termx.ts.mapset.MapSetVersion
+
+import java.time.LocalDate
+
+/**
+ * RED test for tehik ticket KL-98 — {@code MapSetVersionRepository.loadPreviousVersion} must return the prior
+ * version even when it shares a {@code release_date} with the current version.
+ *
+ * <p>The buggy base query excludes same-dated versions with a strict {@code release_date < current} predicate, so
+ * {@code loadPrevious("msprev", "2.0.0")} returns null when 1.0.0 and 2.0.0 share a release date. The fix relaxes
+ * the comparison to {@code <=}, excludes the current version by {@code version}, and orders by version desc.
+ */
+@MicronautTest(transactional = true)
+class MapSetPreviousVersionIT extends TermxIntegTest {
+  @Inject MapSetService mapSetService
+  @Inject MapSetVersionService versionService
+
+  void setup() {
+    SessionStore.setLocal(new SessionInfo().setPrivileges(["*.*.*"] as Set))
+  }
+
+  void cleanup() {
+    SessionStore.clearLocal()
+  }
+
+  def "loadPrevious resolves the prior version even when it shares a release date"() {
+    given: "a map set with two draft versions 1.0.0 and 2.0.0 sharing the same release date"
+    MapSet mapSet = new MapSet().setId("msprev")
+    mapSet.setUri("http://termx-test.local/MapSet/msprev")
+    mapSet.setName("msprev")
+    mapSet.setTitle(new LocalizedName().add("en", "Prev MapSet"))
+    mapSetService.save(mapSet)
+
+    LocalDate releaseDate = LocalDate.of(2024, 1, 1)
+    saveVersion("1.0.0", releaseDate)
+    saveVersion("2.0.0", releaseDate)
+
+    expect: "the previous version of 2.0.0 is 1.0.0"
+    versionService.loadPrevious("msprev", "2.0.0").map { it.version }.orElse(null) == "1.0.0"
+  }
+
+  private void saveVersion(String version, LocalDate releaseDate) {
+    MapSetVersion v = new MapSetVersion()
+    v.setMapSet("msprev")
+    v.setVersion(version)
+    v.setStatus(PublicationStatus.draft)
+    v.setReleaseDate(releaseDate)
+    // scope must serialize to a non-empty jsonb: core.jsonb_trunc collapses an all-null object to SQL NULL,
+    // which violates map_set_version.scope NOT NULL. Set a scalar field so the object survives truncation.
+    MapSetVersion.MapSetVersionScope scope = new MapSetVersion.MapSetVersionScope()
+    scope.setSourceType("code-system")
+    scope.setTargetType("code-system")
+    v.setScope(scope)
+    versionService.save(v)
+  }
+}


### PR DESCRIPTION
Migrates the Tier 1 set of small, general-purpose, low-risk fixes from the TEHIK `tehik-termx-server` fork that upstream never picked up. Each was ported test-first (a failing test written and confirmed red against `main`, then green after the fix).

## Changes (with TEHIK ticket ids)

| Feature | Ticket |
|---|---|
| `CodeSystem.getFirstVersion/getLastVersion` — deterministic tie-break by version string when versions share a release date | KL-96 |
| `BaseFhirMapper.fromFhirName` — keep FHIR `translation` extensions when the primary name is null | KL-118 |
| ValueSet / MapSet / ImplementationGuide — enforce the FHIR id regex `[A-Za-z0-9\-.]{1,64}` on save (`TE119` / new `IG105`); URL-decode the id on VS/MS delete | KL-104 |
| `SnomedController.findConceptDescriptions` — load descriptions from the requested branch instead of the default | commit `57d9010d` (no ticket id in fork) |
| `MapSetVersionRepository.loadPreviousVersion` — resolve the previous version when versions share a release date | KL-98 |
| `ConceptRepository` — resolve associations defined on the base concept when querying a supplement code system, via `base_entity_version_id` | KL-94 |

Notes:
- Id validation is **additive** — the existing `--` separator check is kept and the regex is added on top, so nothing regresses.
- Adds the Spock/bytebuddy/objenesis test dependency set to the `implementation-guide` module (its first tests).

## Testing

- **Gradle suite: 639 tests, 0 failures, 0 errors** (5 pre-existing skips), including new Spock unit tests and two Testcontainers integration tests (`MapSetPreviousVersionIT`, `SupplementAssociationIT`).
- **FHIR tx-ecosystem conformance: 554/600 (score 0.920)** — identical to the prior baseline, i.e. no conformance regression.