### PR TITLE
Import: fix NPE + friendly error when the identifier column is empty on some rows

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/ApiError.java
+++ b/terminology/src/main/java/org/termx/terminology/ApiError.java
@@ -97,6 +97,7 @@ public enum ApiError {
   TE738("TE738", "File contains duplicate concept code rows."),
   TE739("TE739", "The file is not a valid Excel (.xlsx) workbook. If the file is CSV or TSV, choose that import type. If it is a spreadsheet, save or export it as .xlsx (Office Open XML), not .xls."),
   TE740("TE740", "The Excel workbook must contain a worksheet named \"concepts\"."),
+  TE741("TE741", "The concept identifier (\"concept-code\"/\"hierarchical-concept\") is empty on row(s): {{ranges}}. Map the identifier to a column that has a value in every imported row."),
   TE801("TE801", "Association type is required, can't be deleted."),
   TE802("TE802", "Association type is used in code system '{{codeSystem}}' association, can't be deleted."),
   TE803("TE803", "Association type is used in map set '{{mapSet}}' association, can't be deleted."),

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 
@@ -90,7 +91,7 @@ public class CodeSystemFileImportProcessor {
     log.debug("IMPORT DEBUG: Headers: {}", headers);
 
     log.debug("IMPORT DEBUG: Processing {} rows...", rows.size());
-    var entities = rows.stream().map(r -> {
+    var parsedEntities = rows.stream().map(r -> {
       int rowIndex = rows.indexOf(r);
       log.debug("IMPORT DEBUG: Processing row {} of {}", rowIndex + 1, rows.size());
       
@@ -233,12 +234,27 @@ public class CodeSystemFileImportProcessor {
       String conceptCode = conceptCodeOf(entity, null);
       log.debug("IMPORT DEBUG: Row {} - Entity created with concept code: '{}'", rowIndex + 1, conceptCode);
       return entity;
-    }).filter(CollectionUtils::isNotEmpty)
+    }).toList();
+
+    // Rows that carry data but no identifier value (concept-code / hierarchical-concept). This happens
+    // when the identifier is mapped to a column that is empty on some rows. Report the offending rows
+    // clearly (TE741) instead of the generic config-level TE722.
+    List<Integer> missingIdentifierRows = IntStream.range(0, parsedEntities.size())
+        .filter(i -> CollectionUtils.isNotEmpty(parsedEntities.get(i)) && conceptCodeOf(parsedEntities.get(i), null) == null)
+        .mapToObj(i -> i + 2) // file row number: header is row 1, first data row is row 2
+        .toList();
+    if (!missingIdentifierRows.isEmpty()) {
+      log.error("IMPORT DEBUG: {} row(s) without a concept identifier", missingIdentifierRows.size());
+      throw ApiError.TE741.toApiException(Map.of("ranges", formatRanges(missingIdentifierRows)));
+    }
+
+    var entities = parsedEntities.stream().filter(CollectionUtils::isNotEmpty)
         .collect(Collectors.groupingBy(r -> conceptCodeOf(r, RANDOM_UUID)));
 
     log.debug("IMPORT DEBUG: Grouped entities by concept code, total groups: {}", entities.size());
-    
+
     if (entities.containsKey(RANDOM_UUID)) {
+      // Defensive: missing identifiers are already reported as TE741 above.
       log.error("IMPORT DEBUG: Found entities without concept code identifier");
       throw ApiError.TE722.toApiException();
     }
@@ -368,6 +384,24 @@ public class CodeSystemFileImportProcessor {
       return missingValue;
     }
     return values.stream().findFirst().map(v -> (String) v.getValue()).orElse(missingValue);
+  }
+
+  /** Collapse row numbers into a compact, human-readable list of ranges, e.g. "3, 5-9, 42" (capped). */
+  private static String formatRanges(List<Integer> rowNumbers) {
+    List<Integer> sorted = rowNumbers.stream().sorted().distinct().toList();
+    List<String> parts = new ArrayList<>();
+    int start = 0;
+    for (int i = 0; i < sorted.size(); i++) {
+      if (i == sorted.size() - 1 || sorted.get(i + 1) != sorted.get(i) + 1) {
+        int from = sorted.get(start);
+        int to = sorted.get(i);
+        parts.add(from == to ? String.valueOf(from) : from + "-" + to);
+        start = i + 1;
+      }
+    }
+    int cap = 30;
+    String joined = parts.stream().limit(cap).collect(Collectors.joining(", "));
+    return parts.size() > cap ? joined + ", … (" + sorted.size() + " rows total)" : joined;
   }
 
   public static Date transformDate(String date, String format) {

--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
@@ -230,13 +230,11 @@ public class CodeSystemFileImportProcessor {
         entity.put("conceptOrder", List.of(new FileProcessingEntityPropertyValue().setValue(order).setPropertyName("conceptOrder")));
       }
       
-      String conceptCode = entity.getOrDefault(IDENTIFIER_PROPERTY, entity.get(HIERARCHICAL_CONCEPT)).stream()
-          .findFirst().map(v -> (String) v.getValue()).orElse(null);
+      String conceptCode = conceptCodeOf(entity, null);
       log.debug("IMPORT DEBUG: Row {} - Entity created with concept code: '{}'", rowIndex + 1, conceptCode);
       return entity;
     }).filter(CollectionUtils::isNotEmpty)
-        .collect(Collectors.groupingBy(r -> r.getOrDefault(IDENTIFIER_PROPERTY, r.get(HIERARCHICAL_CONCEPT)).stream()
-            .findFirst().map(v -> (String) v.getValue()).orElse(RANDOM_UUID)));
+        .collect(Collectors.groupingBy(r -> conceptCodeOf(r, RANDOM_UUID)));
 
     log.debug("IMPORT DEBUG: Grouped entities by concept code, total groups: {}", entities.size());
     
@@ -356,6 +354,20 @@ public class CodeSystemFileImportProcessor {
       }
     };
     return result;
