### PR TITLE
perf(valueset): skip snapshot expansion in code system impact analysis

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactService.java
@@ -27,7 +27,7 @@ public class ValueSetCodeSystemImpactService {
   private final ValueSetCodeSystemVersionResolver codeSystemVersionResolver;
 
   public List<CodeSystemArtifactImpact> findValueSetImpacts(String codeSystem) {
-    List<ValueSetVersion> versions = valueSetVersionService.query(new ValueSetVersionQueryParams().setCodeSystem(codeSystem).all()).getData();
+    List<ValueSetVersion> versions = valueSetVersionService.queryMeta(new ValueSetVersionQueryParams().setCodeSystem(codeSystem).all()).getData();
     List<CodeSystemArtifactImpact> impacts = new ArrayList<>();
     for (ValueSetVersion version : versions) {
       List<ValueSetVersionRule> rules = Optional.ofNullable(version.getRuleSet()).map(rs -> rs.getRules()).orElse(List.of()).stream()
@@ -42,7 +42,7 @@ public class ValueSetCodeSystemImpactService {
   }
 
   public void refreshDynamicValueSets(String codeSystem) {
-    List<ValueSetVersion> versions = valueSetVersionService.query(new ValueSetVersionQueryParams().setCodeSystem(codeSystem).all()).getData();
+    List<ValueSetVersion> versions = valueSetVersionService.queryMeta(new ValueSetVersionQueryParams().setCodeSystem(codeSystem).all()).getData();
     versions.stream()
         .filter(v -> List.of(PublicationStatus.active, PublicationStatus.draft).contains(v.getStatus()))
         .filter(v -> Optional.ofNullable(v.getRuleSet()).map(rs -> rs.getRules()).orElse(List.of()).stream()

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactService.java
@@ -2,7 +2,9 @@ package org.termx.terminology.terminology.valueset;
 
 import io.micronaut.core.util.CollectionUtils;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import jakarta.inject.Singleton;
@@ -12,6 +14,7 @@ import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConce
 import org.termx.terminology.terminology.valueset.version.ValueSetVersionService;
 import org.termx.ts.PublicationStatus;
 import org.termx.ts.codesystem.CodeSystemArtifactImpact;
+import org.termx.ts.codesystem.CodeSystemVersion;
 import org.termx.ts.codesystem.CodeSystemVersionReference;
 import org.termx.ts.valueset.ValueSetSnapshot;
 import org.termx.ts.valueset.ValueSetSnapshotDependency;
@@ -28,6 +31,10 @@ public class ValueSetCodeSystemImpactService {
 
   public List<CodeSystemArtifactImpact> findValueSetImpacts(String codeSystem) {
     List<ValueSetVersion> versions = valueSetVersionService.queryMeta(new ValueSetVersionQueryParams().setCodeSystem(codeSystem).all()).getData();
+    // Every rule below is filtered to the same code system, so resolving the current version is
+    // identical across all rules/versions, and a referenced version repeats whenever multiple rules
+    // point at it. Memoize resolver lookups (each is a DB hit) for the duration of this call.
+    Map<String, CodeSystemVersion> resolveCache = new HashMap<>();
     List<CodeSystemArtifactImpact> impacts = new ArrayList<>();
     for (ValueSetVersion version : versions) {
       List<ValueSetVersionRule> rules = Optional.ofNullable(version.getRuleSet()).map(rs -> rs.getRules()).orElse(List.of()).stream()
@@ -36,7 +43,7 @@ public class ValueSetCodeSystemImpactService {
       if (CollectionUtils.isEmpty(rules)) {
         continue;
       }
-      impacts.add(aggregateImpact(version, rules));
+      impacts.add(aggregateImpact(version, rules, resolveCache));
     }
     return impacts;
   }
@@ -50,12 +57,12 @@ public class ValueSetCodeSystemImpactService {
         .forEach(v -> valueSetVersionConceptService.expand(v.getValueSet(), v.getVersion()));
   }
 
-  private CodeSystemArtifactImpact toImpact(ValueSetVersion version, ValueSetVersionRule rule) {
-    CodeSystemVersionReference currentVersion = codeSystemVersionResolver.copyReference(codeSystemVersionResolver.resolve(rule.getCodeSystem(), null));
+  private CodeSystemArtifactImpact toImpact(ValueSetVersion version, ValueSetVersionRule rule, Map<String, CodeSystemVersion> resolveCache) {
+    CodeSystemVersionReference currentVersion = codeSystemVersionResolver.copyReference(resolveCached(resolveCache, rule.getCodeSystem(), null));
     boolean dynamic = codeSystemVersionResolver.isDynamic(rule);
     CodeSystemVersionReference resolvedVersion = dynamic
         ? snapshotDependency(version.getSnapshot(), rule.getCodeSystem())
-        : codeSystemVersionResolver.copyReference(codeSystemVersionResolver.resolve(rule.getCodeSystem(), rule.getCodeSystemVersion()));
+        : codeSystemVersionResolver.copyReference(resolveCached(resolveCache, rule.getCodeSystem(), rule.getCodeSystemVersion()));
     boolean affected = currentVersion != null && !Objects.equals(currentVersion.getId(), resolvedVersion == null ? null : resolvedVersion.getId());
 
     return new CodeSystemArtifactImpact()
@@ -70,8 +77,31 @@ public class ValueSetCodeSystemImpactService {
         .setCurrentCodeSystemVersion(currentVersion);
   }
 
-  private CodeSystemArtifactImpact aggregateImpact(ValueSetVersion version, List<ValueSetVersionRule> rules) {
-    List<CodeSystemArtifactImpact> ruleImpacts = rules.stream().map(rule -> toImpact(version, rule)).toList();
+  private CodeSystemVersion resolveCached(Map<String, CodeSystemVersion> cache, String codeSystem, CodeSystemVersionReference requestedVersion) {
+    String key = resolveKey(codeSystem, requestedVersion);
+    // containsKey (not computeIfAbsent) so that a resolved-to-null lookup is cached too.
+    if (cache.containsKey(key)) {
+      return cache.get(key);
+    }
+    CodeSystemVersion resolved = codeSystemVersionResolver.resolve(codeSystem, requestedVersion);
+    cache.put(key, resolved);
+    return resolved;
+  }
+
+  // Mirrors ValueSetCodeSystemVersionResolver.resolve() precedence: explicit version wins over id,
+  // and absence of both means "latest".
+  private static String resolveKey(String codeSystem, CodeSystemVersionReference requestedVersion) {
+    if (requestedVersion != null && requestedVersion.getVersion() != null) {
+      return codeSystem + "|v:" + requestedVersion.getVersion();
+    }
+    if (requestedVersion != null && requestedVersion.getId() != null) {
+      return codeSystem + "|i:" + requestedVersion.getId();
+    }
+    return codeSystem + "|last";
+  }
+
+  private CodeSystemArtifactImpact aggregateImpact(ValueSetVersion version, List<ValueSetVersionRule> rules, Map<String, CodeSystemVersion> resolveCache) {
+    List<CodeSystemArtifactImpact> ruleImpacts = rules.stream().map(rule -> toImpact(version, rule, resolveCache)).toList();
     return ruleImpacts.stream()
         .max((left, right) -> {
           int severityCompare = Integer.compare(severity(left), severity(right));

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionRepository.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionRepository.java
@@ -29,17 +29,23 @@ public class ValueSetVersionRepository extends BaseRepository {
     bp.addColumnProcessor("identifiers", PgBeanProcessor.fromJson(JsonUtil.getListType(Identifier.class)));
   });
 
-  private final static String select = "select distinct on (vsv.id) vsv.*, " +
-      "(select json_build_object(" +
-      "   'id', vss.id, " +
-      "   'valueSet', vss.value_set, " +
-      "   'valueSetVersion', (select json_build_object('id', vsv2.id, 'version', vsv2.version) from terminology.value_set_version vsv2 where vsv2.id = vss.value_set_version_id and vsv2.sys_status = 'A'), " +
-      "   'expansion', vss.expansion, " +
-      "   'dependencies', vss.dependencies, " +
-      "   'createdAt', vss.created_at, " +
-      "   'createdBy', vss.created_by, " +
-      "   'conceptsTotal', vss.concepts_total " +
-      ") from terminology.value_set_snapshot vss where vsv.id = vss.value_set_version_id and vss.sys_status = 'A') as snapshot ," +
+  // Snapshot sub-select. The metadata-only variant omits the (potentially huge) 'expansion' concept
+  // list — callers that only need snapshot metadata (dependencies, createdAt, conceptsTotal), such as
+  // code system impact analysis, must not pay to inline and later decompress every concept.
+  private static String snapshotSelect(boolean includeExpansion) {
+    return "(select json_build_object(" +
+        "   'id', vss.id, " +
+        "   'valueSet', vss.value_set, " +
+        "   'valueSetVersion', (select json_build_object('id', vsv2.id, 'version', vsv2.version) from terminology.value_set_version vsv2 where vsv2.id = vss.value_set_version_id and vsv2.sys_status = 'A'), " +
+        (includeExpansion ? "   'expansion', vss.expansion, " : "") +
+        "   'dependencies', vss.dependencies, " +
+        "   'createdAt', vss.created_at, " +
+        "   'createdBy', vss.created_by, " +
+        "   'conceptsTotal', vss.concepts_total " +
+        ") from terminology.value_set_snapshot vss where vsv.id = vss.value_set_version_id and vss.sys_status = 'A') as snapshot ,";
+  }
+
+  private final static String ruleSetSelect =
       "(select json_build_object(" +
       "   'id', vsvrs.id, " +
       "   'lockedDate', vsvrs.locked_date, " +
@@ -61,6 +67,10 @@ public class ValueSetVersionRepository extends BaseRepository {
       "      'valueSetVersion', (select json_build_object('id', vsv.id, 'version', vsv.version) from terminology.value_set_version vsv where vsv.id = vsvr.value_set_version_id and vsv.sys_status = 'A') " +
       "   )) from terminology.value_set_version_rule vsvr where vsvrs.id = vsvr.rule_set_id and vsvr.sys_status = 'A') " +
       ") from terminology.value_set_version_rule_set vsvrs where vsv.id = vsvrs.value_set_version_id and vsvrs.sys_status = 'A') as rule_set ";
+
+  private final static String select = "select distinct on (vsv.id) vsv.*, " + snapshotSelect(true) + ruleSetSelect;
+  // Same projection as {@link #select} but without the snapshot expansion concept list. See {@link #snapshotSelect}.
+  private final static String selectMeta = "select distinct on (vsv.id) vsv.*, " + snapshotSelect(false) + ruleSetSelect;
 
   public void save(ValueSetVersion version) {
     SaveSqlBuilder ssb = new SaveSqlBuilder();
@@ -98,6 +108,20 @@ public class ValueSetVersionRepository extends BaseRepository {
   }
 
   public QueryResult<ValueSetVersion> query(ValueSetVersionQueryParams params) {
+    return query(params, true);
+  }
+
+  /**
+   * Metadata-only query: returns versions with their rule sets and snapshot metadata but without the
+   * snapshot expansion concept list. Use this when the expansion is not needed (e.g. impact analysis) —
+   * it avoids inlining and gzip-decompressing every snapshot's concepts, which is orders of magnitude
+   * cheaper for code systems referenced by many/large value sets.
+   */
+  public QueryResult<ValueSetVersion> queryMeta(ValueSetVersionQueryParams params) {
+    return query(params, false);
+  }
+
+  private QueryResult<ValueSetVersion> query(ValueSetVersionQueryParams params, boolean includeExpansion) {
     return query(params, p -> {
       SqlBuilder sb = new SqlBuilder("select count(distinct(vsv.id)) from terminology.value_set_version vsv " +
           "inner join terminology.value_set vs on vs.id = vsv.value_set and vs.sys_status = 'A' " +
@@ -109,7 +133,7 @@ public class ValueSetVersionRepository extends BaseRepository {
       sb.append(filter(params));
       return queryForObject(sb.getSql(), Integer.class, sb.getParams());
     }, p -> {
-      SqlBuilder sb = new SqlBuilder(select + "from terminology.value_set_version vsv " +
+      SqlBuilder sb = new SqlBuilder((includeExpansion ? select : selectMeta) + "from terminology.value_set_version vsv " +
           "inner join terminology.value_set vs on vs.id = vsv.value_set and vs.sys_status = 'A' " +
           "left join terminology.value_set_version_rule_set vsvrs on vsvrs.value_set_version_id = vsv.id and vsvrs.sys_status = 'A' " +
           "left join terminology.value_set_version_rule vsvr on vsvr.rule_set_id = vsvrs.id and vsvr.sys_status = 'A' " +
@@ -119,7 +143,9 @@ public class ValueSetVersionRepository extends BaseRepository {
       sb.append(filter(params));
       sb.append(limit(params));
       List<ValueSetVersion> beans = getBeans(sb.getSql(), bp, sb.getParams());
-      fillCompressedExpansions(beans);
+      if (includeExpansion) {
+        fillCompressedExpansions(beans);
+      }
       return beans;
     });
   }

--- a/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/valueset/version/ValueSetVersionService.java
@@ -69,6 +69,10 @@ public class ValueSetVersionService {
     return repository.query(params);
   }
 
+  public QueryResult<ValueSetVersion> queryMeta(ValueSetVersionQueryParams params) {
+    return repository.queryMeta(params);
+  }
+
   @Transactional
   public void activate(String valueSet, String version) {
     ValueSetVersion currentVersion = repository.load(valueSet, version);

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactServiceTest.groovy
@@ -43,7 +43,7 @@ class ValueSetCodeSystemImpactServiceTest extends Specification {
 
     then:
     1 * valueSetVersionService.queryMeta(_ as ValueSetVersionQueryParams) >> new QueryResult([version])
-    2 * codeSystemVersionResolver.resolve("administrative-gender", null) >> currentVersion
+    1 * codeSystemVersionResolver.resolve("administrative-gender", null) >> currentVersion
     1 * codeSystemVersionResolver.isDynamic(firstRule) >> false
     1 * codeSystemVersionResolver.isDynamic(secondRule) >> false
     1 * codeSystemVersionResolver.resolve("administrative-gender", firstRule.codeSystemVersion) >> oldVersion
@@ -58,5 +58,39 @@ class ValueSetCodeSystemImpactServiceTest extends Specification {
     impacts.first().affected
     impacts.first().resolvedCodeSystemVersion.version == "6.0.0"
     impacts.first().currentCodeSystemVersion.version == "6.0.1"
+  }
+
+  def "findValueSetImpacts memoizes resolver lookups across value set versions"() {
+    given:
+    def currentVersion = new CodeSystemVersion().setId(200L).setVersion("6.0.1")
+    def referencedVersion = new CodeSystemVersion().setId(100L).setVersion("6.0.0")
+    def rule = { -> new ValueSetVersionRule()
+        .setId(1L)
+        .setType("include")
+        .setCodeSystem("administrative-gender")
+        .setCodeSystemVersion(new CodeSystemVersionReference().setId(100L).setVersion("6.0.0")) }
+    def firstVs = new ValueSetVersion()
+        .setValueSet("vs-a").setVersion("1.0.0")
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule()]))
+    def secondVs = new ValueSetVersion()
+        .setValueSet("vs-b").setVersion("1.0.0")
+        .setRuleSet(new ValueSetVersionRuleSet().setRules([rule()]))
+
+    when:
+    def impacts = service.findValueSetImpacts("administrative-gender")
+
+    then:
+    1 * valueSetVersionService.queryMeta(_ as ValueSetVersionQueryParams) >> new QueryResult([firstVs, secondVs])
+    // Two value set versions, but each distinct (codeSystem, version) is resolved only once.
+    1 * codeSystemVersionResolver.resolve("administrative-gender", null) >> currentVersion
+    1 * codeSystemVersionResolver.resolve("administrative-gender", { it.version == "6.0.0" }) >> referencedVersion
+    _ * codeSystemVersionResolver.isDynamic(_) >> false
+    _ * codeSystemVersionResolver.copyReference(_ as CodeSystemVersion) >> { CodeSystemVersion source ->
+      new CodeSystemVersionReference().setId(source.id).setVersion(source.version)
+    }
+
+    impacts.size() == 2
+    impacts*.artifactId.sort() == ["vs-a", "vs-b"]
+    impacts.every { it.affected }
   }
 }

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/valueset/ValueSetCodeSystemImpactServiceTest.groovy
@@ -42,7 +42,7 @@ class ValueSetCodeSystemImpactServiceTest extends Specification {
     def impacts = service.findValueSetImpacts("administrative-gender")
 
     then:
-    1 * valueSetVersionService.query(_ as ValueSetVersionQueryParams) >> new QueryResult([version])
+    1 * valueSetVersionService.queryMeta(_ as ValueSetVersionQueryParams) >> new QueryResult([version])
     2 * codeSystemVersionResolver.resolve("administrative-gender", null) >> currentVersion
     1 * codeSystemVersionResolver.isDynamic(firstRule) >> false
     1 * codeSystemVersionResolver.isDynamic(secondRule) >> false


### PR DESCRIPTION
## Problem

The resource **summary** page for a code system (e.g. `/resources/code-systems/rhk10/summary`) takes ~16–17 s to finish loading. Debugging in the browser showed one API call dominates while everything else returns in <1 s, and the other summary panels serialize behind it:

| Request | Time |
|---|---|
| `GET /api/ts/code-systems/rhk10/value-set-impacts` | **~16,700 ms** |
| `GET /api/ts/code-systems/rhk10/versions?limit=-1` | 309 ms |
| everything else | 30–80 ms |

The endpoint returns only ~16 KB / 37 items, so it is pure server-side compute, not payload/network.

## Root cause

`ValueSetCodeSystemImpactService.findValueSetImpacts()` loads every value set version that references the code system via the generic `ValueSetVersionRepository.query()`. That projection **inlines the full snapshot `expansion` concept list** and then `fillCompressedExpansions()` **gzip-decompresses `expansion_bytea`** for each version.

Impact analysis only ever reads the rule sets and snapshot **metadata** (`dependencies`, `createdAt`, `conceptsTotal`) — never the concept list. For `rhk10` (Estonian ICD-10, referenced by 34 value sets) this decompresses tens of thousands of concepts on every summary load, then discards them.

## Fix

- Factor the snapshot sub-select into `snapshotSelect(boolean includeExpansion)` and add a metadata-only `selectMeta` projection that omits the expansion.
- Add `ValueSetVersionRepository.queryMeta()` (and a `ValueSetVersionService.queryMeta()` passthrough) that uses `selectMeta` and skips `fillCompressedExpansions`.
- Use `queryMeta()` from both call sites in `ValueSetCodeSystemImpactService` (`findValueSetImpacts` and `refreshDynamicValueSets`); neither reads expansion concepts.

The full `query()` path is unchanged — the reconstructed `select` constant is byte-identical to the previous one.

## Also in this PR — Closes #413

Memoize the per-rule resolver lookups. Every rule in `findValueSetImpacts` is filtered to the same code system, so `resolve(codeSystem, null)` (the current version) was re-resolved once per rule across every value set version, and a referenced version was re-resolved whenever multiple rules pointed at it — each a DB lookup. Added a per-call cache keyed by `(codeSystem, version|id|latest)` (mirroring the resolver's own precedence) that also caches not-found results.

## Verification

- `:terminology:compileJava` — clean.
- `ValueSetCodeSystemImpactServiceTest` — mocked interaction updated to `queryMeta`; `resolve(cs, null)` now asserted once (was twice, proving the memoization); added a case locking version-resolution caching across value sets. Passes.