### PR TITLE
fix(fhir): derive CapabilityStatement URL from termx.api-url

### DIFF
--- a/termx-core/src/main/java/org/termx/core/fhir/ConformanceInitializer.java
+++ b/termx-core/src/main/java/org/termx/core/fhir/ConformanceInitializer.java
@@ -15,7 +15,9 @@ package org.termx.core.fhir;
 import com.kodality.kefhir.core.service.conformance.loader.ConformanceLoader;
 import com.kodality.kefhir.core.service.conformance.loader.ConformanceStaticLoader;
 import io.micronaut.context.annotation.Replaces;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.core.io.ResourceLoader;
+import jakarta.annotation.PostConstruct;
 import jakarta.inject.Singleton;
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -27,6 +29,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hl7.fhir.r5.model.CapabilityStatement;
 import org.hl7.fhir.r5.model.Resource;
 
 @Slf4j
@@ -37,6 +40,36 @@ public class ConformanceInitializer extends ConformanceStaticLoader {
   private final List<TermxGeneratedConformanceProvider> generators;
   private final ResourceLoader resourceLoader;
   private final ConformanceInitializerDependency conformanceInitializerDependency;
+
+  @Value("${termx.api-url}")
+  String apiUrl;
+
+  /**
+   * The static CapabilityStatement.json ships a fixed FHIR base URL, but every deployment serves FHIR from its own host.
+   * Rewrite it from {@code termx.api-url} (the same property {@code TerminologyCapabilityInitializer} already uses for
+   * TerminologyCapabilities) so the two metadata modes agree.
+   * <p>
+   * This URL is not cosmetic: kefhir's {@code OpenapiComposer} copies {@code implementation.url} into the OpenAPI
+   * {@code servers} block, so a stale value points /fhir-swagger's "Try it out" at a different deployment entirely.
+   * <p>
+   * {@code @PostConstruct} must be repeated here: Micronaut does not inherit it onto an override, and without it the
+   * generated bean definition silently drops {@code InitializingBeanDefinition} — no conformance resource loads at all.
+   */
+  @Override
+  @PostConstruct
+  public void init() {
+    super.init();
+    resources.getOrDefault("CapabilityStatement", List.of()).stream()
+        .filter(CapabilityStatement.class::isInstance)
+        .map(CapabilityStatement.class::cast)
+        .forEach(cs -> {
+          String fhirUrl = apiUrl + "/fhir";
+          cs.setUrl(fhirUrl + "/metadata");
+          cs.getImplementation().setUrl(fhirUrl);
+          cs.getImplementation().setDescription("FHIR TS server running at " + fhirUrl);
+          log.info("CapabilityStatement FHIR base URL set to {}", fhirUrl);
+        });
+  }
 
   @Override
   public List<String> getResources() {

--- a/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ConformanceStartupOrderingTest.groovy
+++ b/termx-integtest/src/test/groovy/org/termx/terminology/fhir/ConformanceStartupOrderingTest.groovy
@@ -26,4 +26,19 @@ class ConformanceStartupOrderingTest extends TermxIntegTest {
     JsonNode body = JsonUtil.fromJson(response.body(), JsonNode.class)
     body.get("resourceType").asText() == "CapabilityStatement"
   }
+
+  def "should advertise the configured deployment url, not the one baked into CapabilityStatement.json"() {
+    when:
+    def request = client.builder("/fhir/metadata").GET().build()
+    def response = client.execute(request, BodyHandlers.ofString())
+    JsonNode body = JsonUtil.fromJson(response.body(), JsonNode.class)
+
+    then: "url is derived from termx.api-url (application-test.yml), not the static resource file"
+    body.get("implementation").get("url").asText() == "http://localhost:8200/api/fhir"
+    body.get("url").asText() == "http://localhost:8200/api/fhir/metadata"
+
+    and: "kefhir copies implementation.url into the OpenAPI servers block, so /fhir-swagger follows it"
+    def swagger = client.execute(client.builder("/fhir-swagger").GET().build(), BodyHandlers.ofString())
+    swagger.body().contains("url: http://localhost:8200/api/fhir")
+  }
 }


### PR DESCRIPTION
Every deployment advertised **demo**’s FHIR base URL, because [`CapabilityStatement.json`](termx-app/src/main/resources/conformance/CapabilityStatement.json#L31) hardcodes `https://demo.termx.org/api/fhir`.

This is not cosmetic — kefhir’s `OpenapiComposer` copies `implementation.url` straight into the OpenAPI `servers` block:

```java
openApi.addServersItem(new Server().url(cs.getImplementation().getUrl()) ...)
```

so `/fhir-swagger` told clients to send requests to demo. On dev, Swagger UI’s “Try it out” executed against a **different deployment**.

It also left one server contradicting itself about the same endpoint:

| dev endpoint | before | after |
|---|---|---|
| `/api/fhir/metadata?mode=terminology` | `https://dev.termx.org/...` ✅ | unchanged ✅ |
| `/api/fhir/metadata` (CapabilityStatement) | `https://demo.termx.org/...` ❌ | `https://dev.termx.org/...` ✅ |

`TERMX_API_URL` was always binding correctly — `TerminologyCapabilityInitializer` already reads `${termx.api-url}` and got it right. The static CapabilityStatement was simply never wired to it. This PR wires it, at load time.

## Note for reviewers: the repeated `@PostConstruct`

`@PostConstruct` is deliberately repeated on the `init()` override. Micronaut does **not** inherit it onto an override — without it the generated bean definition silently stops implementing `InitializingBeanDefinition`, and **no conformance resource loads at all**. Verified by diffing the generated `$ConformanceInitializer$Definition` bytecode against the baseline.

`CapabilityStatement.json` keeps its literal URL as an inert default; it is always overwritten at startup.

## Verification

`ConformanceStartupOrderingTest` (boots the app, hits the live endpoint):

- new test asserts `implementation.url` / `url` come from `termx.api-url`, and that `/fhir-swagger` follows
- confirmed non-vacuous: **fails** with the fix reverted, passes with it
- the pre-existing test in the same class covers the `@PostConstruct` regression

```
tests=2 failures=0 skipped=0
  [PASSED] should expose terminology capabilities only after migrated schema is present
  [PASSED] should advertise the configured deployment url, not the one baked into CapabilityStatement.json
```

## Related / out of scope

- The `termx.api-url` **default** stays `https://demo.termx.org/api` — demo relies on it and this PR avoids changing behaviour there. It is still a landmine: `caresets-server.env` sets no `TERMX_API_URL`, so caresets will keep advertising demo until it does. `termx.web-url` and `chef.url` have the same hardcoded-demo shape.
- The deployment-side half of this bug (a single shared `swaggerapi/swagger-ui` container pinned to demo via absolute URLs in `swagger.env` / `swagger-config.json`) is fixed separately on the host and in `termx-quick-start` / `tutorial`.
- Likely affects the tx-conformance baseline, since the tx-ecosystem suite reads `implementation.url`.