### PR TITLE
fix(valueset): collapse duplicated designations/properties for supplement codes (TLA-4)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptService.java
@@ -284,9 +284,14 @@ public class ValueSetVersionConceptService {
           // version's designations. The expand never returns code system versions newer than the bound
           // one, so the most recent entity version present here is the bound (or the newest still valid
           // as of the bound) version. Collecting designations from every returned version leaked the
-          // other versions' designations. Issue #49.
-          List<CodeSystemEntityVersion> designationVersions = latestCodeSystemVersion(versions);
-          List<Designation> designations = designationVersions.stream()
+          // other versions' designations. Issue #49. A code may also carry several entity versions that
+          // all belong to that one bound version — a supplement re-imported (CSV) several times keeps
+          // every prior entity version as an active member of the same code system version — so scope
+          // down to the single current entity version, otherwise every designation and property value
+          // was emitted once per entity version (shown N times, joined by '#', in the XLSX export and
+          // FHIR expansion). Issue TLA-4.
+          List<CodeSystemEntityVersion> currentVersions = currentEntityVersion(versions);
+          List<Designation> designations = currentVersions.stream()
               .filter(v -> CollectionUtils.isNotEmpty(v.getDesignations()))
               .flatMap(v -> v.getDesignations().stream())
               .filter(d -> !PublicationStatus.retired.equals(d.getStatus())).toList();
@@ -303,10 +308,10 @@ public class ValueSetVersionConceptService {
           c.setActive(calculatedActive(versions));
           c.setNotSelectable(calculatedNotSelectable(versions));
           c.setStatus(versions.stream().findFirst().map(CodeSystemEntityVersion::getStatus).orElse(PublicationStatus.active));
-          c.setAssociations(versions.stream().filter(v -> CollectionUtils.isNotEmpty(v.getAssociations()))
+          c.setAssociations(currentVersions.stream().filter(v -> CollectionUtils.isNotEmpty(v.getAssociations()))
               .flatMap(v -> v.getAssociations().stream()).toList());
           // Optimization of simple EntityPropertyValue (versions excluded)
-          c.setPropertyValues(versions.stream()
+          c.setPropertyValues(currentVersions.stream()
                     .filter(v -> CollectionUtils.isNotEmpty(v.getPropertyValues()))
                     .flatMap(v -> v.getPropertyValues().stream())
                     .filter(p -> properties.containsKey(p.getEntityProperty()))
@@ -363,6 +368,25 @@ public class ValueSetVersionConceptService {
         .map(ValueSetVersionConceptService::maxReleaseDate)
         .map(top -> versions.stream().filter(v -> top.equals(maxReleaseDate(v))).toList())
         .orElse(versions);
+  }
+
+  /**
+   * The single current entity version for a code, once scoped to its latest bound code system version
+   * (see {@link #latestCodeSystemVersion}). When several entity versions of the same code all belong to
+   * that one version — e.g. a supplement re-imported several times keeps every prior entity version as an
+   * active member of the same code system version — pick the newest (by created timestamp, then id) so a
+   * code's designations, properties and associations are not multiplied across those versions. See TLA-4.
+   */
+  static List<CodeSystemEntityVersion> currentEntityVersion(List<CodeSystemEntityVersion> versions) {
+    List<CodeSystemEntityVersion> latest = latestCodeSystemVersion(versions);
+    if (latest.size() <= 1) {
+      return latest;
+    }
+    return latest.stream()
+        .max(Comparator
+            .comparing((CodeSystemEntityVersion v) -> v.getCreated() == null ? OffsetDateTime.MIN : v.getCreated())
+            .thenComparing(v -> v.getId() == null ? Long.MIN_VALUE : v.getId()))
+        .map(List::of).orElse(latest);
   }
 
   private static java.time.LocalDate maxReleaseDate(CodeSystemEntityVersion version) {

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/expansion/ValueSetVersionConceptServiceTest.groovy
@@ -12,9 +12,13 @@ import org.termx.ts.codesystem.CodeSystemEntityVersion
 import org.termx.ts.codesystem.CodeSystemEntityVersionQueryParams
 import org.termx.ts.codesystem.CodeSystemVersionReference
 import org.termx.ts.codesystem.Designation
+import org.termx.ts.codesystem.EntityProperty
+import org.termx.ts.codesystem.EntityPropertyType
+import org.termx.ts.codesystem.EntityPropertyValue
 import org.termx.ts.valueset.ValueSetSnapshot
 
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import org.termx.ts.valueset.ValueSetVersion
 import org.termx.ts.valueset.ValueSetVersionConcept
 import org.termx.ts.valueset.ValueSetVersionRuleSet
@@ -199,6 +203,47 @@ class ValueSetVersionConceptServiceTest extends Specification {
     c.concept.codeSystemVersions as Set == ["2.80", "2.81"] as Set
   }
 
+  def "(TLA-4) decorate collapses designations and properties when a code has several entity versions in one bound version"() {
+    given: "a supplement code carrying two entity versions, both active members of the same (latest) code system version"
+    entityPropertyService.query(_) >> new QueryResult([new EntityProperty().setName("effectiveDate")])
+    def csVer = csVersionRef("20.0.0", LocalDate.of(2025, 5, 30))
+    def older = new CodeSystemEntityVersion().setId(10L).setCodeSystem("supp").setCode("4221000146107").setStatus("active")
+        .setCreated(OffsetDateTime.parse("2025-05-30T00:00:00Z"))
+        .setVersions([csVer])
+        .setDesignations([designation("description", "en", "Cryptococcus magnus (organism)")])
+        .setPropertyValues([propertyValue("effectiveDate", "2017-11-23", 10L)])
+    def newer = new CodeSystemEntityVersion().setId(11L).setCodeSystem("supp").setCode("4221000146107").setStatus("active")
+        .setCreated(OffsetDateTime.parse("2026-05-29T00:00:00Z"))
+        .setVersions([csVer])
+        .setDesignations([designation("description", "en", "Cryptococcus magnus (organism)")])
+        .setPropertyValues([propertyValue("effectiveDate", "2017-11-23", 11L)])
+    codeSystemEntityVersionService.query(_) >> new QueryResult([older, newer])
+
+    and: "the expand returned both entity versions for the same code"
+    def concepts = [suppConcept("4221000146107", 10L), suppConcept("4221000146107", 11L)]
+
+    when:
+    def result = newService().decorate(concepts, suppVersion(), "en")
+
+    then: "the code appears once and neither its designation nor its property value is multiplied"
+    result.size() == 1
+    def c = result.first()
+    c.additionalDesignations.findAll { it.designationType == "description" && it.language == "en" }.size() == 1
+    c.propertyValues.findAll { it.entityProperty == "effectiveDate" }.size() == 1
+  }
+
+  def "(TLA-4) currentEntityVersion keeps the newest entity version sharing the latest code system version"() {
+    given: "two entity versions of the same code, both bound to the same code system version"
+    def csVer = csVersionRef("20.0.0", LocalDate.of(2025, 5, 30))
+    def older = new CodeSystemEntityVersion().setId(10L).setCreated(OffsetDateTime.parse("2025-05-30T00:00:00Z")).setVersions([csVer])
+    def newer = new CodeSystemEntityVersion().setId(11L).setCreated(OffsetDateTime.parse("2026-05-29T00:00:00Z")).setVersions([csVer])
+
+    expect: "only the newest survives (by created, then id), and empty/single inputs pass through"
+    ValueSetVersionConceptService.currentEntityVersion([older, newer])*.id == [11L]
+    ValueSetVersionConceptService.currentEntityVersion([newer]) == [newer]
+    ValueSetVersionConceptService.currentEntityVersion([]) == []
+  }
+
   def "(#49) latestCodeSystemVersion keeps a single version and treats an unreleased version as newest"() {
     expect:
     ValueSetVersionConceptService.latestCodeSystemVersion([]) == []
@@ -235,6 +280,33 @@ class ValueSetVersionConceptServiceTest extends Specification {
             .setCodeSystem("loinc")
             .setCodeSystemUri("http://loinc.org"))
         .setActive(true)
+  }
+
+  private static ValueSetVersionConcept suppConcept(String code, Long conceptVersionId) {
+    return new ValueSetVersionConcept()
+        .setConcept(new ValueSetVersionConcept.ValueSetVersionConceptValue()
+            .setCode(code)
+            .setConceptVersionId(conceptVersionId)
+            .setCodeSystem("supp")
+            .setCodeSystemUri("http://example.org/CodeSystem/supp"))
+        .setActive(true)
+  }
+
+  private static ValueSetVersion suppVersion() {
+    return new ValueSetVersion()
+        .setId(1L)
+        .setStatus("draft")
+        .setRuleSet(new ValueSetVersionRuleSet()
+            .setInactive(false)
+            .setRules([new ValueSetVersionRule().setType("include").setCodeSystem("supp")]))
+  }
+
+  private static EntityPropertyValue propertyValue(String name, Object value, Long codeSystemEntityVersionId) {
+    return new EntityPropertyValue()
+        .setEntityProperty(name)
+        .setValue(value)
+        .setEntityPropertyType(EntityPropertyType.string)
+        .setCodeSystemEntityVersionId(codeSystemEntityVersionId)
   }
 
   private static ValueSetVersion loincVersion() {


### PR DESCRIPTION
## Problem

A value set expansion member could show its **designations and property values multiplied** — the same value repeated N times, joined by `#` — in the **XLSX export** and the **FHIR definition expansion**. Reported against SNOMED supplement-based value sets (Jira TLA-4), e.g.:

- `effectiveDate` → `2016-12-19#2016-12-19#2016-12-19`, property → `4- vähk#4- vähk#4- vähk`
- `description#en` → `Cryptococcus magnus (organism)#…#…` (once per concept version)

## Root cause

The bug reproduces for codes that carry **several entity versions all belonging to the one bound code system version**. A SNOMED supplement re-imported via CSV several times keeps every prior entity version as an active member of the same version (and the English display is pulled from Snowstorm at import, so it too rides on every version).

`ValueSetVersionConceptService.decorate()` then:
- collected designations from `latestCodeSystemVersion(versions)` — which only scopes across *different* CS versions (issue #49), so all versions sharing the latest CS version survived, and
- collected property values from **all** `versions`,

emitting each designation/property once per entity version. The exact-concepts (`Täpsed mõisted`) expand path has no per-code entity-version dedup, unlike the filter path.

> Note: the *cross-version* carry-forward the reporter also describes ("all versions up to that CS version") was a separate cause already removed by #370 (strict per-version). The reporter is on the pre-#370 May build. This PR fixes the remaining *intra-version* multiplication, which persists on `main`.

## Fix

Introduce `currentEntityVersion(versions)`: after `latestCodeSystemVersion` scopes to the newest CS version, collapse to the single newest entity version (by `created`, then `id`). Designations, property values, and associations all read from that one version. Both the stored (`fn01`) and inline (`fn37`) expansion engines funnel through `decorate()`, so this covers XLSX export, the stored FHIR expansion, and inline preview/`$expand`.

Normal single-version codes are unaffected (`size() <= 1` passes through unchanged).

## Tests

- `(TLA-4) decorate collapses designations and properties when a code has several entity versions in one bound version` — reproduction; verified it **fails without the fix**.
- `(TLA-4) currentEntityVersion keeps the newest entity version sharing the latest code system version`.

All 91 valueset tests pass; the existing `#49` scoping tests are unchanged.