### PR TITLE
fix(config): stop defaulting deployment URLs to a real environment

### DIFF
--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -134,7 +134,17 @@ kefhir:
     # passed-in tx-resource's CodeSystem.versionAlgorithm), which 400s otherwise-valid operation calls.
     no-terminology-checks: ${KEFHIR_NO_TERMINOLOGY_CHECKS:true}
 
-chef.url: https://demo.termx.org/chef
+# chef.url — the FSH (FHIR Shorthand) conversion service. Real deployments point CHEF_URL at
+# an internal service (e.g. http://fsh-chef:3000); the default is the same service on
+# localhost. It must NOT default to a public host: unlike the URLs below this one is called,
+# not advertised, so a forgotten override would ship the deployment's own FHIR content to a
+# third party's converter. Failing against localhost is the safe way to be misconfigured.
+#
+# The property is left always-present (rather than dropped so that
+# FhirFshConverter's @Requires(property = "chef.url") disables FSH support) because
+# WikiPageRelatedStructureDefinitionProvider injects that bean unguarded — see the note in
+# the PR description.
+chef.url: ${CHEF_URL:`http://localhost:3000`}
 #github:
 #  client:
 #    id: 'client-id'
@@ -142,8 +152,21 @@ chef.url: https://demo.termx.org/chef
 #  app-name: ${GITHUB_APP_NAME}
 
 termx:
-  web-url: https://demo.termx.org
-  api-url: https://demo.termx.org/api
+  # web-url / api-url are THIS deployment's own externally-reachable addresses. api-url is
+  # not merely cosmetic: it becomes CapabilityStatement.implementation.url, which kefhir
+  # copies into the /fhir-swagger `servers` block — so a wrong value tells clients to send
+  # requests to a different deployment, silently. That is exactly how this went wrong when
+  # the default was a real hostname: environments that never set the override advertised it.
+  #
+  # The defaults are therefore localhost on purpose — obviously-local when a deployment
+  # forgets to override, never some other environment's real address. Set TERMX_WEB_URL and
+  # TERMX_API_URL in every real deployment.
+  #
+  # Backticks around the defaults for the same reason as bob.minio.url below: Micronaut
+  # treats `:` as the var/default delimiter, so ${TERMX_API_URL:http://…} would parse the
+  # default as just `http` and yield a malformed URL.
+  web-url: ${TERMX_WEB_URL:`http://localhost:4200`}
+  api-url: ${TERMX_API_URL:`http://localhost:8200/api`}
   # FHIR terminology conformance testing (tx-ecosystem suite via the FHIR validator's txTests).
   # validator-jar: absolute path to validator_cli.jar (NOT bundled — provided by the deployment, e.g.
   # downloaded in the Dockerfile). tx-url: this server's externally-reachable FHIR base for -tx.


### PR DESCRIPTION
`termx.api-url`, `termx.web-url` and `chef.url` all defaulted to `demo.termx.org`, so any deployment that forgot the override silently adopted **another environment’s** address instead of failing.

That is not hypothetical — it is the bug fixed in #431. `api-url` becomes `CapabilityStatement.implementation.url`, which kefhir copies into the `/fhir-swagger` `servers` block, so every environment without an explicit `TERMX_API_URL` told clients to send requests to demo. And `demo` is now decommissioned (502), so the old defaults point at a **dead host**.

```diff
-chef.url: https://demo.termx.org/chef
+chef.url: ${CHEF_URL:`http://localhost:3000`}
 termx:
-  web-url: https://demo.termx.org
-  api-url: https://demo.termx.org/api
+  web-url: ${TERMX_WEB_URL:`http://localhost:4200`}
+  api-url: ${TERMX_API_URL:`http://localhost:8200/api`}
```

A forgotten override is now obviously local rather than quietly pointing at someone else’s environment, and no default names a deployment that can rot. This matches `application-dev.yml`, which already uses localhost.

`chef.url` gets the same treatment for a stronger reason: it is **called**, not advertised, so a forgotten override would have shipped this deployment’s own FHIR content to a third party’s converter. Failing against localhost is the safe way to be misconfigured.

The defaults use the backtick form for the reason already documented on `bob.minio.url` in this file: Micronaut treats `:` as the var/default delimiter and would otherwise parse the default as just `http`, yielding a malformed URL.

## Verification

The backtick parsing is the real risk here, so I proved it rather than eyeballing it. `application-test.yml` happened to set `api-url` to exactly the new default, so I temporarily **removed** it and re-ran the suite — forcing the value to come from the new default alone:

```
[PASSED] should advertise the configured deployment url, not the one baked into CapabilityStatement.json
```

That test asserts `implementation.url == http://localhost:8200/api/fhir`, so it would have failed with the truncated `http` had the backticks been wrong. `application-test.yml` was then restored (no diff). Full suite: **158 tests, 0 failures, 4 pre-existing skips.**

No live deployment changes behavior: `dev` and `tehik` both set `TERMX_API_URL` explicitly, and `demo`/`caresets` are decommissioned.

## Follow-up worth filing separately (pre-existing, not introduced here)

The cleanest fix for `chef.url` would be **no default at all** — `FhirFshConverter` is `@Requires(property = "chef.url")`, so an absent property would disable FSH conversion gracefully, which is how `ResourceContentCodeSystemVersionFshProvider` and `ResourceContentValueSetVersionFshProvider` are guarded (`@Requires(bean = FhirFshConverter.class)`).

I did not do that because [`WikiPageRelatedStructureDefinitionProvider`](termx-app/src/main/java/org/termx/wiki/WikiPageRelatedStructureDefinitionProvider.java#L15) injects `FhirFshConverter` **unguarded** — a plain `private final` field with no `@Requires` and no `Optional`, unlike every other consumer. Dropping the property would make that bean unconstructable. Guarding it (or making it `Optional`, as `StructureDefinitionContentReferenceService` does) would let `chef.url` become properly optional.