### PR TITLE
ci: run dependencyCheckAggregate only on the root project

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build, run all checks, and publish
         working-directory: .
-        run: ./gradlew clean assemble check pmdCheck spotbugsCheck dependencyCheckAggregate publish
+        run: ./gradlew clean assemble check pmdCheck spotbugsCheck :dependencyCheckAggregate publish
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Third and final blocker on the release publish. After the heap fix (#415) and OSS Index disable (#416), `:bob:dependencyCheckAggregate` still fails with `Analysis failed`: the `dependencyCheck` config (OSS Index off, NVD key) is root-only, but the workflow ran `dependencyCheckAggregate` across **every** subproject, and subprojects keep the default config (OSS Index on → 429).

`dependencyCheckAggregate` already aggregates the full multi-module dependency graph into one report, so per-subproject runs are redundant. Scope the invocation to `:dependencyCheckAggregate` (root only) — fixes the failure and cuts the redundant ~subproject scans.