### PR TITLE
Space: static-site (mdbook) generator config

### DIFF
--- a/termx-api/src/main/java/org/termx/sys/space/Space.java
+++ b/termx-api/src/main/java/org/termx/sys/space/Space.java
@@ -29,6 +29,17 @@ public class Space {
   private List<String> languages;
   private String siteUrl;
 
+  // Static-site (mdbook) generator config, exported into space.json so the wiki is the single place
+  // to configure the published site. A repo's .mdbook/config.yml, if present, still overrides these.
+  private String ssgSkin;
+  private String ssgThemeAccent;
+  private Boolean ssgThemeSwitcher;
+  private String ssgFooterMessage;
+  private String ssgFooterCopyright;
+  private String ssgTxServer;
+  private Boolean ssgSearch;
+  private String ssgLogo;
+
   private List<Package> packages;
 
   @Getter

--- a/termx-core/src/main/java/org/termx/core/sys/space/SpaceRepository.java
+++ b/termx-core/src/main/java/org/termx/core/sys/space/SpaceRepository.java
@@ -37,6 +37,14 @@ public class SpaceRepository extends BaseRepository {
     ssb.property("default_language", space.getDefaultLanguage());
     ssb.jsonProperty("languages", space.getLanguages());
     ssb.property("site_url", space.getSiteUrl());
+    ssb.property("ssg_skin", space.getSsgSkin());
+    ssb.property("ssg_theme_accent", space.getSsgThemeAccent());
+    ssb.property("ssg_theme_switcher", space.getSsgThemeSwitcher());
+    ssb.property("ssg_footer_message", space.getSsgFooterMessage());
+    ssb.property("ssg_footer_copyright", space.getSsgFooterCopyright());
+    ssb.property("ssg_tx_server", space.getSsgTxServer());
+    ssb.property("ssg_search", space.getSsgSearch());
+    ssb.property("ssg_logo", space.getSsgLogo());
 
     SqlBuilder sb = ssb.buildSave("sys.space", "id");
     Long id = jdbcTemplate.queryForObject(sb.getSql(), Long.class, sb.getParams());

--- a/termx-core/src/main/resources/sys/changelog/sys/50-space.sql
+++ b/termx-core/src/main/resources/sys/changelog/sys/50-space.sql
@@ -41,3 +41,14 @@ alter table sys.space add column default_language  text;
 alter table sys.space add column languages         jsonb;
 alter table sys.space add column site_url          text;
 --
+
+--changeset termx:space-ssg-config
+alter table sys.space add column ssg_skin            text;
+alter table sys.space add column ssg_theme_accent    text;
+alter table sys.space add column ssg_theme_switcher  boolean;
+alter table sys.space add column ssg_footer_message  text;
+alter table sys.space add column ssg_footer_copyright text;
+alter table sys.space add column ssg_tx_server       text;
+alter table sys.space add column ssg_search          boolean;
+alter table sys.space add column ssg_logo            text;
+--

--- a/wiki/src/main/java/org/termx/wiki/SpaceGithubDataWikiSsgHandler.java
+++ b/wiki/src/main/java/org/termx/wiki/SpaceGithubDataWikiSsgHandler.java
@@ -103,7 +103,8 @@ public class SpaceGithubDataWikiSsgHandler implements SpaceGithubDataHandler {
     List<ResourceContent> result = new ArrayList<>();
     result.add(new ResourceContent("space.json", toPrettyJson(new SsgSpaceIndex(
         termxWebUrl.orElse(null), space.getCode(), space.getNames(),
-        space.getDescription(), space.getDefaultLanguage(), space.getLanguages(), space.getSiteUrl()))));
+        space.getDescription(), space.getDefaultLanguage(), space.getLanguages(), space.getSiteUrl(),
+        ssgConfig(space)))));
     result.add(new ResourceContent("pages.json", toPrettyJson(composePagesIndex(pages, links))));
     result.addAll(contents.stream().map(p -> {
       boolean html = "html".equals(p.getContentType());
@@ -177,7 +178,34 @@ public class SpaceGithubDataWikiSsgHandler implements SpaceGithubDataHandler {
   }
 
   protected record SsgSpaceIndex(String web, String code, LocalizedName names,
-                                 LocalizedName description, String defaultLang, List<String> langs, String siteUrl) {}
+                                 LocalizedName description, String defaultLang, List<String> langs, String siteUrl,
+                                 SsgConfig ssg) {}
+
+  // Static-site generator config, shaped to mirror mdbook's config.yml so the generator can merge it
+  // directly (a repo's own .mdbook/config.yml still overrides). Any all-null group is omitted.
+  protected record SsgConfig(SsgTheme theme, SsgFooter footer, String txServer, Boolean search, String logo) {}
+  protected record SsgTheme(String skin, String accent, Boolean switcher) {}
+  protected record SsgFooter(String message, String copyright) {}
+
+  static SsgConfig ssgConfig(Space space) {
+    SsgTheme theme = anyNonNull(space.getSsgSkin(), space.getSsgThemeAccent(), space.getSsgThemeSwitcher())
+        ? new SsgTheme(space.getSsgSkin(), space.getSsgThemeAccent(), space.getSsgThemeSwitcher()) : null;
+    SsgFooter footer = anyNonNull(space.getSsgFooterMessage(), space.getSsgFooterCopyright())
+        ? new SsgFooter(space.getSsgFooterMessage(), space.getSsgFooterCopyright()) : null;
+    if (!anyNonNull(theme, footer, space.getSsgTxServer(), space.getSsgSearch(), space.getSsgLogo())) {
+      return null;
+    }
+    return new SsgConfig(theme, footer, space.getSsgTxServer(), space.getSsgSearch(), space.getSsgLogo());
+  }
+
+  private static boolean anyNonNull(Object... values) {
+    for (Object v : values) {
+      if (v != null) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   // Prepend "# {name}" as the body's H1 unless it already opens with one (a single leading '#').
   private static final Pattern LEADING_H1 = Pattern.compile("^\\s*#(?!#)\\s");

--- a/wiki/src/main/java/org/termx/wiki/SpaceMsDevopsDataWikiSsgHandler.java
+++ b/wiki/src/main/java/org/termx/wiki/SpaceMsDevopsDataWikiSsgHandler.java
@@ -90,7 +90,8 @@ public class SpaceMsDevopsDataWikiSsgHandler implements SpaceMsDevopsDataHandler
     List<ResourceContent> result = new ArrayList<>();
     result.add(new ResourceContent("space.json", toPrettyJson(new SpaceGithubDataWikiSsgHandler.SsgSpaceIndex(
         termxWebUrl.orElse(null), space.getCode(), space.getNames(),
-        space.getDescription(), space.getDefaultLanguage(), space.getLanguages(), space.getSiteUrl()))));
+        space.getDescription(), space.getDefaultLanguage(), space.getLanguages(), space.getSiteUrl(),
+        SpaceGithubDataWikiSsgHandler.ssgConfig(space)))));
     result.add(new ResourceContent("pages.json", toPrettyJson(composePagesIndex(pages, links))));
     result.addAll(contents.stream().map(p -> {
       boolean html = "html".equals(p.getContentType());

--- a/wiki/src/test/groovy/org/termx/wiki/SpaceSsgConfigTest.groovy
+++ b/wiki/src/test/groovy/org/termx/wiki/SpaceSsgConfigTest.groovy
@@ -1,0 +1,51 @@
+package org.termx.wiki
+
+import com.kodality.commons.util.JsonUtil
+import org.termx.sys.space.Space
+import spock.lang.Specification
+
+class SpaceSsgConfigTest extends Specification {
+
+  def 'ssgConfig shapes the flat space fields into nested mdbook config'() {
+    given:
+    def space = new Space()
+        .setSsgSkin('helex').setSsgThemeAccent('#0aa').setSsgThemeSwitcher(true)
+        .setSsgFooterMessage('Guide').setSsgFooterCopyright('(c) 2026')
+        .setSsgTxServer('https://dev.termx.org/api/fhir').setSsgSearch(true).setSsgLogo('files/1/logo.png')
+
+    when:
+    def cfg = SpaceGithubDataWikiSsgHandler.ssgConfig(space)
+
+    then:
+    cfg.theme().skin() == 'helex'
+    cfg.theme().accent() == '#0aa'
+    cfg.theme().switcher()
+    cfg.footer().message() == 'Guide'
+    cfg.footer().copyright() == '(c) 2026'
+    cfg.txServer() == 'https://dev.termx.org/api/fhir'
+    cfg.search()
+    cfg.logo() == 'files/1/logo.png'
+  }
+
+  def 'ssgConfig is null when nothing is configured, so space.json omits it entirely'() {
+    expect:
+    SpaceGithubDataWikiSsgHandler.ssgConfig(new Space()) == null
+  }
+
+  def 'an unset theme/footer group is dropped while scalars still export'() {
+    given:
+    def space = new Space().setSsgTxServer('https://x/fhir') // no theme, no footer
+
+    when:
+    def cfg = SpaceGithubDataWikiSsgHandler.ssgConfig(space)
+    def json = JsonUtil.toJson(cfg)
+
+    then:
+    cfg.theme() == null
+    cfg.footer() == null
+    cfg.txServer() == 'https://x/fhir'
+    !json.contains('theme')
+    !json.contains('footer')
+    json.contains('txServer')
+  }
+}


### PR DESCRIPTION
## Why

Follows the wiki↔mdbook metadata work. `space.json` already carries space metadata (description, languages, site URL); this adds the **generator** settings that were previously only maintainable by hand in each repo's `.mdbook/config.yml` — so the wiki becomes the single place to configure the published site.

Part of a 3-repo change: **termx-server** (this), **termx-web** (config UI), **mdbook** (consume `space.json.ssg`).

## What

- **Schema:** typed `ssg_*` columns on `sys.space` — `ssg_skin`, `ssg_theme_accent`, `ssg_theme_switcher`, `ssg_footer_message`, `ssg_footer_copyright`, `ssg_tx_server`, `ssg_search`, `ssg_logo`.
- **Model/persistence:** matching fields on `Space`, round-tripped by `SpaceRepository`.
- **Export:** `SpaceGithubDataWikiSsgHandler` shapes the flat fields into a nested `ssg` block in `space.json` mirroring mdbook's `config.yml` (`theme`/`footer`/`txServer`/`search`/`logo`), omitting any unset group so `space.json` stays clean. `SpaceMsDevopsDataWikiSsgHandler` updated to match.

mdbook merges this as the **base** config; a repo's own `.mdbook/config.yml` still overrides.

## Validation

- Persistence round-trips through `PUT`/`GET /spaces` (all 8 fields).
- Unit test `SpaceSsgConfigTest` (3 cases): flat→nested shaping, empty space → `ssg` omitted, unset theme/footer groups dropped while scalars still export (confirms `JsonUtil` null-omission).
- Local server boots the migration cleanly.