### PR TITLE
ci: split release workflow into parallel build-publish and security-scan jobs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,6 +6,9 @@ on:
       - '*.*.*'
 
 jobs:
+  # The release deliverable: build, run the fast checks (tests, PMD, SpotBugs) and publish
+  # the Maven libraries. Kept independent of the slow OWASP scan so a flaky/slow security
+  # scan never blocks or forces a re-run of the publish.
   build-and-publish:
     runs-on: ubuntu-latest
     name: Build, check, publish
@@ -30,9 +33,52 @@ jobs:
           mkdir -p "$HOME/.gradle"
           echo "org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g" >> "$HOME/.gradle/gradle.properties"
 
-      - name: Build, run all checks, and publish
+      - name: Build, run checks, and publish
         working-directory: .
-        run: ./gradlew clean assemble check pmdCheck spotbugsCheck :dependencyCheckAggregate publish
+        run: ./gradlew clean assemble check pmdCheck spotbugsCheck publish
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # OWASP dependency-check runs in parallel and does NOT gate the publish above — with
+  # failBuildOnCVSS unset (defaults to 11.0) it never fails on a discovered CVE, so it is a
+  # report, not a release gate. Re-run just this job in isolation if it flakes.
+  security-scan:
+    runs-on: ubuntu-latest
+    name: OWASP dependency-check
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Configure Gradle JVM memory
+        run: |
+          mkdir -p "$HOME/.gradle"
+          echo "org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g" >> "$HOME/.gradle/gradle.properties"
+
+      # Root-only aggregate: it already scans the whole multi-module dependency graph into one
+      # report. Running per-subproject is redundant and re-enables analyzers (OSS Index) that the
+      # root project disables. NVD_API_KEY lifts the strict anonymous rate limit (much faster).
+      - name: OWASP dependency-check (aggregate)
+        working-directory: .
+        run: ./gradlew :dependencyCheckAggregate
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+
+      - name: Upload dependency-check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: build/reports/dependency-check-report.*
+          if-no-files-found: warn


### PR DESCRIPTION
Follow-up to the 3.3.0 release-workflow fixes (#415/#416/#417). The workflow ran everything in one serial job, so the ~40-min OWASP scan (bulk of the ~51-min run) gated the publish and could fail an otherwise-good release, forcing a full re-run.

**Split into two parallel jobs:**
- `build-and-publish` — `assemble check pmdCheck spotbugsCheck publish` (the deliverable, ~10–15 min).
- `security-scan` — `:dependencyCheckAggregate`, independent, uploads the HTML report as an artifact. Does **not** gate publish (`failBuildOnCVSS` unset → 11.0 → dep-check never fails on a CVE; it's a report, not a gate). Re-run just this job if it flakes.

Also passes `NVD_API_KEY` to the scan (previously unset) to lift the strict anonymous NVD rate limit.

Applies to future tags; does not re-tag 3.3.0 (already published). Will be cherry-picked to `r3.3`.