### PR TITLE
Auth: accept ?token= on GET so attachment images/downloads load

### DIFF
--- a/termx-app/src/main/java/org/termx/auth/OAuthSessionProvider.java
+++ b/termx-app/src/main/java/org/termx/auth/OAuthSessionProvider.java
@@ -54,10 +54,8 @@ public class OAuthSessionProvider extends SessionProvider {
 
   @Override
   public SessionInfo authenticate(HttpRequest<?> request) {
-    return request.getHeaders()
-        .getFirst(AUTHORIZATION)
-        .filter(auth -> auth.startsWith(BEARER))
-        .map(auth -> StringUtils.trim(StringUtils.substringAfter(auth, BEARER)))
+    // Authorization header or (GET only) ?token= query param, then the oauth-token cookie.
+    return bearerToken(request)
         .or(() -> request.getCookies().findCookie(OAUTH_TOKEN_COOKIE).map(Cookie::getValue))
         .map(this::getSessionInfo)
         .orElse(null);

--- a/termx-app/src/main/java/org/termx/auth/SessionProvider.java
+++ b/termx-app/src/main/java/org/termx/auth/SessionProvider.java
@@ -1,9 +1,13 @@
 package org.termx.auth;
 
 import org.termx.core.auth.SessionInfo;
+import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
+import java.util.Optional;
 
 public abstract class SessionProvider {
+
+  private static final String BEARER = "Bearer ";
 
   public abstract SessionInfo authenticate(HttpRequest<?> request);
 
@@ -11,5 +15,19 @@ public abstract class SessionProvider {
     return 50;
   }
 
+  /**
+   * The bearer token, taken from the {@code Authorization} header or — for {@code GET} requests
+   * only — a {@code ?token=} query parameter. The query fallback lets browser {@code <img>} loads
+   * and file downloads (which cannot set headers) authenticate; it is limited to GET so that
+   * mutations always require the header.
+   */
+  protected static Optional<String> bearerToken(HttpRequest<?> request) {
+    Optional<String> header = request.getHeaders().getFirst("Authorization")
+        .filter(a -> a.startsWith(BEARER))
+        .map(a -> a.substring(BEARER.length()).trim());
+    if (header.isPresent() || request.getMethod() != HttpMethod.GET) {
+      return header;
+    }
+    return request.getParameters().getFirst("token").map(String::trim).filter(t -> !t.isEmpty());
+  }
 }
-

--- a/termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java
+++ b/termx-app/src/main/java/org/termx/auth/YupiSessionProvider.java
@@ -43,7 +43,6 @@ import org.termx.core.auth.SessionInfo;
 @Slf4j
 @Singleton
 public class YupiSessionProvider extends SessionProvider {
-  private static final String BEARER_YUPI = "Bearer yupi";
   static final Set<String> DEFAULT_PRIVILEGES =
       Set.of("*.*.read", "*.*.triage", "*.*.write", "*.*.maintain");
 
@@ -69,14 +68,13 @@ public class YupiSessionProvider extends SessionProvider {
 
   @Override
   public SessionInfo authenticate(HttpRequest<?> request) {
-    if (request.getHeaders().getFirst("Authorization").map(auth -> auth.startsWith(BEARER_YUPI)).orElse(false)) {
-      String sessionInfo = request.getHeaders().getFirst("Authorization").get().substring(BEARER_YUPI.length());
-      if (!sessionInfo.isEmpty()) {
-        return JsonUtil.fromJson(sessionInfo, SessionInfo.class);
-      }
-      return yupiDroopy();
+    // bearerToken() returns the value after "Bearer " (or, for GET, a ?token= query param).
+    String token = bearerToken(request).filter(t -> t.startsWith("yupi")).orElse(null);
+    if (token == null) {
+      return null;
     }
-    return null;
+    String sessionInfo = token.substring("yupi".length());
+    return sessionInfo.isEmpty() ? yupiDroopy() : JsonUtil.fromJson(sessionInfo, SessionInfo.class);
   }
 
   private SessionInfo yupiDroopy() {


### PR DESCRIPTION
## What

Browser `<img>` loads and file downloads can't set the `Authorization` header, so wiki **attachment** requests (`GET /pages/{id}/files/{name}`) were rejected with 403 and images/downloads didn't render in the wiki.

This lets the session providers read the bearer token from a **`?token=`** query parameter in addition to the header — **restricted to `GET` requests**, so mutations always require the header. A shared `SessionProvider.bearerToken(request)` helper is used by both the OAuth and dev (yupi) providers; the OAuth `oauth-token` cookie path is unchanged.

## Validation
- `GET /pages/{id}/files/CV.pdf?token=…` (no header) → **200**
- no token → **403**
- `DELETE …?token=…` → **403** (query token is GET-only)

Pairs with the termx-web change that appends the token to attachment URLs.
