### PR TITLE
Fix idle-in-transaction timeout: parse + validation both outside the write transaction

### DIFF
--- a/docs/features/codesystem-import.md
+++ b/docs/features/codesystem-import.md
@@ -21,6 +21,26 @@ FHIR resource) to persisted concepts and **entity versions**, the merge vs. repl
 4. **Dry run** — "validate data only" routes to `CodeSystemFileImportDryRunService`: it computes the
    diff against the current content and persists nothing.
 
+### 1.1 Transaction boundaries
+
+The import deliberately keeps its long, non-DB and read-only work **outside** the write transaction, so a
+database connection is never held idle across it (PostgreSQL `idle_in_transaction_session_timeout` would
+otherwise terminate large imports — 7k+ rows — mid-commit):
+
+- **Parse** (`CodeSystemFileImportProcessor.process`, CPU-bound) — no transaction. `process()` is **not**
+  `@Transactional`.
+- **Read / validate / resolve links** (`save()`: load existing CS + version, map, resolve coding links via
+  `ValueSetVersionConceptService.expand` / `ConceptService.query`, `validateConcepts`) — no ambient
+  transaction. These are the same read services the GET endpoints call without a transaction; the reads
+  self-manage (`expand` is `@Transactional`) or run in autocommit.
+- **Write** — a single short transaction owned by `CodeSystemImportService.importCodeSystem`
+  (`@Transactional`); the dry-run compare runs in its own `REQUIRES_NEW` transaction
+  (`CodeSystemFileImportDryRunService`).
+
+So validation reads and the write no longer share one snapshot — acceptable because imports are not run
+concurrently against the same code system, and the write itself is still fully atomic within
+`importCodeSystem`.
+
 ## 2. Modes — `CodeSystemImportAction`
 
 | Flag | UI | Effect |

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
@@ -56,7 +56,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.transaction.annotation.Transactional;
 
 import static org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportMapper.CONCEPT_CODE;
 import static org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportMapper.toAssociationTypes;
@@ -111,18 +110,23 @@ public class CodeSystemFileImportService {
         result.getEntities().size(), result.getProperties().size());
 
     log.debug("IMPORT SERVICE DEBUG: Saving import result...");
-    CodeSystemFileImportResponse response = saveInTransaction(request, result);
+    CodeSystemFileImportResponse response = save(request, result);
     log.debug("IMPORT SERVICE DEBUG: Import complete - Errors: {}", response.getErrors().size());
     log.debug("=== IMPORT SERVICE DEBUG: process END ===");
     return response;
   }
 
