### PR TITLE
Fix ClassCastException importing a non-designation property that has a language

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/utils/CodeSystemFileImportProcessor.java
@@ -300,7 +300,11 @@ public class CodeSystemFileImportProcessor {
       ep.setPropertyType(DESIGNATION_PROPERTY_TYPE.equals(prop.getPropertyType()) ? EntityPropertyType.string : prop.getPropertyType());
       ep.setPropertyTypeFormat(prop.getPropertyTypeFormat());
       ep.setPropertyCodeSystem(prop.getPropertyCodeSystem());
-      ep.setLang(prop.getLanguage());
+      // Language belongs to a designation. Only designation-typed columns carry it; a non-designation
+      // property (e.g. a dateTime column that happens to have a language configured) must NOT get a
+      // language, otherwise the mapper misclassifies it as a designation and casts its value (a Date,
+      // Integer, ...) to String — ClassCastException.
+      ep.setLang(DESIGNATION_PROPERTY_TYPE.equals(prop.getPropertyType()) ? prop.getLanguage() : null);
       ep.setValue(transformedValue);
       return ep;
     }).toList();

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportMapperTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportMapperTest.groovy
@@ -94,6 +94,45 @@ b1,B1"""
   }
 
   /**
+   * BUSINESS: A non-designation property that has a language configured (e.g. a dateTime column with a
+   * language, like "Modifikavimo data" in the LT nomenclature) must be imported as a PROPERTY value,
+   * not misclassified as a designation.
+   *
+   * Regression for:
+   *   java.lang.ClassCastException: class java.util.Date cannot be cast to class java.lang.String
+   *   at CodeSystemFileImportMapper.toConceptVersionDesignations
+   * The processor set a language on every property, so a dateTime value (java.util.Date) that carried
+   * a language was routed into the designation path and cast to String.
+   */
+  def "should import a dateTime property with a language as a property value, not a designation"() {
+    given: "a CSV with a concept code, a display designation, and a dateTime column carrying a language"
+    String csvContent = """code,Nimetus,modified
+a1,A1,2024-07-19"""
+
+    byte[] file = csvContent.getBytes("UTF-8")
+
+    CodeSystemFileImportRequest request = new CodeSystemFileImportRequest(
+      type: "csv",
+      codeSystem: new FileProcessingCodeSystem(id: "test-cs", name: "Test CS"),
+      version: new FileProcessingCodeSystemVersion(number: "1.0.0", language: "lt"),
+      properties: [
+        new FileProcessingProperty(columnName: "code", propertyName: "concept-code", propertyType: "string", preferred: true),
+        new FileProcessingProperty(columnName: "Nimetus", propertyName: "display", propertyType: "designation", language: "lt"),
+        new FileProcessingProperty(columnName: "modified", propertyName: "modified", propertyType: "dateTime", propertyTypeFormat: "yyyy-MM-dd", language: "lt")
+      ]
+    )
+
+    when: "processing and mapping the import"
+    CodeSystemFileImportResult result = CodeSystemFileImportProcessor.process(request, file)
+    CodeSystem codeSystem = CodeSystemFileImportMapper.toCodeSystem(request.codeSystem, request.version, result, null, null)
+
+    then: "the date is imported as a property value and only the display remains a designation (no ClassCastException)"
+    def version = codeSystem.concepts.find { it.code == "a1" }.versions[0]
+    version.designations*.designationType == ["display"]
+    version.propertyValues.find { it.entityProperty == "modified" } != null
+  }
+
+  /**
    * BUSINESS: Test concept mapping with parent hierarchy association
    * 
    * Inspired by: immuniseerimise-korvalnahud (Vanem_kood=parent)


### PR DESCRIPTION
## Symptom
After mapping `concept-code` → `Kodas`, the nomenclature import failed with:

```
java.lang.ClassCastException: class java.util.Date cannot be cast to class java.lang.String
    at ...CodeSystemFileImportMapper.lambda$toConceptVersionDesignations$3(CodeSystemFileImportMapper.java:231)
    ...
    at ...CodeSystemFileImportService.save(CodeSystemFileImportService.java:151)
```

## Cause
`CodeSystemFileImportProcessor.mapPropValue` set a language on **every** property value (`ep.setLang(prop.getLanguage())`). The mapper classifies designation vs property purely by *"does any value have a language"* (`toConceptVersionDesignations` = has-language, `toConceptVersionPropertyValues` = no-language). So a non-designation column that carries a language — e.g. a `dateTime` column like **"Modifikavimo data"**, whose value is a `java.util.Date` — was routed into the designation path and cast to `String`. (The same would break for `integer`/`decimal`/`bool`/`coding` values.)

## Fix
Language belongs to a designation. Set it only for designation-typed properties:

```java
ep.setLang(DESIGNATION_PROPERTY_TYPE.equals(prop.getPropertyType()) ? prop.getLanguage() : null);
```

A non-designation property is now imported as a **property value** (with its typed value), never misclassified as a designation.

## Test (TDD)
`CodeSystemFileImportMapperTest` case: process + `toCodeSystem` a CSV with a `concept-code`, a `display` designation, and a `dateTime` column carrying a language. First confirmed **red** (exact `ClassCastException`), then **green**: the date is imported as a property value and only `display` remains a designation. Full mapper + processor suites pass.

## Note
Independent of #410 (missing-identifier NPE/TE741); touches the same file in a different region (`mapPropValue`), so the two merge cleanly in either order.