### PR TITLE
feat(edition-est): port TEHIK fork ICD10-EST dagger/asterisk postfix import

### DIFF
--- a/edition-est/src/main/java/org/termx/editionest/icd10est/utils/Icd10Est.java
+++ b/edition-est/src/main/java/org/termx/editionest/icd10est/utils/Icd10Est.java
@@ -41,6 +41,11 @@ public class Icd10Est {
     public List<Sub> getSub() {
       return null;
     }
+
+    @Override
+    public List<Sub> getPostfix() {
+      return null;
+    }
   }
 
   @Getter
@@ -65,6 +70,11 @@ public class Icd10Est {
 
     @JacksonXmlElementWrapper(useWrapping = false)
     private List<Sub> sub;
+
+    @Override
+    public List<Sub> getPostfix() {
+      return null;
+    }
   }
 
   @Getter
@@ -89,6 +99,11 @@ public class Icd10Est {
 
     @JacksonXmlElementWrapper(useWrapping = false)
     private List<Sub> sub;
+
+    @Override
+    public List<Sub> getPostfix() {
+      return sub;
+    }
   }
 
   @Getter
@@ -113,6 +128,11 @@ public class Icd10Est {
     public List<Sub> getChildren() {
       return sub == null ? null : List.copyOf(sub);
     }
+
+    @Override
+    public List<Sub> getPostfix() {
+      return null;
+    }
   }
 
   @Getter
