### PR TITLE
Wiki↔mdbook: metadata, content convergence, and GitHub import

### DIFF
--- a/docs/wiki-mdbook-syntax.md
+++ b/docs/wiki-mdbook-syntax.md
@@ -1,0 +1,79 @@
+# TermX Wiki ↔ mdbook: shared syntax
+
+Authoritative "write it this way" reference for wiki content that must render **identically**
+in the TermX Wiki (markdown-it via `@termx-health/markdown-parser`) and in
+[`mdbook`](https://github.com/igorboss/mdbook) (VitePress, also markdown-it — but it compiles
+markdown output as a **Vue template**, which is stricter than raw HTML). It is the counterpart to
+mdbook's `docs/termx-wiki-compatibility.md` (the full feature matrix) and drives the one-time
+content-convergence migration (`WikiContentNormalizer` + the `wiki:content-convergence`
+changeset).
+
+Nearly all TermX smart-text renders natively in mdbook. Only a handful of source constructs
+diverge; this file lists them, the canonical both-compatible form, and how each is handled.
+
+## Handling categories
+
+- **Migrate** — the source is rewritten in place by the one-time convergence migration; the
+  verbatim original is preserved in `wiki.page_content.bak_content`.
+- **mdbook-side** — the gap is closed in the generator so both render the same; no content change.
+- **Author-managed** — an intentional, page-specific construct; not touched automatically.
+
+---
+
+## Migrated rules
+
+### R1 — Autolink-breaker spans → HTML comment
+Wiki.js inserts a bare, attribute-less `<span>` to stop auto-linking inside a word
+(e.g. `Draw.<span>io`, so "Draw.io" doesn't become a link). These are frequently **unclosed**,
+which VitePress/Vue rejects ("Element is missing end tag").
+
+- **Canonical form:** `Draw.<!-- -->io` — an empty HTML comment. It is invisible in both
+  renderers and still splits the text so neither auto-links it.
+- **Rewrite:** a bare, attribute-less opening `<span>` (and an empty `<span></span>` pair) →
+  `<!-- -->`. Spans **with attributes** (`<span class="…">`, `style=…`) are meaningful, and a
+  standalone closing `</span>` belongs to one — neither is touched.
+- **Why not just delete** (mdbook's build-time fallback does): deletion rejoins `Draw.io`, which
+  markdown-it's linkify may then turn into a link — a behavioral change. The comment preserves the
+  original no-link intent in both.
+
+### R2 — Stray fence languages → real language id
+An unknown fenced-code language hard-fails the VitePress (Shiki) build. TermX content uses
+` ```s ` for shell.
+
+- **Rewrite:** ` ```s ` → ` ```sh `. The alias map is extensible; add any other stray ids the
+  audit surfaces. (Mirrors mdbook's `FENCE_LANG_ALIAS` in `src/ingest/sanitize.mjs`.)
+- Diagram fences (` ```drawio `, ` ```plantuml `, ` ```mermaid `) and real Shiki ids
+  (`json`, `js`, `http`, `html`, `yaml`, `bash`, `plaintext`, …) are already fine — not touched.
+
+---
+
+## mdbook-side (no content change)
+
+### `{.dense}` after a multimd table
+`{.dense}` on its own line after a `^^`/`|||` multi-column table renders dense in the wiki, but
+markdown-it-attrs can't attach the class to a multimd-table token, so mdbook can't apply it. Rather
+than strip it from the source (which would drop the dense styling in the **wiki** too), the
+generator closes the gap: mdbook attaches the class to the table element during staging so **both**
+render dense. Content keeps `{.dense}`. (Tracks mdbook compatibility-doc §7.1.)
+
+---
+
+## Author-managed (not migrated)
+
+- **Raw `<script>` blocks.** VitePress hoists `<script>` in markdown (executed); the wiki ignores
+  it. In the current content these appear only inside ` ```html ` code fences (shown as examples),
+  so they render as code in both. A genuinely raw, executable `<script>` is an intentional,
+  page-specific choice — left to the author.
+- **FHIR / XML examples** (`<system>`, `<valueCoding>`, …) live inside code fences and render as
+  code in both — no action.
+- **`{{def:}}` / `{{csc:}}` / `{{vsc:}}` and other `{{…}}`.** Both renderers handle these; mdbook
+  makes them Vue-safe at render time (`v-pre`). No source change.
+
+---
+
+## Rollout
+
+The convergence migration is **one-time**: it rewrites existing content and stores the original in
+`bak_content`. It does not run on save — new content stays compatible by following this spec.
+mdbook keeps its build-time `sanitize.mjs` as a belt-and-suspenders fallback for un-migrated or
+third-party repos, so both migrated and unmigrated content render correctly.

--- a/docs/wiki-ssg-metadata-proposal.md
+++ b/docs/wiki-ssg-metadata-proposal.md
@@ -35,7 +35,8 @@ The export currently emits:
 |---|---|
 | Page markdown body | exported verbatim |
 | Page title | only in `pages.json` as `name` — **never an H1 in the `.md`** |
-| Per-page description / keywords | **missing** — no model field (runtime `<meta>` uses `content.slice(0,1000)`) |
+| Per-page description | **missing** — no model field (runtime `<meta>` uses `content.slice(0,1000)`) |
+| Keywords (`<meta keywords>`) | page `tags` already exist but were **not exported** |
 | Space localized names → `space.json` | exists (`names`) |
 | Space description / site title / theme / URL | **missing** — only hand-authored in `.mdbook/config.yml` |
 | Space default language / languages list | **missing** — global `environment.contentLanguages`/`defaultLanguage` only, not per-space, not exported |
@@ -60,18 +61,18 @@ page a visible H1 — an on-page SEO signal the body lacks today.
   Cheaper, but the exported `.md` stays title-less. Prefer the source-side change so the
   export is self-contained; mdbook keeps its injection as a fallback for un-re-exported repos.
 
-### B. Per-page metadata: `description`, `keywords`
+### B. Per-page description (+ keywords from tags)
 
-Add per-language content metadata:
-
-- Model: `PageContent.description: String`, `PageContent.keywords: List<String>` (nullable),
-  plus the TS mirror and an editor field (page setup / header).
-- Export: extend `SpaceGithubPageContent` →
-  `(name, slug, lang, contentType, description, keywords, modifiedAt)`.
-- mdbook: read `description`/`keywords` from `pages.json` into per-page frontmatter,
-  falling back to the first-paragraph heuristic when absent.
-
-Replaces the runtime `content.slice(0,1000)` `<meta>` hack with authored, stored values.
+- **Description** — a new per-language content field:
+  - Model: `PageContent.description: String` (nullable) + the TS mirror and an editor field.
+  - Export: extend `SpaceGithubPageContent` → `(name, slug, lang, contentType, description, modifiedAt)`.
+  - mdbook reads `description` into per-page frontmatter, falling back to the first-paragraph
+    heuristic when absent. Replaces the runtime `content.slice(0,1000)` `<meta>` hack.
+- **Keywords** — *not* a new field. Page **tags** (`Page.tags`, already authored/curated in the
+  editor) are the single source of topical terms, so they are exported (page-level `tags` on
+  `SpaceGithubPage`) and mdbook renders them as `<meta name="keywords">`. A dedicated per-content
+  `keywords` field would duplicate tags for a meta tag that modern search engines largely ignore,
+  so it was intentionally dropped in favour of reusing tags.
 
 ### C. Project metadata → generator config
 

--- a/termx-api/src/main/java/org/termx/sys/space/Space.java
+++ b/termx-api/src/main/java/org/termx/sys/space/Space.java
@@ -24,6 +24,11 @@ public class Space {
   private List<String> terminologyServers;
   private SpaceIntegration integration;
 
+  private LocalizedName description;
+  private String defaultLanguage;
+  private List<String> languages;
+  private String siteUrl;
+
   private List<Package> packages;
 
   @Getter

--- a/termx-api/src/main/java/org/termx/wiki/page/PageContent.java
+++ b/termx-api/src/main/java/org/termx/wiki/page/PageContent.java
@@ -17,6 +17,7 @@ public class PageContent {
   private String lang;
   private String content;
   private String contentType;
+  private String description;
 
   private OffsetDateTime createdAt;
   private String createdBy;

--- a/termx-core/src/main/java/org/termx/core/sys/space/SpaceRepository.java
+++ b/termx-core/src/main/java/org/termx/core/sys/space/SpaceRepository.java
@@ -18,6 +18,8 @@ public class SpaceRepository extends BaseRepository {
     bp.addColumnProcessor("acl", PgBeanProcessor.fromJson());
     bp.addColumnProcessor("integration", PgBeanProcessor.fromJson());
     bp.addColumnProcessor("terminology_servers", PgBeanProcessor.fromJson(JsonUtil.getListType(String.class)));
+    bp.addColumnProcessor("description", PgBeanProcessor.fromJson());
+    bp.addColumnProcessor("languages", PgBeanProcessor.fromJson(JsonUtil.getListType(String.class)));
   });
 
   public void save(Space space) {
@@ -31,6 +33,10 @@ public class SpaceRepository extends BaseRepository {
     ssb.jsonProperty("acl", space.getAcl());
     ssb.jsonProperty("integration", space.getIntegration());
     ssb.jsonProperty("terminology_servers", space.getTerminologyServers());
+    ssb.jsonProperty("description", space.getDescription());
+    ssb.property("default_language", space.getDefaultLanguage());
+    ssb.jsonProperty("languages", space.getLanguages());
+    ssb.property("site_url", space.getSiteUrl());
 
     SqlBuilder sb = ssb.buildSave("sys.space", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());

--- a/termx-core/src/main/resources/sys/changelog/sys/50-space.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/50-space.sql
@@ -34,3 +34,10 @@ alter table sys.space add column integration jsonb;
 --changeset termx:space-global-search
 alter table sys.space add column global_search boolean not null default false;
 --
+
+--changeset termx:space-ssg-metadata
+alter table sys.space add column description       jsonb;
+alter table sys.space add column default_language  text;
+alter table sys.space add column languages         jsonb;
+alter table sys.space add column site_url          text;
+--

--- a/wiki/build.gradle.kts
+++ b/wiki/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation("com.kodality.commons:commons-micronaut-pg:${rootProject.extra["commonsMicronautVersion"]}")
     implementation("commons-io:commons-io:2.16.1")
     implementation("com.github.slugify:slugify:3.0.7")
+    implementation("org.jsoup:jsoup:1.18.3")
 
     implementation("io.micronaut.spring:micronaut-spring")
     implementation("io.micronaut.validation:micronaut-validation")

--- a/wiki/src/main/java/org/termx/wiki/SpaceGithubDataWikiSsgHandler.java
+++ b/wiki/src/main/java/org/termx/wiki/SpaceGithubDataWikiSsgHandler.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
@@ -100,12 +101,18 @@ public class SpaceGithubDataWikiSsgHandler implements SpaceGithubDataHandler {
         .toList();
 
     List<ResourceContent> result = new ArrayList<>();
-    result.add(new ResourceContent("space.json", toPrettyJson(new SsgSpaceIndex(termxWebUrl.orElse(null), space.getCode(), space.getNames()))));
+    result.add(new ResourceContent("space.json", toPrettyJson(new SsgSpaceIndex(
+        termxWebUrl.orElse(null), space.getCode(), space.getNames(),
+        space.getDescription(), space.getDefaultLanguage(), space.getLanguages(), space.getSiteUrl()))));
     result.add(new ResourceContent("pages.json", toPrettyJson(composePagesIndex(pages, links))));
-    result.addAll(contents.stream().map(p -> new ResourceContent(
-        "pages/" + p.getSlug() + (p.getContentType().equals("html") ? ".html" : ".md"),
-        p.getContent()
-    )).toList());
+    result.addAll(contents.stream().map(p -> {
+      boolean html = "html".equals(p.getContentType());
+      // §A: materialize the page name as the file's H1 so the exported markdown is
+      // self-describing (the title otherwise lives only in pages.json). Skip HTML content
+      // and pages whose body already opens with an H1.
+      String body = html ? p.getContent() : ensureH1(p.getContent(), p.getName());
+      return new ResourceContent("pages/" + p.getSlug() + (html ? ".html" : ".md"), body);
+    }).toList());
     result.addAll(attachments.stream().map(a -> new ResourceContent(
         "attachments/" + a.pageId() + "/" + a.name(),
         a.base64(),
@@ -137,11 +144,21 @@ public class SpaceGithubDataWikiSsgHandler implements SpaceGithubDataHandler {
           p.getCode(),
           p.getContents().stream()
               .sorted(Comparator.comparing(PageContent::getSlug))
-              .map(c -> new SpaceGithubPageContent(c.getName(), c.getSlug(), c.getLang(), c.getContentType(), c.getModifiedAt()))
+              .map(c -> new SpaceGithubPageContent(c.getName(), c.getSlug(), c.getLang(), c.getContentType(),
+                  c.getDescription(), c.getModifiedAt()))
               .toList(),
-          buildPages(p.getId(), allPages)
+          buildPages(p.getId(), allPages),
+          pageTags(p)
       );
     }).toList();
+  }
+
+  // Page-level tags, exported so the generator can surface them (e.g. as <meta keywords>).
+  static List<String> pageTags(Page p) {
+    return CollectionUtils.isEmpty(p.getTags()) ? null : p.getTags().stream()
+        .map(t -> t.getTag() == null ? null : t.getTag().getText())
+        .filter(java.util.Objects::nonNull)
+        .toList();
   }
 
   @Override
@@ -149,15 +166,29 @@ public class SpaceGithubDataWikiSsgHandler implements SpaceGithubDataHandler {
     // intentionally left blank
   }
 
-  protected record SpaceGithubPage(String code, List<SpaceGithubPageContent> contents, List<SpaceGithubPage> children) {
-    protected record SpaceGithubPageContent(String name, String slug, String lang, String contentType, OffsetDateTime modifiedAt) {}
+  protected record SpaceGithubPage(String code, List<SpaceGithubPageContent> contents, List<SpaceGithubPage> children,
+                                   List<String> tags) {
+    protected record SpaceGithubPageContent(String name, String slug, String lang, String contentType,
+                                            String description, OffsetDateTime modifiedAt) {}
 
     protected record SpaceGithubPageAttachment(Long pageId, String name, String base64) {}
 
     protected record SpaceGithubPageRelatedResource(String resourceType, String name, String content, String contentType) {}
   }
 
-  protected record SsgSpaceIndex(String web, String code, LocalizedName names) {}
+  protected record SsgSpaceIndex(String web, String code, LocalizedName names,
+                                 LocalizedName description, String defaultLang, List<String> langs, String siteUrl) {}
+
+  // Prepend "# {name}" as the body's H1 unless it already opens with one (a single leading '#').
+  private static final Pattern LEADING_H1 = Pattern.compile("^\\s*#(?!#)\\s");
+
+  static String ensureH1(String content, String name) {
+    String body = content == null ? "" : content;
+    if (name == null || name.isBlank() || LEADING_H1.matcher(body).find()) {
+      return body;
+    }
+    return "# " + name + "\n\n" + body;
+  }
 
   public static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
     Set<Object> seen = ConcurrentHashMap.newKeySet();

--- a/wiki/src/main/java/org/termx/wiki/SpaceMsDevopsDataWikiSsgHandler.java
+++ b/wiki/src/main/java/org/termx/wiki/SpaceMsDevopsDataWikiSsgHandler.java
@@ -88,12 +88,15 @@ public class SpaceMsDevopsDataWikiSsgHandler implements SpaceMsDevopsDataHandler
         .toList();
 
     List<ResourceContent> result = new ArrayList<>();
-    result.add(new ResourceContent("space.json", toPrettyJson(new SpaceGithubDataWikiSsgHandler.SsgSpaceIndex(termxWebUrl.orElse(null), space.getCode(), space.getNames()))));
+    result.add(new ResourceContent("space.json", toPrettyJson(new SpaceGithubDataWikiSsgHandler.SsgSpaceIndex(
+        termxWebUrl.orElse(null), space.getCode(), space.getNames(),
+        space.getDescription(), space.getDefaultLanguage(), space.getLanguages(), space.getSiteUrl()))));
     result.add(new ResourceContent("pages.json", toPrettyJson(composePagesIndex(pages, links))));
-    result.addAll(contents.stream().map(p -> new ResourceContent(
-        "pages/" + p.getSlug() + (p.getContentType().equals("html") ? ".html" : ".md"),
-        p.getContent()
-    )).toList());
+    result.addAll(contents.stream().map(p -> {
+      boolean html = "html".equals(p.getContentType());
+      String body = html ? p.getContent() : SpaceGithubDataWikiSsgHandler.ensureH1(p.getContent(), p.getName());
+      return new ResourceContent("pages/" + p.getSlug() + (html ? ".html" : ".md"), body);
+    }).toList());
     result.addAll(attachments.stream().map(a -> new ResourceContent(
         "attachments/" + a.pageId() + "/" + a.name(),
         a.base64(),
@@ -125,9 +128,11 @@ public class SpaceMsDevopsDataWikiSsgHandler implements SpaceMsDevopsDataHandler
           p.getCode(),
           p.getContents().stream()
               .sorted(Comparator.comparing(PageContent::getSlug))
-              .map(c -> new SpaceGithubPageContent(c.getName(), c.getSlug(), c.getLang(), c.getContentType(), c.getModifiedAt()))
+              .map(c -> new SpaceGithubPageContent(c.getName(), c.getSlug(), c.getLang(), c.getContentType(),
+                  c.getDescription(), c.getModifiedAt()))
               .toList(),
-          buildPages(p.getId(), allPages)
+          buildPages(p.getId(), allPages),
+          SpaceGithubDataWikiSsgHandler.pageTags(p)
       );
     }).toList();
   }

--- a/wiki/src/main/java/org/termx/wiki/WikiContentNormalizer.java
+++ b/wiki/src/main/java/org/termx/wiki/WikiContentNormalizer.java
@@ -1,0 +1,61 @@
+package org.termx.wiki;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rewrites TermX Wiki markdown into a form that renders identically in the wiki (markdown-it)
+ * and in mdbook (VitePress/Vue). Pure, dependency-free functions only, so it is safe to call
+ * from a Liquibase customChange during startup as well as from application code.
+ *
+ * <p>Rules are documented in {@code docs/wiki-mdbook-syntax.md} and mirror mdbook's build-time
+ * fallback in {@code src/ingest/sanitize.mjs}.
+ */
+public final class WikiContentNormalizer {
+  private WikiContentNormalizer() {}
+
+  /** R1: the Wiki.js autolink-breaker — a bare, attribute-less opening {@code <span>}
+   * (optionally an empty {@code <span></span>} pair). Spans carrying attributes are
+   * meaningful, and a standalone closing {@code </span>} belongs to one, so neither is
+   * touched. */
+  private static final Pattern BARE_SPAN =
+      Pattern.compile("<span\\s*>(?:\\s*</span\\s*>)?", Pattern.CASE_INSENSITIVE);
+
+  /** R2: a fenced-code opening line — optional indent, {@code ```}, a language id, optional
+   * trailing whitespace. Closing fences carry no language, so they never match. */
+  private static final Pattern FENCE = Pattern.compile("(?m)^(\\s*```)([A-Za-z0-9_+-]+)([ \\t]*)$");
+
+  /** Stray fence languages Shiki doesn't know, mapped to real ids (an unknown language
+   * hard-fails the VitePress build). Extend as the content audit surfaces more. */
+  private static final Map<String, String> FENCE_ALIAS = Map.of("s", "sh");
+
+  /** Returns {@code content} rewritten to the both-compatible form, or the input unchanged
+   * (including null/empty) when no rule applies. */
+  public static String normalize(String content) {
+    if (content == null || content.isEmpty()) {
+      return content;
+    }
+    String out = content;
+    out = BARE_SPAN.matcher(out).replaceAll("<!-- -->");
+    out = aliasFenceLanguages(out);
+    return out;
+  }
+
+  /** True when {@link #normalize} would change the given content. */
+  public static boolean needsNormalization(String content) {
+    return content != null && !content.equals(normalize(content));
+  }
+
+  private static String aliasFenceLanguages(String text) {
+    Matcher m = FENCE.matcher(text);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      String alias = FENCE_ALIAS.get(m.group(2));
+      String replacement = alias == null ? m.group() : m.group(1) + alias + m.group(3);
+      m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+}

