### PR TITLE
Standardise MinIO/Bob config on BOB_MINIO_* env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ That starts MinIO on `:9000` (S3 API) and `:9001` (web console) with `minio` / `
 For production, override via env vars on the JVM:
 
 ```
-MINIO_URL=https://minio.example.com
-MINIO_ACCESS_KEY=...
-MINIO_SECRET_KEY=...
+BOB_MINIO_URL=https://minio.example.com
+BOB_MINIO_ACCESS_KEY=...
+BOB_MINIO_SECRET_KEY=...
 ```
 
-If `MINIO_URL` is unset and there's no `bob.minio.url` override, the application starts but every `/bob/*` write returns a structured `BOB101 Object storage (Minio) is not configured` error — see [`BobObjectService.getMinio`](bob/src/main/java/org/termx/bob/BobObjectService.java).
+If `BOB_MINIO_URL` is unset and there's no `bob.minio.url` override, the application starts but every `/bob/*` write returns a structured `BOB101 Object storage (Minio) is not configured` error — see [`BobObjectService.getMinio`](bob/src/main/java/org/termx/bob/BobObjectService.java).

--- a/bob/src/main/java/org/termx/bob/BobObjectService.java
+++ b/bob/src/main/java/org/termx/bob/BobObjectService.java
@@ -130,11 +130,11 @@ public class BobObjectService {
   private MinioService getMinio() {
     // ApiClientException so the framework's DefaultExceptionHandler returns a structured 400
     // with our code instead of a generic XX100 System error. The message tells operators what
-    // to do — local dev forgets scripts/run-minio.sh frequently, prod deploys forget MINIO_URL.
+    // to do — local dev forgets scripts/run-minio.sh frequently, prod deploys forget BOB_MINIO_URL.
     return minioService.orElseThrow(() -> new ApiClientException(Issue.error(
         "BOB101",
         "Object storage (Minio) is not configured. " +
             "Local dev: run scripts/run-minio.sh. " +
-            "Production: set MINIO_URL / MINIO_ACCESS_KEY / MINIO_SECRET_KEY env vars.")));
+            "Production: set BOB_MINIO_URL / BOB_MINIO_ACCESS_KEY / BOB_MINIO_SECRET_KEY env vars.")));
   }
 }

--- a/deployment/docker-compose/server.env
+++ b/deployment/docker-compose/server.env
@@ -12,10 +12,11 @@ MICRONAUT_SERVER_CORS_ENABLED=true# for development only
 # Object storage (Minio) for Wiki attachments and SNOMED / LOINC archive uploads.
 # Defaults talk to the bundled `termx-minio` service in docker-compose.yml; the
 # values here must match the MINIO_ROOT_USER / MINIO_ROOT_PASSWORD set there.
+# BOB_MINIO_* are the app's access credentials (distinct from the MinIO root account).
 # ================================================================================
-MINIO_URL=http://termx-minio:9000
-MINIO_ACCESS_KEY=minio
-MINIO_SECRET_KEY=minio123
+BOB_MINIO_URL=http://termx-minio:9000
+BOB_MINIO_ACCESS_KEY=minio
+BOB_MINIO_SECRET_KEY=minio123
 
 # ================================================================================
 # SMTP Email Configuration (optional)

--- a/docs/features/deployment-configuration.md
+++ b/docs/features/deployment-configuration.md
@@ -18,7 +18,7 @@ compose stack, the public installation guide, and the feature docs in this folde
 | **PostgreSQL** | Standard `postgres` image env. | `pg.env` |
 
 > **Gotcha — colons in URL defaults.** In `application.yml`, URL defaults are wrapped in backticks
-> (`` ${MINIO_URL:`http://localhost:9000`} ``) because Micronaut treats `:` as the value/default
+> (`` ${BOB_MINIO_URL:`http://localhost:9000`} ``) because Micronaut treats `:` as the value/default
 > delimiter. When you *set* the env var you do **not** add backticks — just the plain URL.
 
 > **Selecting a profile.** `MICRONAUT_ENVIRONMENTS=<name>` loads `application-<name>.yml`
@@ -74,9 +74,10 @@ Development-only auth (do **not** use in production):
 | `BOB_MINIO_ACCESS_KEY` | `minio` | Access key (`bob.minio.access-key`) |
 | `BOB_MINIO_SECRET_KEY` | `minio123` | Secret key (`bob.minio.secret-key`) |
 
-> The base `application.yml` placeholders are `MINIO_URL` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`;
-> deployments and the feature docs use the `BOB_MINIO_*` names. Both bind to the same `bob.minio.*`
-> properties — prefer `BOB_MINIO_*`.
+> The `application.yml` placeholders are `BOB_MINIO_URL` / `BOB_MINIO_ACCESS_KEY` / `BOB_MINIO_SECRET_KEY`.
+> The `BOB_` prefix keeps the app's access credentials distinct from the MinIO server's own root
+> account (`MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`). The older unprefixed `MINIO_URL` /
+> `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` names are **no longer read** — use `BOB_MINIO_*`.
 
 ### 1.6 Large terminology import (SNOMED + LOINC archives) — see [`snomed-import-management.md`](snomed-import-management.md), [`loinc-import-management.md`](loinc-import-management.md)
 | Env var / property | Default | Purpose |
@@ -294,12 +295,12 @@ credentials (`minio`/`minio123`).
 
 ## 7. Caveats, gotchas & known divergences
 
-### Variable-name divergences
-- **MinIO: `MINIO_*` vs `BOB_MINIO_*`.** The base `application.yml` declares `MINIO_URL` /
-  `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`, while quick-start, the public install guide, and the
-  large-import feature doc use `BOB_MINIO_*`. Both resolve to the same `bob.minio.*` properties (the
-  `BOB_MINIO_*` form via Micronaut relaxed binding). **Use `BOB_MINIO_*`** and don't set the two
-  spellings to different values.
+### Variable names
+- **MinIO: use `BOB_MINIO_*`.** `application.yml` declares `BOB_MINIO_URL` / `BOB_MINIO_ACCESS_KEY` /
+  `BOB_MINIO_SECRET_KEY`, consistent with quick-start, the public install guide, and the large-import
+  feature doc. The `BOB_` prefix keeps the app's access credentials distinct from the MinIO server's
+  own root account (`MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`). The older unprefixed `MINIO_*` names
+  are **no longer read**.
 - **Snowstorm & Keycloak have no `${ENV}` placeholders.** `snowstorm.*` is hard-coded in
   `application.yml` (with sensible defaults); `keycloak.*` only appears in profile files
   (`application-demo.yml` / `application-dev.yml`). You still override them with `SNOWSTORM_*` /
@@ -308,7 +309,7 @@ credentials (`minio`/`minio123`).
 
 ### Config-parsing gotchas
 - **Colons in URL defaults are backticked in YAML, not in env.** A default like
-  `` ${MINIO_URL:`http://localhost:9000`} `` is backticked so Micronaut doesn't treat `:` as the
+  `` ${BOB_MINIO_URL:`http://localhost:9000`} `` is backticked so Micronaut doesn't treat `:` as the
   value/default delimiter. When you *set* the env var, give the plain URL — no backticks.
 - **Web JSON-typed vars must be valid JSON.** `UI_LANGUAGES`, `CONTENT_LANGUAGES`, `EXTRA_LANGUAGES`,
   `EMBEDDED`, `GUEST_DISABLED` are parsed as JSON; an empty value is dropped and the built-in default

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -89,19 +89,23 @@ auth:
 # Local dev: defaults match scripts/run-minio.sh (which starts a `tx-minio` container with
 # `minio/minio123` credentials on :9000). Run that script once and bob just works.
 #
-# Production: override via env. If MINIO_URL is not set at runtime, the MinioClient bean is
+# Production: override via env. If BOB_MINIO_URL is not set at runtime, the MinioClient bean is
 # not created and any Bob upload returns a clear 503 "object storage not configured" error
 # (handled in BobObjectService.getMinio).
+#
+# The BOB_ prefix disambiguates the app's access credentials from the MinIO server's own
+# root account (MINIO_ROOT_USER / MINIO_ROOT_PASSWORD). The older MINIO_URL / MINIO_ACCESS_KEY /
+# MINIO_SECRET_KEY names are no longer read — use BOB_MINIO_*.
 bob:
   minio:
     # Backticks around the default — Micronaut treats `:` as the var/default delimiter,
-    # so `${MINIO_URL:http://…}` parses the default as just `http`, the URL is then
+    # so `${BOB_MINIO_URL:http://…}` parses the default as just `http`, the URL is then
     # malformed and the okhttp client inside the Minio SDK fails with
     # NoRouteToHostException. Same backtick pattern as the `datasources.default.url`
     # line at the top of this file.
-    url: ${MINIO_URL:`http://localhost:9000`}
-    access-key: ${MINIO_ACCESS_KEY:minio}
-    secret-key: ${MINIO_SECRET_KEY:minio123}
+    url: ${BOB_MINIO_URL:`http://localhost:9000`}
+    access-key: ${BOB_MINIO_ACCESS_KEY:minio}
+    secret-key: ${BOB_MINIO_SECRET_KEY:minio123}
 
 snowstorm:
   url: https://snowstorm.termx.org/


### PR DESCRIPTION
## Problem
The Bob object-store config (`bob.minio.*`) declared its **explicit** `application.yml` placeholders as `MINIO_URL` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`, while the quick-start repo, `deployment/docker-compose/server.env` and the feature docs all use `BOB_MINIO_*` — which worked only *implicitly* via Micronaut relaxed binding. So `MINIO_*` looked authoritative in the code but `BOB_MINIO_*` was the documented preference. That mismatch is exactly what caused a recent false "quick-start MinIO is broken" report.

## Change
Make `BOB_MINIO_*` the explicit, first-class binding across the repo:
- **`application.yml`** — placeholders → `${BOB_MINIO_URL:…}` / `${BOB_MINIO_ACCESS_KEY:…}` / `${BOB_MINIO_SECRET_KEY:…}` (same backticked-default form as the existing `${DB_URL:…}` line).
- **`deployment/docker-compose/server.env`**, **`README.md`**, and **`BobObjectService`**'s `BOB101` guidance message updated to `BOB_MINIO_*`.
- **`deployment-configuration.md`** documents `BOB_MINIO_*` as the names and notes the unprefixed `MINIO_*` are no longer read.

The `BOB_` prefix also keeps the app's access credentials distinct from the MinIO server's own root account (`MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD`).

## ⚠️ Breaking
Deployments setting the unprefixed `MINIO_URL` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` must rename them to `BOB_MINIO_*`. Otherwise `bob.minio.url` falls back to the `localhost:9000` default and Bob uploads return `503`. (The termx-quick-start repo and `deployment/docker-compose` already use `BOB_MINIO_*`; this PR updates the latter.) `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` are unaffected.

## Verification
Static change: the `application.yml` placeholder is structurally identical to the verified `${DB_URL:`…`}` placeholder, and the Java edit is a string-literal only. A repo-wide grep confirms no remaining non-root `MINIO_*` references. Not runtime-booted.