+  }
+
+  /**
+   * The concept code of a parsed row: the first {@code concept-code} value, else the first
+   * {@code hierarchical-concept} value. A row that carries neither (e.g. an empty identifier cell)
+   * yields {@code missingValue} — for grouping that is {@link #RANDOM_UUID}, which the caller turns
+   * into a clear TE722 "missing identifier" error instead of a NullPointerException.
+   */
+  private static String conceptCodeOf(Map<String, List<FileProcessingEntityPropertyValue>> entity, String missingValue) {
+    List<FileProcessingEntityPropertyValue> values = entity.getOrDefault(IDENTIFIER_PROPERTY, entity.get(HIERARCHICAL_CONCEPT));
+    if (values == null) {
+      return missingValue;
+    }
+    return values.stream().findFirst().map(v -> (String) v.getValue()).orElse(missingValue);
   }
 
   public static Date transformDate(String date, String format) {

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportProcessorTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportProcessorTest.groovy
@@ -566,19 +566,20 @@ a1,A1"""
   }
 
   /**
-   * BUSINESS: A row that has data but no mapped identifier value must fail with a clear
-   * "missing identifier" error (TE722), NOT a NullPointerException.
+   * BUSINESS: A row that has data but no mapped identifier value must fail with a clear,
+   * user-friendly error that names the offending row(s) — NOT a NullPointerException, and not the
+   * generic config-level TE722 ("At least 'concept-code' or 'hierarchical-concept' should be
+   * specified"), which is misleading when the identifier IS mapped but empty on some rows.
    *
    * Reproduces the crash at CodeSystemFileImportProcessor (getOrDefault(IDENTIFIER_PROPERTY,
-   * get(HIERARCHICAL_CONCEPT)).stream()): when a row has neither a concept-code nor a
-   * hierarchical-concept value, getOrDefault returns null and .stream() throws NPE before the
-   * intended TE722 (RANDOM_UUID grouping) validation is reached.
+   * get(HIERARCHICAL_CONCEPT)).stream()): a row with neither a concept-code nor a
+   * hierarchical-concept value made getOrDefault return null and .stream() threw NPE.
    *
-   * nomenclature-1.0.10.csv triggers this whenever concept-code is mapped to a column that is
-   * empty on some rows (e.g. the LOINC code column, empty for ~1858 rows).
+   * nomenclature-1.0.10.csv triggers this: concept-code is mapped to the LOINC column, empty on
+   * ~1858 rows (univocity parses empty cells as null).
    */
-  def "should raise a clear missing-identifier error (not NPE) when a row has no identifier value"() {
-    given: "a CSV where one row has an empty concept-code cell but other data"
+  def "should report offending rows (TE741, not NPE) when a row has no identifier value"() {
+    given: "a CSV where the second data row (file row 3) has an empty concept-code cell but other data"
     String csvContent = """code,display#en
 a1,A1
 ,B2"""
@@ -596,10 +597,11 @@ a1,A1
     when: "processing the import"
     CodeSystemFileImportProcessor.process(request, file)
 
-    then: "it fails gracefully with the missing-identifier error (TE722), not a NullPointerException"
+    then: "it fails gracefully naming the offending row(s), not a NullPointerException"
     def exception = thrown(Exception)
     !(exception instanceof NullPointerException)
-    exception.message.contains("TE722")
+    exception.message.contains("TE741")
+    exception.message.contains("3") // the file row number of the identifier-less row
   }
 
   /**

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportProcessorTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportProcessorTest.groovy
@@ -566,6 +566,43 @@ a1,A1"""
   }
 
   /**
+   * BUSINESS: A row that has data but no mapped identifier value must fail with a clear
+   * "missing identifier" error (TE722), NOT a NullPointerException.
+   *
+   * Reproduces the crash at CodeSystemFileImportProcessor (getOrDefault(IDENTIFIER_PROPERTY,
+   * get(HIERARCHICAL_CONCEPT)).stream()): when a row has neither a concept-code nor a
+   * hierarchical-concept value, getOrDefault returns null and .stream() throws NPE before the
+   * intended TE722 (RANDOM_UUID grouping) validation is reached.
+   *
+   * nomenclature-1.0.10.csv triggers this whenever concept-code is mapped to a column that is
+   * empty on some rows (e.g. the LOINC code column, empty for ~1858 rows).
+   */
+  def "should raise a clear missing-identifier error (not NPE) when a row has no identifier value"() {
+    given: "a CSV where one row has an empty concept-code cell but other data"
+    String csvContent = """code,display#en
+a1,A1
+,B2"""
+
+    byte[] file = csvContent.getBytes("UTF-8")
+
+    CodeSystemFileImportRequest request = new CodeSystemFileImportRequest(
+      type: "csv",
+      properties: [
+        new FileProcessingProperty(columnName: "code", propertyName: "concept-code", propertyType: "string", preferred: true),
+        new FileProcessingProperty(columnName: "display#en", propertyName: "display", propertyType: "designation", language: "en")
+      ]
+    )
+
+    when: "processing the import"
+    CodeSystemFileImportProcessor.process(request, file)
+
+    then: "it fails gracefully with the missing-identifier error (TE722), not a NullPointerException"
+    def exception = thrown(Exception)
+    !(exception instanceof NullPointerException)
+    exception.message.contains("TE722")
+  }
+
+  /**
    * BUSINESS: Test auto concept order feature
    * 
    * Validates that:


### PR DESCRIPTION
## Symptom
Importing a CSV (e.g. `nomenclature-1.0.10.csv`) crashed with:

```
java.lang.NullPointerException: Cannot invoke "java.util.List.stream()" because the
return value of "java.util.Map.getOrDefault(Object, Object)" is null
    at ...CodeSystemFileImportProcessor.lambda$process$9(CodeSystemFileImportProcessor.java:233)
```

Root cause: the user maps `concept-code` → the **Kodas LOINC** column, which is empty on ~1858 rows. `entity.getOrDefault(IDENTIFIER_PROPERTY, entity.get(HIERARCHICAL_CONCEPT))` returns `null` for such rows and `.stream()` NPEs (univocity parses empty cells as `null`).

## Changes
1. **No crash** — null-safe `conceptCodeOf(entity, missingValue)` helper used by both the per-row log and the `groupingBy` classifier.
2. **User-friendly error** — instead of the generic config-level `TE722` ("At least 'concept-code' or 'hierarchical-concept' should be specified" — misleading when the identifier *is* mapped but empty on some rows), collect the offending file row numbers and raise a new **TE741**:

   > The concept identifier ("concept-code"/"hierarchical-concept") is empty on row(s): 3, 5-9, 42. Map the identifier to a column that has a value in every imported row.

   Row numbers are collapsed into compact ranges (mirroring `TE713`) and capped for very large counts (`…, … (N rows total)`).

## Practical fix for the reported import
Map **concept-code → `Kodas`** (never empty) instead of `Kodas LOINC` (empty for those ~1858 rows). The error now says exactly which rows are the problem.

## Tests (TDD)
`CodeSystemFileImportProcessorTest` case importing a CSV with an identifier-less row:
- first **red** reproducing the exact NPE stacktrace (line 233),
- then **red** again asserting the friendly `TE741` (still `TE722` at that point),
- then **green**: asserts `TE741`, names the offending row, and explicitly *not* a `NullPointerException`.

Full import suite passes.