### PR TITLE
Freeze page-content slug for stable URLs

### DIFF
--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
@@ -121,21 +121,18 @@ public class WikiGithubImportService {
     normalizeNodes(tree, slugToName);
     content.put("pages.json", JsonUtil.toJson(tree));
 
-    // The parser re-slugifies each content from its name on save (PageContentService.prepare) and
-    // then keys the .md files it applies by that slug — so key the markdown the same way, not by
-    // the file name (a repo's stored slug can differ from slugify(name)). Only .md referenced by
-    // pages.json is fetched (orphans are skipped so the parser can't NPE); attachments/resources
-    // are not imported.
-    Slugify slugify = Slugify.builder().build();
+    // The .md is keyed by its own slug — the same slug pages.json declares, which the parser now
+    // stores verbatim (slugs are stable, PageContentService.prepare no longer re-derives them from
+    // the name). Only .md referenced by pages.json is fetched (orphans are skipped so the parser
+    // can't NPE); attachments/resources are not imported.
     Map<String, String> keyToPath = new LinkedHashMap<>();
     for (String path : blobs) {
       if (!path.endsWith(".md") || !path.startsWith(prefix)) {
         continue;
       }
       String fileSlug = StringUtils.removeEnd(StringUtils.substringAfterLast("/" + path, "/"), ".md");
-      String name = slugToName.get(fileSlug);
-      if (name != null) {
-        keyToPath.put(slugify.slugify(name) + ".md", path);
+      if (slugToName.containsKey(fileSlug)) {
+        keyToPath.put(fileSlug + ".md", path);
       }
     }
     Map<String, String> fetched = fetchAll(keyToPath, coords, branch, req.getToken(), false);

--- a/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentService.java
+++ b/wiki/src/main/java/org/termx/wiki/pagecontent/PageContentService.java
@@ -1,6 +1,7 @@
 package org.termx.wiki.pagecontent;
 
 import com.github.slugify.Slugify;
+import org.apache.commons.lang3.StringUtils;
 import com.kodality.commons.model.QueryResult;
 import org.termx.core.sys.provenance.Provenance;
 import org.termx.core.sys.provenance.ProvenanceService;
@@ -95,16 +96,21 @@ public class PageContentService {
 
   private PageContent prepare(PageContent c, Long pageId) {
     Page page = pageRepository.load(pageId);
+    Slugify slugify = Slugify.builder().build();
 
-    c.setSlug(Slugify.builder().build().slugify(c.getName()));
     c.setContent(c.getContent() == null ? "" : c.getContent());
     c.setSpaceId(page.getSpaceId());
 
     if (c.getId() == null) {
+      // Create: use the provided slug, else derive a stable one from the name.
+      c.setSlug(slugify.slugify(StringUtils.isNotBlank(c.getSlug()) ? c.getSlug() : c.getName()));
       Long templateId = page.getSettings() != null ? page.getSettings().getTemplateId() : null;
       c.setContent(templateContentService.findContent(templateId, c.getLang()).orElse(c.getContent()));
     } else {
+      // Update: keep the stored slug (a rename must not change the URL); only an explicitly
+      // provided slug changes it.
       PageContent currentContent = load(c.getId());
+      c.setSlug(StringUtils.isNotBlank(c.getSlug()) ? slugify.slugify(c.getSlug()) : currentContent.getSlug());
       if (!currentContent.getContentType().equals(c.getContentType())) {
         c.setContent(TextUtil.convertText(c.getContent(), currentContent.getContentType(), c.getContentType()));
       }


### PR DESCRIPTION
## Why

`PageContentService.prepare()` re-derived each content's `slug` from the page **name** on every save. So renaming a page silently changed its published URL — breaking inbound links, the `code`/slug anchors used by comments and SEO metadata, and re-import matching (the GitHub importer had to mirror the re-slugify with a `slugify(name)` workaround to line the `.md` files up).

## What

- **Slug is frozen.** It's set once on create (from an explicit `slug`, else slugified from the name) and preserved on update. A rename no longer touches the URL.
- **Still editable.** An explicitly provided, non-blank `slug` updates it (slugified), so authors can deliberately change a URL.
- **Importer simplified.** With slugs stable, `WikiGithubImportService.buildFromTermx` keys each `.md` by the slug `pages.json` declares (the file's own slug) instead of `slugify(name)`. This also removes the earlier NPE workaround.

The companion termx-web change adds an editable **Slug** field to the page setup modal.

## Validation

Against a local server (empty-ish dev DB) importing `termx-health/tutorial`:
- Import: **77 pages / 65 attachments**, no NPE.
- Re-import: idempotent — still 77 pages, **77 distinct slugs, zero duplicates**.
- Rename with blank slug → slug stays `chef` (frozen).
- Explicit slug → changes to `chef-master`.