### PR TITLE
Import attachments referenced by named folder or percent-encoded name

### DIFF
--- a/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
+++ b/wiki/src/main/java/org/termx/wiki/importer/WikiGithubImportService.java
@@ -13,6 +13,7 @@ import org.termx.wiki.page.PageService;
 import org.termx.wiki.pageattachment.PageAttachmentService;
 import org.termx.wiki.pagecontent.PageContentService;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -251,7 +252,9 @@ public class WikiGithubImportService {
   // Markdown image / link, with an optional <bracketed> URL (so asset names with spaces parse).
   private static final Pattern MD_IMAGE = Pattern.compile("!\\[([^\\]]*)]\\(\\s*(?:<([^>]*)>|([^)\\s]+))\\s*(?:\"[^\"]*\")?\\)");
   private static final Pattern MD_LINK = Pattern.compile("(?<!!)\\[([^\\]]*)]\\(\\s*(?:<([^>]*)>|([^)\\s]+))\\s*(?:\"[^\"]*\")?\\)");
-  private static final Pattern FILES_REF = Pattern.compile("files/(\\d+)/(.+)");
+  // A TermX attachment reference: files/<folder>/<name>. The folder is usually the numeric page id,
+  // but legacy content also uses a named folder (e.g. files/wiki/x.png stored under attachments/wiki/).
+  private static final Pattern FILES_REF = Pattern.compile("files/([^/]+)/(.+)");
   private static final Map<String, String> CONTENT_TYPES = Map.of(
       "png", "image/png", "jpg", "image/jpeg", "jpeg", "image/jpeg", "gif", "image/gif",
       "svg", "image/svg+xml", "webp", "image/webp", "pdf", "application/pdf");
@@ -289,7 +292,9 @@ public class WikiGithubImportService {
     StringBuilder sb = new StringBuilder();
     while (m.find()) {
       String label = m.group(1);
-      String url = m.group(2) != null ? m.group(2).trim() : m.group(3);
+      // Decode %XX so a percent-encoded name (files/207/Screenshot%202024...png) resolves to the
+      // real repo path and gets a clean stored name; the original text is kept if we don't import it.
+      String url = decodeRef(m.group(2) != null ? m.group(2).trim() : m.group(3));
       String replacement = m.group(); // keep the original unless we import the asset
       if (importableAsset(url, image, pageId)) {
         try {
@@ -335,6 +340,19 @@ public class WikiGithubImportService {
   private String attachmentName(String ref) {
     String name = ref.contains("/") ? StringUtils.substringAfterLast(ref, "/") : ref;
     return StringUtils.substringBefore(StringUtils.substringBefore(name, "?"), "#");
+  }
+
+  /** Decodes %XX escapes in a reference (keeping a literal {@code +}); returns it unchanged if it
+   * holds no escapes or is malformed. */
+  static String decodeRef(String ref) {
+    if (ref == null || ref.indexOf('%') < 0) {
+      return ref;
+    }
+    try {
+      return URLDecoder.decode(ref.replace("+", "%2B"), StandardCharsets.UTF_8);
+    } catch (RuntimeException e) {
+      return ref;
+    }
   }
 
   private String resolveRepoPath(String ref, String prefix, boolean gitbook, String hrefDir) {


### PR DESCRIPTION
## Problem

After importing `termx-health/tutorial` into a space, ~27 images were broken on the site (e.g. `/wiki/tutorial/value-set` → `value-set-main.png`, several images on `snomed-ct-configuration`, `permissions`, `authentication`, concept-map/value-set pages). The rendered `<img>` pointed at an unrewritten reference like `files/wiki/value-set-main.png` → `dev.termx.org/files/wiki/…` → 404.

Two importer gaps caused it:

1. **Named attachment folders.** The reference pattern was `files/(\d+)/…` — numeric page-id folders only. Legacy tutorial content references `files/wiki/x.png` and `files/tutorial/x.png`, whose files live under `attachments/wiki/` and `attachments/tutorial/`. These didn't match, so `resolveRepoPath` looked under `files/…` (wrong), the fetch 404'd, and the reference was left as-is → broken image.
2. **Percent-encoded names.** `files/207/Screenshot%202024-06-11%20at%2014.50.15.png` was never decoded, so the repo path kept the `%20` escapes, the fetch missed the real (space-containing) file, and again the reference was left unrewritten.

## Fix

- Broaden the attachment-reference folder to any non-slash segment (`files/([^/]+)/…`), so named folders resolve to `attachments/<folder>/<name>`.
- Decode `%XX` escapes (keeping a literal `+`) before building the repo path and the stored file name.

Both paths already re-attach the file to the target page and rewrite the reference to `files/<newPageId>/<name>`, which the renderer resolves via `/api/pages/<id>/files/<name>`.

## Validation

Local server, fresh space, importing `termx-health/tutorial`:
- Imported **attachments 65 → 92** — the 24 named-folder + 3 percent-encoded references that previously failed.
- Post-import scan: **0** non-numeric-folder and **0** percent-encoded/spaced references remain (the only two regex hits are an external `orphadata.com/…-files/` URL and a `files/<id>` doc placeholder — not images).
- Spot checks: `files/wiki/value-set-main.png` → `files/281/value-set-main.png`; `files/207/Screenshot%20….png` → `files/294/Screenshot-2024-06-11-at-14.50.15.png`; all serve **200** with real byte sizes.

To heal dev: deploy this and re-import the tutorial (import is idempotent; it rewrites the still-broken references in place).

## Note

Touches `WikiGithubImportService.java`, same file as #427 (slug freeze) and #426 (import tests) — edits are in disjoint regions (asset pattern/helpers vs. `buildFromTermx` vs. a new test file), so no content conflict expected regardless of merge order.