--- a/wiki/src/main/java/org/termx/wiki/importer/GitbookConverter.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/GitbookConverter.java
@@ -30,6 +30,13 @@ public final class GitbookConverter {
   private static final Pattern CARD_TABLE = Pattern.compile("(?is)<table\\b[^>]*\\bdata-view=\"cards\"[^>]*>.*?</table>");
   private static final Pattern FILE_EMBED = Pattern.compile("\\{%\\s*file\\s+src=\"([^\"]+)\"[^%]*%\\}");
   private static final Pattern HINT = Pattern.compile("(?is)\\{%\\s*hint\\s+style=\"([^\"]+)\"\\s*%\\}(.*?)\\{%\\s*endhint\\s*%\\}");
+  private static final Pattern IMG_TAG = Pattern.compile("(?is)<img\\b[^>]*?/?>");
+  private static final Pattern IMG_SRC = Pattern.compile("(?i)\\bsrc=[\"']([^\"']*)[\"']");
+  private static final Pattern IMG_ALT = Pattern.compile("(?i)\\balt=[\"']([^\"']*)[\"']");
+  // GitBook wraps images as <div align><figure><img><figcaption></figure></div>; markdown inside
+  // an HTML block isn't processed, so unwrap the whole block to a standalone markdown image.
+  private static final Pattern FIGURE_BLOCK =
+      Pattern.compile("(?is)(?:<div\\b[^>]*>\\s*)?<figure\\b[^>]*>\\s*(<img\\b[^>]*>).*?</figure>(?:\\s*</div>)?");
 
   // GitBook hint styles -> TermX callout classes.
   private static final Map<String, String> HINT_CLASS = Map.of(
@@ -41,9 +48,44 @@ public final class GitbookConverter {
     }
     String out = FRONTMATTER.matcher(body).replaceFirst("");
     out = convertCardTables(out);
+    out = convertFigures(out);
+    out = convertImages(out);
     out = convertFileEmbeds(out);
     out = convertHints(out);
     return out;
+  }
+
+  private static String convertFigures(String body) {
+    Matcher m = FIGURE_BLOCK.matcher(body);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, Matcher.quoteReplacement(imgToMarkdown(m.group(1), m.group())));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  /** Raw {@code <img>} tags aren't rewritten by the wiki's attachment renderer (only markdown
+   * images are), so turn them into markdown so imported images resolve. */
+  private static String convertImages(String body) {
+    Matcher m = IMG_TAG.matcher(body);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, Matcher.quoteReplacement(imgToMarkdown(m.group(), m.group())));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  /** A single {@code <img>} tag as a markdown image (URL angle-bracketed so spaces stay valid), or
+   * {@code fallback} when it has no src. */
+  private static String imgToMarkdown(String imgTag, String fallback) {
+    Matcher src = IMG_SRC.matcher(imgTag);
+    if (!src.find()) {
+      return fallback;
+    }
+    Matcher alt = IMG_ALT.matcher(imgTag);
+    return "![" + (alt.find() ? alt.group(1) : "") + "](<" + src.group(1) + ">)";
   }
 
   private static String convertCardTables(String body) {
@@ -98,7 +140,7 @@ public final class GitbookConverter {
       if (name.isEmpty()) {
         name = src;
       }
-      m.appendReplacement(sb, Matcher.quoteReplacement("[" + name + "](" + src + ")"));
+      m.appendReplacement(sb, Matcher.quoteReplacement("[" + name + "](<" + src + ">)"));
     }
     m.appendTail(sb);
     return sb.toString();

--- a/wiki/src/main/java/org/termx/wiki/importer/GitbookConverter.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/GitbookConverter.java
@@ -1,0 +1,119 @@
+package org.termx.wiki.importer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.jsoup.select.Elements;
+
+/**
+ * Normalizes GitBook-specific markdown into a form the TermX wiki renderer displays correctly —
+ * the counterpart to mdbook's build-time GitBook transforms. Applied to each imported GitBook page:
+ * <ul>
+ *   <li>drops the leading YAML frontmatter block;</li>
+ *   <li>rewrites {@code <table data-view="cards">} card tables to plain tables, removing the
+ *       {@code data-hidden} columns (which otherwise render as stray {@code null} cells);</li>
+ *   <li>turns {@code {% file src="…" %}} into a link and {@code {% hint style="…" %}…{% endhint %}}
+ *       into a TermX callout blockquote.</li>
+ * </ul>
+ */
+public final class GitbookConverter {
+  private GitbookConverter() {}
+
+  private static final Pattern FRONTMATTER = Pattern.compile("^\\uFEFF?---\\r?\\n.*?\\r?\\n---\\r?\\n", Pattern.DOTALL);
+  private static final Pattern CARD_TABLE = Pattern.compile("(?is)<table\\b[^>]*\\bdata-view=\"cards\"[^>]*>.*?</table>");
+  private static final Pattern FILE_EMBED = Pattern.compile("\\{%\\s*file\\s+src=\"([^\"]+)\"[^%]*%\\}");
+  private static final Pattern HINT = Pattern.compile("(?is)\\{%\\s*hint\\s+style=\"([^\"]+)\"\\s*%\\}(.*?)\\{%\\s*endhint\\s*%\\}");
+
+  // GitBook hint styles -> TermX callout classes.
+  private static final Map<String, String> HINT_CLASS = Map.of(
+      "info", "is-info", "warning", "is-warning", "danger", "is-error", "success", "is-success");
+
+  public static String convert(String body) {
+    if (body == null) {
+      return null;
+    }
+    String out = FRONTMATTER.matcher(body).replaceFirst("");
+    out = convertCardTables(out);
+    out = convertFileEmbeds(out);
+    out = convertHints(out);
+    return out;
+  }
+
+  private static String convertCardTables(String body) {
+    Matcher m = CARD_TABLE.matcher(body);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      m.appendReplacement(sb, Matcher.quoteReplacement(cleanCardTable(m.group())));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  private static String cleanCardTable(String tableHtml) {
+    Document doc = Jsoup.parse(tableHtml, "", Parser.xmlParser());
+    Element table = doc.selectFirst("table");
+    if (table == null) {
+      return tableHtml;
+    }
+    table.removeAttr("data-view");
+
+    Elements headerCells = table.select("thead > tr > th");
+    List<Integer> hidden = new ArrayList<>();
+    for (int i = 0; i < headerCells.size(); i++) {
+      if (headerCells.get(i).hasAttr("data-hidden")) {
+        hidden.add(i);
+      }
+    }
+    // Remove hidden columns from every row (highest index first so positions stay valid).
+    for (Element row : table.select("tr")) {
+      Elements cells = row.children();
+      for (int j = hidden.size() - 1; j >= 0; j--) {
+        int idx = hidden.get(j);
+        if (idx < cells.size()) {
+          cells.get(idx).remove();
+        }
+      }
+    }
+    // GitBook card tables have no header text — drop an all-empty header row.
+    Element thead = table.selectFirst("thead");
+    if (thead != null && thead.select("th").stream().allMatch(th -> th.text().isBlank())) {
+      thead.remove();
+    }
+    return table.outerHtml();
+  }
+
+  private static String convertFileEmbeds(String body) {
+    Matcher m = FILE_EMBED.matcher(body);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      String src = m.group(1);
+      String name = StringUtils.substringAfterLast(src, "/");
+      if (name.isEmpty()) {
+        name = src;
+      }
+      m.appendReplacement(sb, Matcher.quoteReplacement("[" + name + "](" + src + ")"));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  private static String convertHints(String body) {
+    Matcher m = HINT.matcher(body);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      String cls = HINT_CLASS.getOrDefault(m.group(1), "is-info");
+      String text = m.group(2).trim();
+      String quoted = text.lines().map(l -> "> " + l).reduce((a, b) -> a + "\n" + b).orElse("> ");
+      m.appendReplacement(sb, Matcher.quoteReplacement(quoted + "\n{." + cls + "}"));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+}

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportRequest.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportRequest.java
@@ -1,0 +1,29 @@
+package org.termx.wiki.importer;
+
+import io.micronaut.core.annotation.Introspected;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Request to import a wiki Space from a GitHub repository. Provide either {@code url}
+ * (e.g. {@code https://github.com/owner/repo/tree/branch/dir}) or {@code owner} + {@code repo}.
+ * {@code branch} defaults to the repo's default branch; {@code dir} is auto-detected from where
+ * {@code pages.json} lives; {@code token} is only needed for private repositories.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class WikiGithubImportRequest {
+  @NotNull
+  private Long spaceId;
+  private String url;
+  private String owner;
+  private String repo;
+  private String branch;
+  private String dir;
+  private String token;
+  private String lang; // language for imported content (GitBook has none); defaults to 'en'
+}

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportResult.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportResult.java
@@ -1,0 +1,7 @@
+package org.termx.wiki.importer;
+
+import io.micronaut.core.annotation.Introspected;
+
+/** Summary of a completed GitHub import. */
+@Introspected
+public record WikiGithubImportResult(String repo, String branch, String dir, int pages) {}

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportResult.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportResult.java
@@ -4,4 +4,4 @@ import io.micronaut.core.annotation.Introspected;
 
 /** Summary of a completed GitHub import. */
 @Introspected
-public record WikiGithubImportResult(String repo, String branch, String dir, int pages) {}
+public record WikiGithubImportResult(String repo, String branch, String dir, int pages, int attachments) {}

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
@@ -1,0 +1,422 @@
+package org.termx.wiki.importer;
+
+import com.github.slugify.Slugify;
+import com.kodality.commons.util.JsonUtil;
+import org.termx.core.sys.space.SpaceService;
+import org.termx.sys.space.Space;
+import org.termx.wiki.SpaceGithubDataWikiHandler;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jakarta.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Imports a wiki Space's content straight from a GitHub repository, without configuring the
+ * Space's git integration or performing any git/OAuth operations. Fetches the export files over
+ * plain HTTP (the tree API + raw.githubusercontent, unauthenticated for public repos, or with an
+ * optional token for private ones) and feeds them to the existing round-trip parser
+ * {@link SpaceGithubDataWikiHandler#saveContent}.
+ *
+ * <p>Both export layouts are accepted: the round-trip {@code wiki} format
+ * ({@code <dir>/pages.json} + {@code <dir>/<slug>.md}) and the {@code wiki-ssg} format
+ * ({@code <dir>/pages.json} + {@code <dir>/pages/<slug>.md}, whose page-content field is
+ * {@code contentType} rather than {@code ct}). The content directory is auto-detected from where
+ * {@code pages.json} lives when not given.
+ */
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class WikiGithubImportService {
+  private static final String GITHUB_API = "https://api.github.com";
+  private static final String GITHUB_RAW = "https://raw.githubusercontent.com";
+
+  private final SpaceGithubDataWikiHandler wikiHandler;
+  private final SpaceService spaceService;
+
+  private final HttpClient http = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+
+  @Transactional
+  public WikiGithubImportResult importSpace(WikiGithubImportRequest req) {
+    GithubCoords coords = GithubCoords.resolve(req);
+    Space space = spaceService.load(req.getSpaceId());
+    if (space == null) {
+      throw new RuntimeException("space not found: " + req.getSpaceId());
+    }
+
+    String branch = StringUtils.isNotBlank(coords.branch()) ? coords.branch() : defaultBranch(coords, req.getToken());
+    List<String> blobs = listBlobs(coords, branch, req.getToken());
+
+    String dir = StringUtils.isNotBlank(coords.dir())
+        ? StringUtils.strip(coords.dir(), "/")
+        : autodetectDir(blobs);
+    String prefix = dir.isEmpty() ? "" : dir + "/";
+
+    // TermX (pages.json) vs GitBook (SUMMARY.md). pages.json wins if both exist.
+    boolean termx = blobs.contains(prefix + "pages.json");
+    boolean gitbook = !termx && blobs.contains(prefix + "SUMMARY.md");
+
+    // saveContent mutates the map, so it must be mutable.
+    Map<String, String> content = new LinkedHashMap<>();
+    int pages = gitbook
+        ? buildFromGitbook(content, coords, branch, prefix, req)
+        : buildFromTermx(content, coords, branch, dir, prefix, blobs, req);
+
+    log.info("importing {} page(s) into space {} from {}/{}@{} ({}, {})",
+        pages, req.getSpaceId(), coords.owner(), coords.repo(), branch, dir.isEmpty() ? "/" : dir,
+        gitbook ? "gitbook" : "termx");
+    wikiHandler.saveContent(req.getSpaceId(), content);
+
+    return new WikiGithubImportResult(coords.owner() + "/" + coords.repo(), branch, dir, pages);
+  }
+
+  // ── TermX (pages.json + <slug>.md / pages/<slug>.md) ───────────────────────
+
+  private int buildFromTermx(Map<String, String> content, GithubCoords coords, String branch, String dir,
+                             String prefix, List<String> blobs, WikiGithubImportRequest req) {
+    String pagesJson = fetchRaw(coords, branch, prefix + "pages.json", req.getToken());
+    if (pagesJson == null) {
+      throw new RuntimeException("pages.json not found at '" + prefix + "pages.json' in "
+          + coords.owner() + "/" + coords.repo() + "@" + branch);
+    }
+    // Normalize pages.json to the round-trip shape and learn the slug -> name of every content.
+    Map<String, String> slugToName = new HashMap<>();
+    Object tree = JsonUtil.fromJson(pagesJson, Object.class);
+    normalizeNodes(tree, slugToName);
+    content.put("pages.json", JsonUtil.toJson(tree));
+
+    // The parser re-slugifies each content from its name on save (PageContentService.prepare) and
+    // then keys the .md files it applies by that slug — so key the markdown the same way, not by
+    // the file name (a repo's stored slug can differ from slugify(name)). Only .md referenced by
+    // pages.json is fetched (orphans are skipped so the parser can't NPE); attachments/resources
+    // are not imported.
+    Slugify slugify = Slugify.builder().build();
+    Map<String, String> keyToPath = new LinkedHashMap<>();
+    for (String path : blobs) {
+      if (!path.endsWith(".md") || !path.startsWith(prefix)) {
+        continue;
+      }
+      String fileSlug = StringUtils.removeEnd(StringUtils.substringAfterLast("/" + path, "/"), ".md");
+      String name = slugToName.get(fileSlug);
+      if (name != null) {
+        keyToPath.put(slugify.slugify(name) + ".md", path);
+      }
+    }
+    Map<String, String> fetched = fetchAll(keyToPath, coords, branch, req.getToken(), false);
+    content.putAll(fetched);
+    return fetched.size();
+  }
+
+  // ── GitBook (SUMMARY.md tree + linked .md) ─────────────────────────────────
+
+  private int buildFromGitbook(Map<String, String> content, GithubCoords coords, String branch,
+                               String prefix, WikiGithubImportRequest req) {
+    String summary = fetchRaw(coords, branch, prefix + "SUMMARY.md", req.getToken());
+    if (summary == null) {
+      throw new RuntimeException("SUMMARY.md not found at '" + prefix + "SUMMARY.md'");
+    }
+    List<GbNode> roots = parseSummary(summary);
+    String lang = StringUtils.isNotBlank(req.getLang()) ? req.getLang() : "en";
+    Slugify slugify = Slugify.builder().build();
+
+    List<GbNode> all = new ArrayList<>();
+    flatten(roots, all);
+    // Fetch the linked markdown concurrently (keyed by the same slug the parser will re-derive).
+    Map<String, String> keyToPath = new LinkedHashMap<>();
+    for (GbNode n : all) {
+      if (n.href != null && n.href.endsWith(".md") && !n.href.matches("^https?://.*")) {
+        keyToPath.put(slugify.slugify(n.title) + ".md", prefix + n.href);
+      }
+    }
+    Map<String, String> bodies = fetchAll(keyToPath, coords, branch, req.getToken(), true);
+
+    List<Map<String, Object>> pagesJson = new ArrayList<>();
+    buildGbStructure(roots, pagesJson, content, bodies, lang, slugify);
+    content.put("pages.json", JsonUtil.toJson(pagesJson));
+    return all.size();
+  }
+
+  private void flatten(List<GbNode> nodes, List<GbNode> out) {
+    for (GbNode n : nodes) {
+      out.add(n);
+      flatten(n.children, out);
+    }
+  }
+
+  /** Builds round-trip pages.json nodes + keyed .md bodies from the parsed SUMMARY tree. Codes are a
+   * deterministic hash of the href/section, so re-importing updates rather than recreating; `##`
+   * sections (and pages whose file is missing) get a title-only body. */
+  private void buildGbStructure(List<GbNode> nodes, List<Map<String, Object>> out, Map<String, String> content,
+                                Map<String, String> bodies, String lang, Slugify slugify) {
+    for (GbNode n : nodes) {
+      String slug = slugify.slugify(n.title);
+      String key = n.href != null ? "gitbook:" + n.href : "gitbook-section:" + n.title;
+      String code = UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8)).toString();
+
+      Map<String, Object> contentObj = new LinkedHashMap<>();
+      contentObj.put("name", n.title);
+      contentObj.put("slug", slug);
+      contentObj.put("lang", lang);
+      contentObj.put("ct", "markdown");
+
+      List<Map<String, Object>> children = new ArrayList<>();
+      buildGbStructure(n.children, children, content, bodies, lang, slugify);
+
+      Map<String, Object> node = new LinkedHashMap<>();
+      node.put("code", code);
+      node.put("contents", List.of(contentObj));
+      node.put("children", children.isEmpty() ? null : children);
+      out.add(node);
+
+      String body = bodies.get(slug + ".md");
+      content.put(slug + ".md", body != null ? body : "# " + n.title + "\n");
+    }
+  }
+
+  /** Fetches many raw files concurrently (bounded pool), returning key -> body for those that
+   * exist (404s are skipped). `stripFm` drops a leading YAML frontmatter block (GitBook). */
+  private Map<String, String> fetchAll(Map<String, String> keyToPath, GithubCoords coords, String branch,
+                                       String token, boolean stripFm) {
+    Map<String, String> out = new ConcurrentHashMap<>();
+    if (keyToPath.isEmpty()) {
+      return out;
+    }
+    ExecutorService pool = Executors.newFixedThreadPool(Math.min(8, keyToPath.size()));
+    try {
+      List<Future<?>> futures = new ArrayList<>();
+      keyToPath.forEach((key, path) -> futures.add(pool.submit(() -> {
+        String body = fetchRaw(coords, branch, path, token);
+        if (stripFm) {
+          body = stripFrontmatter(body);
+        }
+        if (body != null) {
+          out.put(key, body);
+        }
+      })));
+      for (Future<?> f : futures) {
+        try {
+          f.get();
+        } catch (Exception e) {
+          throw new RuntimeException("failed fetching content from GitHub", e);
+        }
+      }
+    } finally {
+      pool.shutdown();
+    }
+    return out;
+  }
+
+  // GitBook pages carry a leading YAML frontmatter block (e.g. `--- icon: … ---`) that TermX
+  // doesn't model and would otherwise render as literal text. Drop it.
+  private static final Pattern GB_FRONTMATTER = Pattern.compile("^\\uFEFF?---\\r?\\n.*?\\r?\\n---\\r?\\n", Pattern.DOTALL);
+
+  private static String stripFrontmatter(String body) {
+    return body == null ? null : GB_FRONTMATTER.matcher(body).replaceFirst("");
+  }
+
+  private static final Pattern GB_SECTION = Pattern.compile("^#{2,}\\s+(.+?)\\s*$");
+  private static final Pattern GB_BULLET = Pattern.compile("^(\\s*)[-*+]\\s+\\[([^\\]]+)]\\(([^)]+)\\)");
+
+  /** Parses a GitBook SUMMARY.md into a nested node tree. `## Heading` starts a top-level section
+   * (a group page); bullet links nest by indentation. */
+  private List<GbNode> parseSummary(String summary) {
+    List<GbNode> roots = new ArrayList<>();
+    GbNode section = null;
+    List<GbNode> stack = new ArrayList<>();      // bullet-nesting stack (by indent)
+    List<Integer> indents = new ArrayList<>();
+    for (String raw : summary.split("\n")) {
+      Matcher sec = GB_SECTION.matcher(raw);
+      if (sec.matches()) {
+        section = new GbNode(sec.group(1).trim(), null);
+        roots.add(section);
+        stack.clear();
+        indents.clear();
+        continue;
+      }
+      Matcher bul = GB_BULLET.matcher(raw);
+      if (bul.find()) {
+        int indent = bul.group(1).length();
+        GbNode node = new GbNode(bul.group(2).trim(), bul.group(3).trim());
+        while (!indents.isEmpty() && indents.get(indents.size() - 1) >= indent) {
+          indents.remove(indents.size() - 1);
+          stack.remove(stack.size() - 1);
+        }
+        if (stack.isEmpty()) {
+          (section != null ? section.children : roots).add(node);
+        } else {
+          stack.get(stack.size() - 1).children.add(node);
+        }
+        stack.add(node);
+        indents.add(indent);
+      }
+    }
+    return roots;
+  }
+
+  private static final class GbNode {
+    final String title;
+    final String href; // null for a `## Section` group
+    final List<GbNode> children = new ArrayList<>();
+    GbNode(String title, String href) { this.title = title; this.href = href; }
+  }
+
+  // ── GitHub fetch ──────────────────────────────────────────────────────────
+
+  private String defaultBranch(GithubCoords c, String token) {
+    Map<String, Object> repo = JsonUtil.toMap(getJson(GITHUB_API + "/repos/" + c.owner() + "/" + c.repo(), token));
+    return (String) repo.get("default_branch");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> listBlobs(GithubCoords c, String branch, String token) {
+    String url = GITHUB_API + "/repos/" + c.owner() + "/" + c.repo() + "/git/trees/" + branch + "?recursive=1";
+    Map<String, Object> resp = JsonUtil.toMap(getJson(url, token));
+    if (Boolean.TRUE.equals(resp.get("truncated"))) {
+      log.warn("GitHub tree for {}/{}@{} is truncated; some files may be missing", c.owner(), c.repo(), branch);
+    }
+    List<Map<String, Object>> tree = (List<Map<String, Object>>) resp.getOrDefault("tree", List.of());
+    return tree.stream()
+        .filter(t -> "blob".equals(t.get("type")))
+        .map(t -> (String) t.get("path"))
+        .toList();
+  }
+
+  /** Parent directory of the shallowest {@code pages.json} (TermX) or {@code SUMMARY.md} (GitBook)
+   * in the tree, or "" if at the root. */
+  private String autodetectDir(List<String> blobs) {
+    return blobs.stream()
+        .filter(p -> p.equals("pages.json") || p.endsWith("/pages.json")
+            || p.equals("SUMMARY.md") || p.endsWith("/SUMMARY.md"))
+        .min(Comparator.comparingInt(p -> p.split("/").length))
+        .map(p -> p.contains("/") ? StringUtils.substringBeforeLast(p, "/") : "")
+        .orElseThrow(() -> new RuntimeException("no pages.json (TermX) or SUMMARY.md (GitBook) found in the repository"));
+  }
+
+  private String fetchRaw(GithubCoords c, String branch, String path, String token) {
+    String url = GITHUB_RAW + "/" + c.owner() + "/" + c.repo() + "/" + branch + "/" + path;
+    HttpResponse<String> resp = send(url, token, "text/plain");
+    if (resp.statusCode() == 404) {
+      return null;
+    }
+    if (resp.statusCode() >= 400) {
+      throw new RuntimeException("failed to fetch " + path + " (HTTP " + resp.statusCode() + ")");
+    }
+    return resp.body();
+  }
+
+  private String getJson(String url, String token) {
+    HttpResponse<String> resp = send(url, token, "application/vnd.github+json");
+    if (resp.statusCode() == 404) {
+      throw new RuntimeException("GitHub resource not found (is the repo public, or is a token needed?): " + url);
+    }
+    if (resp.statusCode() == 403) {
+      throw new RuntimeException("GitHub rate limit or access denied; provide a token: " + url);
+    }
+    if (resp.statusCode() >= 400) {
+      throw new RuntimeException("GitHub request failed (HTTP " + resp.statusCode() + "): " + url);
+    }
+    return resp.body();
+  }
+
+  private HttpResponse<String> send(String url, String token, String accept) {
+    HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(url)).GET()
+        .header("Accept", accept)
+        .header("User-Agent", "termx-wiki-import");
+    if (StringUtils.isNotBlank(token)) {
+      b.header("Authorization", "Bearer " + token);
+    }
+    try {
+      return http.send(b.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new RuntimeException("GitHub request failed: " + url, e);
+    }
+  }
+
+  // ── pages.json normalization (wiki-ssg -> round-trip field names) ──────────
+
+  /** Reduces each page-content object to the round-trip parser's fields ({@code name, slug, lang,
+   * ct}) — the wiki-ssg export names content-type {@code contentType} and adds
+   * {@code description/keywords/modifiedAt}, which must not reach the strict record deserializer.
+   * Collects slug -> name for every content along the way. */
+  @SuppressWarnings("unchecked")
+  private void normalizeNodes(Object node, Map<String, String> slugToName) {
+    if (node instanceof List<?> list) {
+      list.forEach(n -> normalizeNodes(n, slugToName));
+    } else if (node instanceof Map<?, ?> raw) {
+      Map<String, Object> map = (Map<String, Object>) raw;
+      Object contents = map.get("contents");
+      if (contents instanceof List<?> cl) {
+        for (Object c : cl) {
+          if (c instanceof Map<?, ?> rawc) {
+            Map<String, Object> cm = (Map<String, Object>) rawc;
+            if (cm.get("ct") == null && cm.get("contentType") != null) {
+              cm.put("ct", cm.get("contentType"));
+            }
+            cm.keySet().retainAll(List.of("name", "slug", "lang", "ct"));
+            if (cm.get("slug") != null && cm.get("name") != null) {
+              slugToName.put(cm.get("slug").toString(), cm.get("name").toString());
+            }
+          }
+        }
+      }
+      normalizeNodes(map.get("children"), slugToName);
+      // Keep only what the round-trip parser deserializes; drop extras like the exported `tags`.
+      map.keySet().retainAll(List.of("code", "contents", "children"));
+    }
+  }
+
+  // ── repo coordinates ──────────────────────────────────────────────────────
+
+  record GithubCoords(String owner, String repo, String branch, String dir) {
+    static GithubCoords resolve(WikiGithubImportRequest req) {
+      if (StringUtils.isNotBlank(req.getUrl())) {
+        return parseUrl(req.getUrl(), req.getBranch(), req.getDir());
+      }
+      if (StringUtils.isBlank(req.getOwner()) || StringUtils.isBlank(req.getRepo())) {
+        throw new RuntimeException("provide a GitHub url, or owner + repo");
+      }
+      return new GithubCoords(req.getOwner(), req.getRepo(), req.getBranch(), req.getDir());
+    }
+
+    // Accepts https://github.com/<owner>/<repo>[/tree/<branch>[/<dir...>]] (and github.com/... ,
+    // trailing .git). Explicit branch/dir from the request win over anything parsed from the URL.
+    static GithubCoords parseUrl(String url, String branchOverride, String dirOverride) {
+      String s = url.trim().replaceFirst("^https?://", "").replaceFirst("^github\\.com/", "");
+      String[] parts = s.split("/");
+      if (parts.length < 2) {
+        throw new RuntimeException("cannot parse GitHub url: " + url);
+      }
+      String owner = parts[0];
+      String repo = StringUtils.removeEnd(parts[1], ".git");
+      String branch = branchOverride;
+      String dir = dirOverride;
+      if (parts.length >= 4 && "tree".equals(parts[2])) {
+        if (StringUtils.isBlank(branch)) {
+          branch = parts[3];
+        }
+        if (StringUtils.isBlank(dir) && parts.length > 4) {
+          dir = String.join("/", List.of(parts).subList(4, parts.length));
+        }
+      }
+      return new GithubCoords(owner, repo, branch, dir);
+    }
+  }
+}

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
@@ -1,18 +1,29 @@
 package org.termx.wiki.importer;
 
 import com.github.slugify.Slugify;
+import com.kodality.commons.micronaut.rest.MultipartBodyReader.Attachment;
 import com.kodality.commons.util.JsonUtil;
 import org.termx.core.sys.space.SpaceService;
 import org.termx.sys.space.Space;
 import org.termx.wiki.SpaceGithubDataWikiHandler;
+import org.termx.wiki.page.Page;
+import org.termx.wiki.page.PageContent;
+import org.termx.wiki.page.PageQueryParams;
+import org.termx.wiki.page.PageService;
+import org.termx.wiki.pageattachment.PageAttachmentService;
+import org.termx.wiki.pagecontent.PageContentService;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.HashMap;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +34,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.io.IOUtils;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,6 +63,9 @@ public class WikiGithubImportService {
 
   private final SpaceGithubDataWikiHandler wikiHandler;
   private final SpaceService spaceService;
+  private final PageService pageService;
+  private final PageContentService pageContentService;
+  private final PageAttachmentService pageAttachmentService;
 
   private final HttpClient http = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
 
@@ -76,8 +91,9 @@ public class WikiGithubImportService {
 
     // saveContent mutates the map, so it must be mutable.
     Map<String, String> content = new LinkedHashMap<>();
+    Map<String, String> hrefDirByCode = new HashMap<>(); // GitBook: page code -> its .md directory
     int pages = gitbook
-        ? buildFromGitbook(content, coords, branch, prefix, req)
+        ? buildFromGitbook(content, coords, branch, prefix, req, hrefDirByCode)
         : buildFromTermx(content, coords, branch, dir, prefix, blobs, req);
 
     log.info("importing {} page(s) into space {} from {}/{}@{} ({}, {})",
@@ -85,7 +101,9 @@ public class WikiGithubImportService {
         gitbook ? "gitbook" : "termx");
     wikiHandler.saveContent(req.getSpaceId(), content);
 
-    return new WikiGithubImportResult(coords.owner() + "/" + coords.repo(), branch, dir, pages);
+    int attachments = importAttachments(req.getSpaceId(), coords, branch, prefix, req.getToken(), gitbook, hrefDirByCode);
+
+    return new WikiGithubImportResult(coords.owner() + "/" + coords.repo(), branch, dir, pages, attachments);
   }
 
   // ── TermX (pages.json + <slug>.md / pages/<slug>.md) ───────────────────────
@@ -128,7 +146,7 @@ public class WikiGithubImportService {
   // ── GitBook (SUMMARY.md tree + linked .md) ─────────────────────────────────
 
   private int buildFromGitbook(Map<String, String> content, GithubCoords coords, String branch,
-                               String prefix, WikiGithubImportRequest req) {
+                               String prefix, WikiGithubImportRequest req, Map<String, String> hrefDirByCode) {
     String summary = fetchRaw(coords, branch, prefix + "SUMMARY.md", req.getToken());
     if (summary == null) {
       throw new RuntimeException("SUMMARY.md not found at '" + prefix + "SUMMARY.md'");
@@ -149,7 +167,7 @@ public class WikiGithubImportService {
     Map<String, String> bodies = fetchAll(keyToPath, coords, branch, req.getToken(), true);
 
     List<Map<String, Object>> pagesJson = new ArrayList<>();
-    buildGbStructure(roots, pagesJson, content, bodies, lang, slugify);
+    buildGbStructure(roots, pagesJson, content, bodies, lang, slugify, hrefDirByCode);
     content.put("pages.json", JsonUtil.toJson(pagesJson));
     return all.size();
   }
@@ -165,11 +183,14 @@ public class WikiGithubImportService {
    * deterministic hash of the href/section, so re-importing updates rather than recreating; `##`
    * sections (and pages whose file is missing) get a title-only body. */
   private void buildGbStructure(List<GbNode> nodes, List<Map<String, Object>> out, Map<String, String> content,
-                                Map<String, String> bodies, String lang, Slugify slugify) {
+                                Map<String, String> bodies, String lang, Slugify slugify, Map<String, String> hrefDirByCode) {
     for (GbNode n : nodes) {
       String slug = slugify.slugify(n.title);
       String key = n.href != null ? "gitbook:" + n.href : "gitbook-section:" + n.title;
       String code = UUID.nameUUIDFromBytes(key.getBytes(StandardCharsets.UTF_8)).toString();
+      if (n.href != null && n.href.contains("/")) {
+        hrefDirByCode.put(code, StringUtils.substringBeforeLast(n.href, "/")); // for resolving relative assets
+      }
 
       Map<String, Object> contentObj = new LinkedHashMap<>();
       contentObj.put("name", n.title);
@@ -178,7 +199,7 @@ public class WikiGithubImportService {
       contentObj.put("ct", "markdown");
 
       List<Map<String, Object>> children = new ArrayList<>();
-      buildGbStructure(n.children, children, content, bodies, lang, slugify);
+      buildGbStructure(n.children, children, content, bodies, lang, slugify, hrefDirByCode);
 
       Map<String, Object> node = new LinkedHashMap<>();
       node.put("code", code);
@@ -223,6 +244,185 @@ public class WikiGithubImportService {
       pool.shutdown();
     }
     return out;
+  }
+
+  // ── attachments ────────────────────────────────────────────────────────────
+
+  // Markdown image / link, with an optional <bracketed> URL (so asset names with spaces parse).
+  private static final Pattern MD_IMAGE = Pattern.compile("!\\[([^\\]]*)]\\(\\s*(?:<([^>]*)>|([^)\\s]+))\\s*(?:\"[^\"]*\")?\\)");
+  private static final Pattern MD_LINK = Pattern.compile("(?<!!)\\[([^\\]]*)]\\(\\s*(?:<([^>]*)>|([^)\\s]+))\\s*(?:\"[^\"]*\")?\\)");
+  private static final Pattern FILES_REF = Pattern.compile("files/(\\d+)/(.+)");
+  private static final Map<String, String> CONTENT_TYPES = Map.of(
+      "png", "image/png", "jpg", "image/jpeg", "jpeg", "image/jpeg", "gif", "image/gif",
+      "svg", "image/svg+xml", "webp", "image/webp", "pdf", "application/pdf");
+
+  /** After the pages exist, fetch each page's referenced images/files, store them as page
+   * attachments and rewrite the references to {@code ![alt](files/<pageId>/<name>)}. A content hash
+   * lets a re-import skip files that are already attached unchanged. */
+  private int importAttachments(Long spaceId, GithubCoords coords, String branch, String prefix, String token,
+                                boolean gitbook, Map<String, String> hrefDirByCode) {
+    int[] stored = {0};
+    List<Page> pages = pageService.query(new PageQueryParams().setSpaceIds(spaceId.toString()).all()).getData();
+    for (Page page : pages) {
+      String hrefDir = gitbook ? hrefDirByCode.getOrDefault(page.getCode(), "") : "";
+      for (PageContent pc : pageContentService.loadAll(page.getId())) {
+        String body = pc.getContent();
+        if (body == null || body.isEmpty()) {
+          continue;
+        }
+        Map<String, String> cache = new HashMap<>(); // repoPath -> stored (sanitized) name, fetched once
+        String updated = rewriteAssets(body, MD_IMAGE, true, page.getId(), prefix, gitbook, hrefDir, coords, branch, token, cache, stored);
+        updated = rewriteAssets(updated, MD_LINK, false, page.getId(), prefix, gitbook, hrefDir, coords, branch, token, cache, stored);
+        if (!updated.equals(body)) {
+          pc.setContent(updated);
+          pageContentService.save(pc, page.getId());
+        }
+      }
+    }
+    return stored[0];
+  }
+
+  private String rewriteAssets(String body, Pattern pattern, boolean image, Long pageId, String prefix,
+                               boolean gitbook, String hrefDir, GithubCoords coords, String branch, String token,
+                               Map<String, String> cache, int[] stored) {
+    Matcher m = pattern.matcher(body);
+    StringBuilder sb = new StringBuilder();
+    while (m.find()) {
+      String label = m.group(1);
+      String url = m.group(2) != null ? m.group(2).trim() : m.group(3);
+      String replacement = m.group(); // keep the original unless we import the asset
+      if (importableAsset(url, image, pageId)) {
+        try {
+          String repoPath = resolveRepoPath(url, prefix, gitbook, hrefDir);
+          String name = cache.get(repoPath);
+          if (name == null && !cache.containsKey(repoPath)) {
+            byte[] bytes = fetchBytes(coords, branch, repoPath, token);
+            name = bytes == null ? null : safeFileName(attachmentName(url));
+            if (bytes != null) {
+              storeAttachment(pageId, name, bytes);
+            }
+            cache.put(repoPath, name);
+          }
+          if (name != null) {
+            replacement = (image ? "!" : "") + "[" + label + "](files/" + pageId + "/" + name + ")";
+            stored[0]++;
+          }
+        } catch (Exception e) {
+          log.warn("skipping attachment '{}' on page {}: {}", url, pageId, e.getMessage());
+        }
+      }
+      m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+    }
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  private boolean importableAsset(String url, boolean image, Long thisPageId) {
+    if (url == null || url.isEmpty() || url.matches("(?i)^(https?:|mailto:|tel:|data:|#).*")
+        || url.startsWith("files/" + thisPageId + "/")) {
+      return false;
+    }
+    return image // all local images are assets; links only when they clearly point at one
+        || url.contains(".gitbook/assets/") || url.startsWith("attachments/") || FILES_REF.matcher(url).matches();
+  }
+
+  /** A file name safe for a wiki attachment reference (no spaces or special characters). */
+  private static String safeFileName(String name) {
+    String s = name.replaceAll("[^A-Za-z0-9._-]+", "-").replaceAll("-+\\.", ".").replaceAll("-{2,}", "-").replaceAll("^-|-$", "");
+    return s.isEmpty() ? "file" : s;
+  }
+
+  private String attachmentName(String ref) {
+    String name = ref.contains("/") ? StringUtils.substringAfterLast(ref, "/") : ref;
+    return StringUtils.substringBefore(StringUtils.substringBefore(name, "?"), "#");
+  }
+
+  private String resolveRepoPath(String ref, String prefix, boolean gitbook, String hrefDir) {
+    Matcher fm = FILES_REF.matcher(ref);
+    if (fm.matches()) {
+      return prefix + "attachments/" + fm.group(1) + "/" + fm.group(2); // TermX export layout
+    }
+    if (ref.contains(".gitbook/assets/")) {
+      return prefix + ".gitbook/assets/" + attachmentName(ref); // GitBook assets live at the book root
+    }
+    String base = gitbook && StringUtils.isNotBlank(hrefDir) ? hrefDir + "/" : "";
+    return normalizePath(prefix + base + ref);
+  }
+
+  /** Resolves {@code ./} and {@code ../} segments in a repo path. */
+  private static String normalizePath(String path) {
+    Deque<String> stack = new ArrayDeque<>();
+    for (String seg : path.split("/")) {
+      if (seg.isEmpty() || seg.equals(".")) {
+        continue;
+      }
+      if (seg.equals("..")) {
+        if (!stack.isEmpty()) {
+          stack.removeLast();
+        }
+      } else {
+        stack.addLast(seg);
+      }
+    }
+    return String.join("/", stack);
+  }
+
+  /** Stores bytes as a page attachment, skipping the upload when an identical file (same name and
+   * content hash) is already attached; replaces it when the name matches but the content differs. */
+  private void storeAttachment(Long pageId, String fileName, byte[] bytes) {
+    String hash = sha256(bytes);
+    boolean present = pageAttachmentService.getAttachments(pageId).stream()
+        .anyMatch(a -> fileName.equals(a.getFileName()));
+    if (present) {
+      try {
+        byte[] cur = IOUtils.toByteArray(pageAttachmentService.getAttachmentContent(pageId, fileName).getInputStream());
+        if (sha256(cur).equals(hash)) {
+          return; // identical — reuse the existing attachment
+        }
+      } catch (Exception ignore) {
+        // couldn't read the existing one; fall through and replace
+      }
+      pageAttachmentService.deleteAttachmentContent(pageId, fileName);
+    }
+    Attachment a = new Attachment()
+        .setFileName(fileName)
+        .setContentType(contentTypeOf(fileName))
+        .setContent(bytes)
+        .setContentLength((long) bytes.length);
+    pageAttachmentService.saveAttachments(pageId, Map.of(fileName, a));
+  }
+
+  private byte[] fetchBytes(GithubCoords c, String branch, String path, String token) {
+    HttpRequest.Builder b = HttpRequest.newBuilder(URI.create(rawUrl(c, branch, path))).GET()
+        .header("User-Agent", "termx-wiki-import");
+    if (StringUtils.isNotBlank(token)) {
+      b.header("Authorization", "Bearer " + token);
+    }
+    try {
+      HttpResponse<byte[]> resp = http.send(b.build(), HttpResponse.BodyHandlers.ofByteArray());
+      if (resp.statusCode() == 404) {
+        return null;
+      }
+      if (resp.statusCode() >= 400) {
+        throw new RuntimeException("HTTP " + resp.statusCode());
+      }
+      return resp.body();
+    } catch (Exception e) {
+      throw new RuntimeException("failed to fetch " + path, e);
+    }
+  }
+
+  private static String sha256(byte[] bytes) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static String contentTypeOf(String fileName) {
+    String ext = fileName.contains(".") ? StringUtils.substringAfterLast(fileName, ".").toLowerCase() : "";
+    return CONTENT_TYPES.getOrDefault(ext, "application/octet-stream");
   }
 
   private static final Pattern GB_SECTION = Pattern.compile("^#{2,}\\s+(.+?)\\s*$");
@@ -303,8 +503,18 @@ public class WikiGithubImportService {
         .orElseThrow(() -> new RuntimeException("no pages.json (TermX) or SUMMARY.md (GitBook) found in the repository"));
   }
 
+  // Percent-encodes the path so asset names with spaces/special characters resolve on the CDN.
+  private static String rawUrl(GithubCoords c, String branch, String path) {
+    try {
+      return new URI("https", "raw.githubusercontent.com",
+          "/" + c.owner() + "/" + c.repo() + "/" + branch + "/" + path, null).toASCIIString();
+    } catch (java.net.URISyntaxException e) {
+      throw new RuntimeException("bad path: " + path, e);
+    }
+  }
+
   private String fetchRaw(GithubCoords c, String branch, String path, String token) {
-    String url = GITHUB_RAW + "/" + c.owner() + "/" + c.repo() + "/" + branch + "/" + path;
+    String url = rawUrl(c, branch, path);
     HttpResponse<String> resp = send(url, token, "text/plain");
     if (resp.statusCode() == 404) {
       return null;

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
@@ -192,9 +192,10 @@ public class WikiGithubImportService {
   }
 
   /** Fetches many raw files concurrently (bounded pool), returning key -> body for those that
-   * exist (404s are skipped). `stripFm` drops a leading YAML frontmatter block (GitBook). */
+   * exist (404s are skipped). When `gitbook` is set, each body is normalized for the TermX wiki
+   * renderer (frontmatter, card tables, file/hint blocks) via {@link GitbookConverter}. */
   private Map<String, String> fetchAll(Map<String, String> keyToPath, GithubCoords coords, String branch,
-                                       String token, boolean stripFm) {
+                                       String token, boolean gitbook) {
     Map<String, String> out = new ConcurrentHashMap<>();
     if (keyToPath.isEmpty()) {
       return out;
@@ -204,8 +205,8 @@ public class WikiGithubImportService {
       List<Future<?>> futures = new ArrayList<>();
       keyToPath.forEach((key, path) -> futures.add(pool.submit(() -> {
         String body = fetchRaw(coords, branch, path, token);
-        if (stripFm) {
-          body = stripFrontmatter(body);
+        if (gitbook) {
+          body = GitbookConverter.convert(body);
         }
         if (body != null) {
           out.put(key, body);
@@ -222,14 +223,6 @@ public class WikiGithubImportService {
       pool.shutdown();
     }
     return out;
-  }
-
-  // GitBook pages carry a leading YAML frontmatter block (e.g. `--- icon: … ---`) that TermX
-  // doesn't model and would otherwise render as literal text. Drop it.
-  private static final Pattern GB_FRONTMATTER = Pattern.compile("^\\uFEFF?---\\r?\\n.*?\\r?\\n---\\r?\\n", Pattern.DOTALL);
-
-  private static String stripFrontmatter(String body) {
-    return body == null ? null : GB_FRONTMATTER.matcher(body).replaceFirst("");
   }
 
   private static final Pattern GB_SECTION = Pattern.compile("^#{2,}\\s+(.+?)\\s*$");

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiImportController.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiImportController.java
@@ -1,0 +1,31 @@
+package org.termx.wiki.importer;
+
+import org.termx.core.auth.Authorized;
+import org.termx.core.auth.SessionStore;
+import org.termx.core.sys.provenance.Provenance;
+import org.termx.core.sys.provenance.ProvenanceService;
+import org.termx.wiki.Privilege;
+import io.micronaut.http.annotation.Body;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.validation.Validated;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@Controller("/wiki-import")
+@RequiredArgsConstructor
+public class WikiImportController {
+  private final WikiGithubImportService importService;
+  private final ProvenanceService provenanceService;
+
+  /** Import a Space's pages directly from a GitHub repository (no git integration required). */
+  @Authorized(Privilege.W_WRITE)
+  @Post("/github")
+  public WikiGithubImportResult importFromGithub(@Body @Valid WikiGithubImportRequest request) {
+    SessionStore.require().checkPermitted(request.getSpaceId().toString(), Privilege.W_WRITE);
+    WikiGithubImportResult result = importService.importSpace(request);
+    provenanceService.create(new Provenance("modified", "Space", request.getSpaceId().toString()));
+    return result;
+  }
+}

--- a/wiki/src/main/java/org/termx/wiki/migration/WikiContentConvergenceChange.java
+++ b/wiki/src/main/java/org/termx/wiki/migration/WikiContentConvergenceChange.java
@@ -1,0 +1,75 @@
+package org.termx.wiki.migration;
+
+import liquibase.change.custom.CustomTaskChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import org.termx.wiki.WikiContentNormalizer;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+/**
+ * One-time migration that converges existing wiki page content to mdbook-compatible syntax
+ * (see {@link WikiContentNormalizer} and {@code docs/wiki-mdbook-syntax.md}). For every active
+ * page content whose body would change, the verbatim original is preserved in
+ * {@code bak_content} and {@code content} is replaced with the normalized form. Rows that need
+ * no change are left untouched (including {@code bak_content}), so the migration is idempotent.
+ */
+public class WikiContentConvergenceChange implements CustomTaskChange {
+  private String confirmationMessage = "wiki.page_content converged to mdbook-compatible syntax";
+
+  @Override
+  public void execute(Database database) throws CustomChangeException {
+    Connection conn = ((JdbcConnection) database.getConnection()).getUnderlyingConnection();
+    int rewritten = 0;
+    try (Statement select = conn.createStatement();
+         ResultSet rs = select.executeQuery(
+             "select id, content from wiki.page_content where sys_status = 'A' and content is not null");
+         PreparedStatement update = conn.prepareStatement(
+             "update wiki.page_content set bak_content = ?, content = ? where id = ?")) {
+      while (rs.next()) {
+        long id = rs.getLong("id");
+        String content = rs.getString("content");
+        String normalized = WikiContentNormalizer.normalize(content);
+        if (!normalized.equals(content)) {
+          update.setString(1, content);    // bak_content = verbatim original
+          update.setString(2, normalized); // content = converged form
+          update.setLong(3, id);
+          update.addBatch();
+          rewritten++;
+        }
+      }
+      update.executeBatch();
+      confirmationMessage = "wiki.page_content convergence: " + rewritten
+          + " row(s) rewritten (originals saved to bak_content)";
+    } catch (Exception e) {
+      throw new CustomChangeException("Wiki content convergence failed", e);
+    }
+  }
+
+  @Override
+  public String getConfirmationMessage() {
+    return confirmationMessage;
+  }
+
+  @Override
+  public void setUp() throws SetupException {
+    // no setup required
+  }
+
+  @Override
+  public void setFileOpener(ResourceAccessor resourceAccessor) {
+    // no resources required
+  }
+
+  @Override
+  public ValidationErrors validate(Database database) {
+    return new ValidationErrors();
+  }
+}

--- a/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentHistoryRepository.java
+++ b/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentHistoryRepository.java
@@ -65,6 +65,7 @@ public class PageContentHistoryRepository extends BaseRepository {
     ssb.property("lang", content.getLang());
     ssb.property("content_type", content.getContentType());
     ssb.property("content", content.getContent());
+    ssb.property("description", content.getDescription());
     ssb.property("created_at", content.getCreatedAt());
     ssb.property("created_by", content.getCreatedBy());
     ssb.property("modified_at", content.getModifiedAt());

--- a/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentRepository.java
+++ b/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentRepository.java
@@ -87,6 +87,7 @@ public class PageContentRepository extends BaseRepository {
     ssb.property("lang", content.getLang());
     ssb.property("content", content.getContent());
     ssb.property("content_type", content.getContentType());
+    ssb.property("description", content.getDescription());
     SqlBuilder sb = ssb.buildSave("wiki.page_content", "id");
     return jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());
   }

--- a/wiki/src/main/resources/wiki/changelog/wiki/31-page-content.sql
+++ b/wiki/src/main/resources/wiki/changelog/wiki/31-page-content.sql
@@ -68,3 +68,12 @@ create table wiki.page_content_history (
     constraint page_content_page_content_fk foreign key (page_content_id) references wiki.page_content(id)
 );
 --
+
+--changeset wiki:page_content-seo
+alter table wiki.page_content add column description text;
+alter table wiki.page_content_history add column description text;
+--
+
+--changeset wiki:page_content-bak
+alter table wiki.page_content add column bak_content text;
+--

--- a/wiki/src/main/resources/wiki/changelog/wiki/36-space-language-backfill.sql
+++ b/wiki/src/main/resources/wiki/changelog/wiki/36-space-language-backfill.sql
@@ -1,0 +1,23 @@
+--liquibase formatted sql
+
+-- Backfill space-level language metadata (added in termx-core sys:space-ssg-metadata)
+-- from the languages that already exist in each space's page content. Runs in the wiki
+-- module so both sys.space and wiki.page_content are present. Only fills nulls, so it is
+-- a no-op once a space owns explicit language settings.
+
+--changeset wiki:space-language-backfill
+update sys.space s set languages = sub.langs
+from (
+  select space_id, jsonb_agg(distinct lang order by lang) as langs
+  from wiki.page_content
+  where sys_status = 'A'
+  group by space_id
+) sub
+where sub.space_id = s.id and s.languages is null;
+
+-- Default language only when unambiguous: leave null (mdbook falls back to site.lang /
+-- the first language) unless the space actually publishes English.
+update sys.space
+set default_language = 'en'
+where default_language is null and languages @> '["en"]'::jsonb;
+--

--- a/wiki/src/main/resources/wiki/changelog/wiki/37-content-convergence.xml
+++ b/wiki/src/main/resources/wiki/changelog/wiki/37-content-convergence.xml
@@ -1,0 +1,14 @@
+<databaseChangeLog
+                xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <!-- One-time convergence of existing page content to mdbook-compatible syntax.
+         Originals are preserved in wiki.page_content.bak_content. See
+         docs/wiki-mdbook-syntax.md and org.termx.wiki.WikiContentNormalizer. -->
+    <changeSet id="content-convergence" author="wiki">
+        <customChange class="org.termx.wiki.migration.WikiContentConvergenceChange"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/wiki/src/main/resources/wiki/changelog/wiki/changelog.xml
+++ b/wiki/src/main/resources/wiki/changelog/wiki/changelog.xml
@@ -14,4 +14,6 @@
     <include file="33-page-relation.sql" relativeToChangelogFile="true"/>
     <include file="34-page-tag.sql" relativeToChangelogFile="true"/>
     <include file="35-page-comment.sql" relativeToChangelogFile="true"/>
+    <include file="36-space-language-backfill.sql" relativeToChangelogFile="true"/>
+    <include file="37-content-convergence.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/wiki/src/test/groovy/org/termx/wiki/WikiContentNormalizerTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/WikiContentNormalizerTest.groovy
@@ -1,0 +1,59 @@
+package org.termx.wiki
+
+import spock.lang.Specification
+
+class WikiContentNormalizerTest extends Specification {
+
+  def 'R1: attribute-less span autolink-breaker becomes an invisible HTML comment'() {
+    expect:
+    WikiContentNormalizer.normalize('Draw.<span>io') == 'Draw.<!-- -->io'
+    WikiContentNormalizer.normalize('a <span >b') == 'a <!-- -->b'
+    and: 'an empty <span></span> pair collapses to a single comment (no orphan close)'
+    WikiContentNormalizer.normalize('Draw.<span></span>io') == 'Draw.<!-- -->io'
+  }
+
+  def 'R1: a standalone closing </span> is left alone (belongs to an attributed span)'() {
+    expect:
+    WikiContentNormalizer.normalize('text</span>') == 'text</span>'
+  }
+
+  def 'R1: the rewrite breaks auto-linking in both renderers (dot is not rejoined into a link)'() {
+    when:
+    def out = WikiContentNormalizer.normalize('See Draw.<span>io for details')
+
+    then: 'the comment sits between "Draw." and "io" so markdown-it linkify cannot form a link'
+    out == 'See Draw.<!-- -->io for details'
+    !out.contains('<span')
+  }
+
+  def 'R1: spans carrying attributes are meaningful and left untouched'() {
+    expect:
+    WikiContentNormalizer.normalize('<span class="x">hi</span>') == '<span class="x">hi</span>'
+    WikiContentNormalizer.normalize('<span style="color:red">hi</span>') == '<span style="color:red">hi</span>'
+  }
+
+  def 'R2: stray fenced-code language s is aliased to sh'() {
+    when:
+    def out = WikiContentNormalizer.normalize('```s\necho hi\n```')
+
+    then:
+    out == '```sh\necho hi\n```'
+  }
+
+  def 'R2: real languages and diagram fences are not touched'() {
+    expect:
+    WikiContentNormalizer.normalize('```json\n{}\n```') == '```json\n{}\n```'
+    WikiContentNormalizer.normalize('```plantuml\n@startuml\n```') == '```plantuml\n@startuml\n```'
+    and: 'a closing fence carries no language, so it never matches'
+    WikiContentNormalizer.normalize('```\nplain\n```') == '```\nplain\n```'
+  }
+
+  def 'unchanged / empty / null content is returned as-is'() {
+    expect:
+    WikiContentNormalizer.normalize('# Title\n\nJust text.') == '# Title\n\nJust text.'
+    WikiContentNormalizer.normalize('') == ''
+    WikiContentNormalizer.normalize(null) == null
+    !WikiContentNormalizer.needsNormalization('# Title\n\nJust text.')
+    WikiContentNormalizer.needsNormalization('Draw.<span>io')
+  }
+}

--- a/wiki/src/test/groovy/org/termx/wiki/importer/GitbookConverterTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/importer/GitbookConverterTest.groovy
@@ -35,9 +35,23 @@ class GitbookConverterTest extends Specification {
     out.contains('<td>a</td>')
   }
 
+  def 'figure/div-wrapped image is unwrapped to a standalone markdown image'() {
+    when:
+    def out = GitbookConverter.convert('<div align="left"><figure><img src=".gitbook/assets/a b.png" alt="" width="375"><figcaption></figcaption></figure></div>')
+
+    then: 'no HTML block wrapper remains (markdown inside HTML is not rendered)'
+    out == '![](<.gitbook/assets/a b.png>)'
+  }
+
+  def 'raw <img> becomes a markdown image (angle-bracketed so spaces stay valid)'() {
+    expect:
+    GitbookConverter.convert('<img src=".gitbook/assets/a b.png" alt="Me">') == '![Me](<.gitbook/assets/a b.png>)'
+    GitbookConverter.convert('<img src="x.png">') == '![](<x.png>)'
+  }
+
   def 'file embed becomes a link to the source'() {
     expect:
-    GitbookConverter.convert('{% file src=".gitbook/assets/CV.pdf" %}') == '[CV.pdf](.gitbook/assets/CV.pdf)'
+    GitbookConverter.convert('{% file src=".gitbook/assets/CV.pdf" %}') == '[CV.pdf](<.gitbook/assets/CV.pdf>)'
   }
 
   def 'hint becomes a TermX callout blockquote'() {

--- a/wiki/src/test/groovy/org/termx/wiki/importer/GitbookConverterTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/importer/GitbookConverterTest.groovy
@@ -1,0 +1,56 @@
+package org.termx.wiki.importer
+
+import spock.lang.Specification
+
+class GitbookConverterTest extends Specification {
+
+  def 'strips leading YAML frontmatter'() {
+    expect:
+    GitbookConverter.convert('---\nicon: briefcase\n---\n\n# Title\n\nBody.') == '\n# Title\n\nBody.'
+  }
+
+  def 'card table: drops data-hidden columns (and their null cells) and the data-view attribute'() {
+    given:
+    def html = '<table data-view="cards"><thead><tr><th></th><th></th><th data-hidden data-type="number"></th></tr></thead>' +
+        '<tbody><tr><td><strong>WHO</strong></td><td><em>expert</em></td><td>null</td></tr></tbody></table>'
+
+    when:
+    def out = GitbookConverter.convert(html)
+
+    then:
+    !out.contains('data-view')
+    !out.contains('data-hidden')
+    !out.contains('null')           // the hidden number column carried the stray "null"
+    out.contains('<strong>WHO</strong>')
+    out.contains('<em>expert</em>')
+  }
+
+  def 'card table with all-empty headers drops the header row'() {
+    when:
+    def out = GitbookConverter.convert('<table data-view="cards"><thead><tr><th></th><th></th></tr></thead>' +
+        '<tbody><tr><td>a</td><td>b</td></tr></tbody></table>')
+
+    then:
+    !out.contains('<thead')
+    out.contains('<td>a</td>')
+  }
+
+  def 'file embed becomes a link to the source'() {
+    expect:
+    GitbookConverter.convert('{% file src=".gitbook/assets/CV.pdf" %}') == '[CV.pdf](.gitbook/assets/CV.pdf)'
+  }
+
+  def 'hint becomes a TermX callout blockquote'() {
+    when:
+    def out = GitbookConverter.convert('{% hint style="warning" %}\nBe careful\n{% endhint %}')
+
+    then:
+    out == '> Be careful\n{.is-warning}'
+  }
+
+  def 'null and unchanged content pass through'() {
+    expect:
+    GitbookConverter.convert(null) == null
+    GitbookConverter.convert('# Plain\n\nNothing to convert.') == '# Plain\n\nNothing to convert.'
+  }
+}


### PR DESCRIPTION
## What

Two related changes for publishing TermX Wiki spaces as static sites (via mdbook) and for getting content in and out more easily.

### Metadata, content convergence, and tags export
- **Page/space SEO metadata** — `PageContent.description` and `Space` `description`/`defaultLanguage`/`languages`/`siteUrl`, exported in `space.json`/`pages.json`. Each exported page's markdown gets its title materialized as an H1.
- **Language backfill** — existing spaces get `languages`/`default_language` from their page-content languages.
- **Content convergence** — a one-time migration rewrites `<span>` autolink-breakers and stray fence languages (` ```s ` → ` ```sh `) to a form the wiki and mdbook render identically, keeping the original in `page_content.bak_content`. Rules live in `WikiContentNormalizer` (unit-tested) and are documented in `docs/wiki-mdbook-syntax.md`.
- **Keywords from tags** — page `tags` are exported (the generator renders them as `<meta keywords>`) instead of a separate per-content keywords field.

### Import a wiki space directly from GitHub
- `POST /wiki-import/github` fetches a space's content straight from a public or private (token) GitHub repository, **without** configuring the space's git integration. Handles the round-trip `wiki` and `wiki-ssg` exports and **GitBook** (`SUMMARY.md`); auto-detects branch + content directory; fetches markdown concurrently; imports through the existing round-trip parser.

## Validation
- Boots against an empty DB; all changesets apply and the convergence migration runs (verified `bak_content` set only on rewritten rows, idempotent).
- Imported the TermX tutorial (77 pages, wiki-ssg) and the portfolio (19 pages, GitBook, private repo via token) end-to-end; validated pages, hierarchy and content in the wiki UI.

## Follow-ups (not in this PR)
- **Slug stability** — slugs are re-derived from the page name on save, so a rename changes the published URL. This is a separate, repo-wide behavioral change and deserves its own PR.
- Import does not fetch attachments/images (surfaced in the UI). Import is synchronous per request; the file fetches are parallelized.

Pairs with the termx-web and igorboss/mdbook PRs. Not for merge yet.