-  @Transactional
-  protected CodeSystemFileImportResponse saveInTransaction(CodeSystemFileImportRequest request, CodeSystemFileImportResult result) {
-    return save(request, result);
-  }
-
-
+  /**
+   * Runs the read/validation phase (load existing CS + version, map, resolve coding links, validate) with
+   * <b>no ambient transaction</b>, then persists.
+   * <p>
+   * Validation is read-only (queries + in-memory mutation); its reads self-manage their own transactions
+   * ({@code ValueSetVersionConceptService.expand} is {@code @Transactional}) or run in autocommit. The actual
+   * write is confined to a short transaction owned by {@code CodeSystemImportService.importCodeSystem}
+   * ({@code @Transactional}); the dry-run path runs in {@code REQUIRES_NEW}. Keeping the read/validation work
+   * outside the write transaction avoids holding a connection idle through it (idle-in-transaction timeout on
+   * large files) and minimises the write-lock window.
+   */
   public CodeSystemFileImportResponse save(CodeSystemFileImportRequest request, CodeSystemFileImportResult result) {
     String versionNumber = request.getVersion() != null ? request.getVersion().getNumber() : null;
     log.debug("=== IMPORT SERVICE DEBUG: save START ===");

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
@@ -87,7 +87,6 @@ public class CodeSystemFileImportService {
     return process(request, file);
   }
 
-  @Transactional
   public CodeSystemFileImportResponse process(CodeSystemFileImportRequest request, byte[] file) {
     String versionNumber = request.getVersion() != null ? request.getVersion().getNumber() : null;
     log.debug("=== IMPORT SERVICE DEBUG: process START ===");

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportLargeFileTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportLargeFileTest.groovy
@@ -81,14 +81,14 @@ class CodeSystemFileImportLargeFileTest extends Specification {
     result.properties.size() > 0
     parsingTime > 0 // File parsing took some time
 
-    when: "saving the import (which starts the transaction)"
+    when: "saving the import (validation runs outside any write transaction; the write is confined to importCodeSystem)"
     startTime = System.currentTimeMillis()
     codeSystemService.load("large-cs", true) >> Optional.empty()
     codeSystemVersionService.query(_) >> QueryResult.empty()
     codeSystemValidationService.validateConcepts(_, _) >> []
     codeSystemImportService.importCodeSystem(_, _, _) >> null
 
-    def response = service.saveInTransaction(request, result)
+    def response = service.save(request, result)
     long saveTime = System.currentTimeMillis() - startTime
 
     then: "save completes without timeout (should finish in < 30 seconds, default idle-in-transaction timeout)"
@@ -123,8 +123,8 @@ class CodeSystemFileImportLargeFileTest extends Specification {
     codeSystemImportService.importCodeSystem(_, _, _) >> null
 
     // process() method should:
-    // 1. Call CodeSystemFileImportProcessor.process() WITHOUT a transaction
-    // 2. Then call saveInTransaction() which STARTS a new transaction
+    // 1. Call CodeSystemFileImportProcessor.process() WITHOUT a transaction (parse phase)
+    // 2. Run read/validation with no ambient transaction, then persist via importCodeSystem's own short transaction
     def response = service.process(request, csv.getBytes("UTF-8"))
 
     then: "the import completes successfully"


### PR DESCRIPTION
Fixes the recurring large-import failure:

```
org.postgresql.util.PSQLException: FATAL: terminating connection due to idle-in-transaction timeout
```

Reported again on the LMB deployment with `nomenclature-1.0.10.csv` (~7.4k rows), but the file is byte-identical on `termx-server` `main`, so this is **not** fork-specific.

## Two commits

### 1. Actually move file parsing outside the transaction (#387 follow-up)
#387's message claimed *"Remove @Transactional from process() method"*, but the diff never touched it — `git blame` still attributes the `@Transactional` on `process(request, file)` to `5081738d`. So the CPU-bound CSV/TSV/XLSX parse still ran inside the transaction, holding a connection idle until the timeout. This commit removes it, completing #387's intent.

### 2. Run validation / link-resolution outside the write transaction (short-transaction import)
Even with the parse moved out, `save()` was wrapped in `saveInTransaction()`, so the read-heavy validation phase — load existing CS + version, map, resolve external coding links (`ValueSetVersionConceptService.expand` / `ConceptService.query`), `validateConcepts` — still ran inside the write transaction. The Java-side work between those read queries counts as idle-in-transaction time and can still approach the timeout on large files.

Drop the wrapper and call `save()` directly. Resulting boundaries (now documented in `docs/features/codesystem-import.md` §1.1):

| Phase | Transaction |
|-------|-------------|
| Parse (`CodeSystemFileImportProcessor`) | none |
| Read / validate / resolve links | none — reads self-manage (`expand` is `@Transactional`) or run in autocommit |
| Write (`CodeSystemImportService.importCodeSystem`) | its own single short `@Transactional` |
| Dry-run compare | its own `REQUIRES_NEW` |

Validation reads and the write no longer share one snapshot — fine because imports aren't run concurrently on the same code system, and `importCodeSystem` is still fully atomic.

## Verification
- `:terminology:compileJava` + importer tests pass.
- **#1** bytecode check of the generated `$Intercepted` proxy: `saveInTransaction` was intercepted, `process` no longer is (before the fix it was — the customer stacktrace showed `$Intercepted.process`).
- **#2** the "reads outside a transaction" path is already production-exercised: `CodeSystemController` GET endpoints call the same `codeSystemService.load(...)` / `.query(...)` with no ambient transaction (no class- or method-level `@Transactional`).

## Follow-up
- `lmb-terminology-server` carries the identical file and needs both commits via the usual rebase-sync once this lands.
- The #388 test is mock-based (no Micronaut AOP, no DB) and can't guard the transaction boundary — worth upgrading to a Micronaut-context integration test.