### PR TITLE
ci: raise Gradle daemon heap for release build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
 
+      - name: Configure Gradle JVM memory
+        run: |
+          mkdir -p "$HOME/.gradle"
+          echo "org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g" >> "$HOME/.gradle/gradle.properties"
+
       - name: Build, run all checks, and publish
         working-directory: .
         run: ./gradlew clean assemble check pmdCheck spotbugsCheck dependencyCheckAggregate publish


### PR DESCRIPTION
The `Build and publish on release` workflow (first run: tag 3.3.0) fails at `:dependencyCheckAggregate` with `Java heap space` — the Gradle daemon's default 512 MiB heap can't run the OWASP dependency-check, so the build dies before `publish`.

Configure a 6 GB daemon heap in the CI `GRADLE_USER_HOME` (`~/.gradle/gradle.properties`) so the scan completes and the release artifacts publish. Scoped to CI — local developer builds keep the default heap.