@@ -135,6 +155,11 @@ public class Icd10Est {
 
     @Override
     public List<Node> getChildren() {
+      return null;
+    }
+
+    @Override
+    public List<Sub> getPostfix() {
       return null;
     }
 
@@ -183,6 +208,8 @@ public class Icd10Est {
     List<String> getNotice();
 
     List<? extends Node> getChildren();
+
+    List<Sub> getPostfix();
 
     List<Sub> getSub();
   }

--- a/edition-est/src/main/java/org/termx/editionest/icd10est/utils/Icd10EstMapper.java
+++ b/edition-est/src/main/java/org/termx/editionest/icd10est/utils/Icd10EstMapper.java
@@ -15,6 +15,7 @@ import org.termx.ts.codesystem.EntityPropertyKind;
 import org.termx.ts.codesystem.EntityPropertyType;
 import org.termx.ts.codesystem.EntityPropertyValue;
 import org.termx.editionest.icd10est.utils.Icd10Est.Node;
+import org.termx.editionest.icd10est.utils.Icd10Est.Sub;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import java.util.ArrayList;
@@ -59,18 +60,17 @@ public class Icd10EstMapper {
 
   private static List<CodeSystemImportRequestConcept> toConcepts(List<Icd10Est> diagnoses) {
     List<CodeSystemImportRequestConcept> concepts = new ArrayList<>();
-    diagnoses.forEach(d -> concepts.addAll(parseNodeChild(d.getChapter(), null)));
+    diagnoses.forEach(d -> concepts.addAll(parseNodeChild(d.getChapter(), null, null)));
     return concepts;
   }
 
-  private static List<CodeSystemImportRequestConcept> parseNodeChild(Node element, Node parent) {
+  private static List<CodeSystemImportRequestConcept> parseNodeChild(Node element, Node parent, List<Sub> postfixes) {
     List<CodeSystemImportRequestConcept> concepts = new ArrayList<>();
     concepts.add(Icd10EstMapper.toConcept(element, parent));
     if (element.getChildren() != null) {
-      element.getChildren().forEach(child -> concepts.addAll(parseNodeChild(child, element)));
-    }
-    if (element.getSub() != null) {
-      element.getSub().forEach(sub -> parseNodeChild(sub, element));
+      element.getChildren().forEach(child -> concepts.addAll(parseNodeChild(child, element, element.getPostfix())));
+    } else if (postfixes != null) {
+      postfixes.forEach(postfix -> concepts.add(Icd10EstMapper.toPostfixConcept(postfix, element)));
     }
     return concepts;
   }
@@ -81,6 +81,16 @@ public class Icd10EstMapper {
     concept.setCode(element.getCode());
     concept.setDesignations(mapDesignations(element));
     concept.setPropertyValues(mapPropertyValues(element));
+    concept.setAssociations(mapAssociations(parent));
+    return concept;
+  }
+
+  private static CodeSystemImportRequestConcept toPostfixConcept(Node element, Node parent) {
+    String[] prefix = element.getCode().split("\\*");
+
+    CodeSystemImportRequestConcept concept = new CodeSystemImportRequestConcept();
+    concept.setCode(parent.getCode() + prefix[prefix.length - 1]);
+    concept.setDesignations(mapDesignations(element));
     concept.setAssociations(mapAssociations(parent));
     return concept;
   }

--- a/edition-est/src/test/groovy/org/termx/Icd10EstPostfixMapperSpec.groovy
+++ b/edition-est/src/test/groovy/org/termx/Icd10EstPostfixMapperSpec.groovy
@@ -1,0 +1,54 @@
+package org.termx
+
+import com.kodality.commons.model.LocalizedName
+import org.termx.editionest.icd10est.utils.Icd10Est
+import org.termx.editionest.icd10est.utils.Icd10EstMapper
+import org.termx.ts.codesystem.CodeSystemImportConfiguration
+import spock.lang.Specification
+
+import java.time.LocalDate
+
+/**
+ * Migrated from tehik fork (ICD10-EST import fix, commits 234a750e / 58ea7d2c): a subsection's
+ * dagger/asterisk postfix &lt;sub&gt; codes are appended to each leaf item as child concepts
+ * (item code + the suffix after '*'), rather than being discarded.
+ *
+ * NOTE: this is a SYNTHETIC test. The shipped fixture `icd10-est.xml` contains no &lt;sub&gt;
+ * postfix elements, so this encodes the fork's algorithm rather than real Estonian source data.
+ * It should be re-grounded against a real ICD10-EST XML sample carrying dagger/asterisk codes
+ * before the exact code-composition rule (`split("*")`, `parent.code + suffix`) is fully trusted.
+ */
+class Icd10EstPostfixMapperSpec extends Specification {
+
+  def config = new CodeSystemImportConfiguration(
+      uri: 'https://pub.e-tervis.ee/classifications/RHK-10/8',
+      publisher: 'Ministry of Social Affairs of Estonia',
+      version: '8',
+      validFrom: LocalDate.of(2022, 1, 1),
+      codeSystem: 'icd-10-est',
+      codeSystemName: new LocalizedName(Map.of("et", "RHK-10")),
+      codeSystemDescription: new LocalizedName(Map.of("et", "RHK-10")))
+
+  private static Icd10Est.Obj obj(String est) {
+    new Icd10Est.Obj(hidden: 1, nameEst: est)
+  }
+
+  def "postfix subs on a subsection are appended to leaf item codes"() {
+    given: "a subsection carries a postfix Sub '*.1'; its leaf item 'A02' has no subs of its own"
+    def postfix = new Icd10Est.Sub(code: "*.1", object: [obj("Postfix name")])
+    def item = new Icd10Est.Item(code: "A02", object: [obj("Item name")])
+    def subsection = new Icd10Est.SubSection(code: "A00-A09", object: [obj("SubSection")], children: [item], sub: [postfix])
+    def section = new Icd10Est.Section(code: "A00-B99", object: [obj("Section")], children: [subsection])
+    def chapter = new Icd10Est.Chapter(code: "I", object: [obj("Chapter")], children: [section])
+    def icd = new Icd10Est(chapter: chapter)
+
+    when:
+    def concepts = Icd10EstMapper.toRequest(config, [icd]).concepts
+
+    then: "a postfix concept 'A02.1' (leaf item code + the suffix after '*') is produced"
+    def postfixConcept = concepts.find { it.code == "A02.1" }
+    postfixConcept != null
+    postfixConcept.designations*.name.contains("Postfix name")
+    postfixConcept.associations*.targetCode == ["A02"]
+  }
+}


### PR DESCRIPTION
Migrates the Estonia-only ICD10-EST postfix import fix from `tehik-termx-server` (fork commits `234a750e`, `58ea7d2c`). Ported test-first (red → green).

## Change
A subsection's dagger/asterisk postfix `<sub>` codes are appended to each **leaf item** as child concepts (`item.code + <suffix after '*'>`), rather than parsed-and-discarded as base did. Adds `Node.getPostfix()` (`SubSection` returns its `sub`; others null) and `Icd10EstMapper.toPostfixConcept()`.

## ⚠️ Validation caveat
The shipped `icd10-est.xml` fixture contains **no `<sub>` postfix elements**, so this is covered by a **synthetic** unit test that encodes the fork's algorithm, not real Estonian source data. **Before trusting in production, re-ground it against a real ICD10-EST XML sample** with dagger/asterisk codes to confirm the `split("*")` / `parent.code + suffix` composition and the assumption that subsection-level (not item-level) subs are the postfixes.

## Testing
- New synthetic spec `Icd10EstPostfixMapperSpec` (red on base → green after port).
- Existing `Icd10EstMapperTest` unaffected (no `<sub>` in the fixture).
- Full suite: **626 tests, 0 failures, 0 errors** (5 pre-existing skips).