### PR TITLE
Test: GitHub-import path resolution and attachment dedup

### DIFF
--- a/wiki/build.gradle.kts
+++ b/wiki/build.gradle.kts
@@ -28,4 +28,6 @@ dependencies {
     testImplementation("org.spockframework:spock-core") {
         exclude(group = "org.codehaus.groovy", module = "groovy-all")
     }
+    testImplementation("net.bytebuddy:byte-buddy:1.17.8") // lets Spock mock concrete classes
+    testImplementation("org.objenesis:objenesis:3.4")
 }

--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
@@ -317,7 +317,7 @@ public class WikiGithubImportService {
     return sb.toString();
   }
 
-  private boolean importableAsset(String url, boolean image, Long thisPageId) {
+  static boolean importableAsset(String url, boolean image, Long thisPageId) {
     if (url == null || url.isEmpty() || url.matches("(?i)^(https?:|mailto:|tel:|data:|#).*")
         || url.startsWith("files/" + thisPageId + "/")) {
       return false;
@@ -327,17 +327,17 @@ public class WikiGithubImportService {
   }
 
   /** A file name safe for a wiki attachment reference (no spaces or special characters). */
-  private static String safeFileName(String name) {
+  static String safeFileName(String name) {
     String s = name.replaceAll("[^A-Za-z0-9._-]+", "-").replaceAll("-+\\.", ".").replaceAll("-{2,}", "-").replaceAll("^-|-$", "");
     return s.isEmpty() ? "file" : s;
   }
 
-  private String attachmentName(String ref) {
+  static String attachmentName(String ref) {
     String name = ref.contains("/") ? StringUtils.substringAfterLast(ref, "/") : ref;
     return StringUtils.substringBefore(StringUtils.substringBefore(name, "?"), "#");
   }
 
-  private String resolveRepoPath(String ref, String prefix, boolean gitbook, String hrefDir) {
+  static String resolveRepoPath(String ref, String prefix, boolean gitbook, String hrefDir) {
     Matcher fm = FILES_REF.matcher(ref);
     if (fm.matches()) {
       return prefix + "attachments/" + fm.group(1) + "/" + fm.group(2); // TermX export layout
@@ -350,7 +350,7 @@ public class WikiGithubImportService {
   }
 
   /** Resolves {@code ./} and {@code ../} segments in a repo path. */
-  private static String normalizePath(String path) {
+  static String normalizePath(String path) {
     Deque<String> stack = new ArrayDeque<>();
     for (String seg : path.split("/")) {
       if (seg.isEmpty() || seg.equals(".")) {
@@ -369,7 +369,7 @@ public class WikiGithubImportService {
 
   /** Stores bytes as a page attachment, skipping the upload when an identical file (same name and
    * content hash) is already attached; replaces it when the name matches but the content differs. */
-  private void storeAttachment(Long pageId, String fileName, byte[] bytes) {
+  void storeAttachment(Long pageId, String fileName, byte[] bytes) {
     String hash = sha256(bytes);
     boolean present = pageAttachmentService.getAttachments(pageId).stream()
         .anyMatch(a -> fileName.equals(a.getFileName()));
@@ -412,7 +412,7 @@ public class WikiGithubImportService {
     }
   }
 
-  private static String sha256(byte[] bytes) {
+  static String sha256(byte[] bytes) {
     try {
       return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
     } catch (Exception e) {

--- a/wiki/src/test/groovy/org/termx/wiki/importer/WikiGithubImportServiceTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/importer/WikiGithubImportServiceTest.groovy
@@ -1,0 +1,130 @@
+package org.termx.wiki.importer
+
+import io.micronaut.http.MediaType
+import io.micronaut.http.server.types.files.StreamedFile
+import org.termx.core.sys.space.SpaceService
+import org.termx.wiki.SpaceGithubDataWikiHandler
+import org.termx.wiki.page.Page
+import org.termx.wiki.page.PageService
+import org.termx.wiki.pageattachment.PageAttachmentService
+import org.termx.wiki.pagecontent.PageContentService
+import spock.lang.Specification
+
+class WikiGithubImportServiceTest extends Specification {
+
+  // ── asset path resolution ──────────────────────────────────────────────────
+
+  def 'resolveRepoPath: TermX files/<id>/ maps to the attachments/ layout'() {
+    expect:
+    WikiGithubImportService.resolveRepoPath('files/64/pm.png', 'source/', false, '') == 'source/attachments/64/pm.png'
+  }
+
+  def 'resolveRepoPath: GitBook .gitbook/assets always resolves to the book root, regardless of ../'() {
+    expect:
+    WikiGithubImportService.resolveRepoPath('../.gitbook/assets/CV.pdf', 'source/', true, 'general') == 'source/.gitbook/assets/CV.pdf'
+    WikiGithubImportService.resolveRepoPath('.gitbook/assets/a b.png', 'source/', true, 'general/sub') == 'source/.gitbook/assets/a b.png'
+  }
+
+  def 'resolveRepoPath: a page-relative asset is resolved against the page directory'() {
+    expect:
+    WikiGithubImportService.resolveRepoPath('img/x.png', 'source/', true, 'general') == 'source/general/img/x.png'
+    WikiGithubImportService.resolveRepoPath('../img/x.png', 'source/', true, 'general/sub') == 'source/general/img/x.png'
+  }
+
+  def 'normalizePath: resolves ./ and ../ segments'() {
+    expect:
+    WikiGithubImportService.normalizePath('a/b/../c') == 'a/c'
+    WikiGithubImportService.normalizePath('a/./b') == 'a/b'
+    WikiGithubImportService.normalizePath('a//b/') == 'a/b'
+  }
+
+  // ── file names ──────────────────────────────────────────────────────────────
+
+  def 'safeFileName: strips spaces and special characters, keeps the extension'() {
+    expect:
+    WikiGithubImportService.safeFileName('Igor @ Valukoja 8 (1).jpeg') == 'Igor-Valukoja-8-1.jpeg'
+    WikiGithubImportService.safeFileName('IgorBossenkoCV.pdf') == 'IgorBossenkoCV.pdf'
+    WikiGithubImportService.safeFileName('a  b.png') == 'a-b.png'
+  }
+
+  def 'attachmentName: takes the basename, dropping query/anchor'() {
+    expect:
+    WikiGithubImportService.attachmentName('.gitbook/assets/x.png') == 'x.png'
+    WikiGithubImportService.attachmentName('files/1/a.png?v=2') == 'a.png'
+  }
+
+  // ── which references get imported ────────────────────────────────────────────
+
+  def 'importableAsset: external, anchor and self-references are skipped'() {
+    expect:
+    !WikiGithubImportService.importableAsset('https://x.io/a.png', true, 1L)
+    !WikiGithubImportService.importableAsset('#section', true, 1L)
+    !WikiGithubImportService.importableAsset('files/1/a.png', true, 1L) // already this page's attachment
+  }
+
+  def 'importableAsset: all local images, but only asset-like links'() {
+    expect:
+    WikiGithubImportService.importableAsset('.gitbook/assets/a.png', true, 1L)   // image
+    WikiGithubImportService.importableAsset('.gitbook/assets/cv.pdf', false, 1L) // asset link
+    WikiGithubImportService.importableAsset('files/2/a.png', false, 1L)          // asset link (other page)
+    and: 'semantic links are left alone'
+    !WikiGithubImportService.importableAsset('page:home', false, 1L)
+    !WikiGithubImportService.importableAsset('cs:icd-10', false, 1L)
+  }
+
+  // ── hash-based dedup / idempotency ───────────────────────────────────────────
+
+  // storeAttachment only uses PageAttachmentService; the other collaborators aren't touched.
+  private WikiGithubImportService serviceWith(PageAttachmentService pas) {
+    new WikiGithubImportService(null, null, null, null, pas)
+  }
+
+  private static StreamedFile stream(byte[] bytes) {
+    new StreamedFile(new ByteArrayInputStream(bytes), MediaType.APPLICATION_OCTET_STREAM_TYPE)
+  }
+
+  def 'storeAttachment: uploads when the page has no such attachment'() {
+    given:
+    def pas = Mock(PageAttachmentService)
+    def svc = serviceWith(pas)
+
+    when:
+    svc.storeAttachment(1L, 'a.png', [1, 2, 3] as byte[])
+
+    then:
+    1 * pas.getAttachments(1L) >> []
+    1 * pas.saveAttachments(1L, _)
+    0 * pas.deleteAttachmentContent(_, _)
+  }
+
+  def 'storeAttachment: skips the upload when an identical file (same hash) is already attached'() {
+    given:
+    def bytes = [1, 2, 3] as byte[]
+    def pas = Mock(PageAttachmentService)
+    def svc = serviceWith(pas)
+
+    when:
+    svc.storeAttachment(1L, 'a.png', bytes)
+
+    then:
+    1 * pas.getAttachments(1L) >> [new Page.PageAttachment(fileName: 'a.png')]
+    1 * pas.getAttachmentContent(1L, 'a.png') >> stream(bytes)
+    0 * pas.saveAttachments(_, _)      // identical -> reused
+    0 * pas.deleteAttachmentContent(_, _)
+  }
+
+  def 'storeAttachment: replaces when the name matches but the content differs'() {
+    given:
+    def pas = Mock(PageAttachmentService)
+    def svc = serviceWith(pas)
+
+    when:
+    svc.storeAttachment(1L, 'a.png', [1, 2, 3] as byte[])
+
+    then:
+    1 * pas.getAttachments(1L) >> [new Page.PageAttachment(fileName: 'a.png')]
+    1 * pas.getAttachmentContent(1L, 'a.png') >> stream([9, 9] as byte[])
+    1 * pas.deleteAttachmentContent(1L, 'a.png')
+    1 * pas.saveAttachments(1L, _)
+  }
+}


### PR DESCRIPTION
Adds `WikiGithubImportServiceTest` (11 cases) covering the parts of the GitHub importer that were validated only manually:

- **Path resolution** — `resolveRepoPath` for the TermX `files/<id>/` scheme, GitBook `.gitbook/assets` (always book-root) and page-relative refs; `normalizePath` `./`/`../` handling.
- **File names** — `safeFileName` sanitization (spaces/special chars, keep extension), `attachmentName` basename.
- **Importable-asset filter** — external/anchor/self skipped; all local images, asset-like links only (`page:`/`cs:` left alone).
- **Hash dedup / idempotency** — via a mocked `PageAttachmentService`: skip when the same file (same SHA-256) is already attached, replace when the name matches but content differs, upload when absent.

Adds `byte-buddy` + `objenesis` to the wiki **test** scope (so Spock can mock the concrete service) and makes the tested helpers package-private. Full `:wiki:test` green.