### PR TITLE
Configurable role claims and release-attachment container

### DIFF
--- a/termx-app/src/main/java/org/termx/auth/PrivilegeStoreOAuthSessionPrivilegeMapper.java
+++ b/termx-app/src/main/java/org/termx/auth/PrivilegeStoreOAuthSessionPrivilegeMapper.java
@@ -1,6 +1,7 @@
 package org.termx.auth;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Singleton;
 import lombok.RequiredArgsConstructor;
 import org.termx.uam.privilege.PrivilegeStore;
@@ -15,8 +16,23 @@ import java.util.Set;
 public class PrivilegeStoreOAuthSessionPrivilegeMapper implements OAuthSessionPrivilegeMapper {
     private final PrivilegeStore privilegeStore;
 
+    /**
+     * Comma-separated, dot-separated claim paths holding role names, tried in order and unioned.
+     *
+     * <p>Defaults to the flat {@code roles} claim, so existing deployments are unaffected. Keycloak
+     * puts realm roles at {@code realm_access.roles} and client roles at
+     * {@code resource_access.<client>.roles}; a deployment on either sets this rather than
+     * implementing its own mapper.
+     *
+     * <p>Bound as a plain String and split here rather than as a {@code List<String>}: this is the
+     * authentication path, and a binding that silently yielded an empty list would strip every
+     * user's privileges. Splitting explicitly keeps that behaviour visible and testable.
+     */
+    @Value("${auth.privilege.mapper.role-claims:roles}")
+    String roleClaims;
+
     @Override
     public Set<String> getPrivileges(Map<String, Object> json) {
-        return privilegeStore.getPrivileges((List<String>) json.get("roles"));
+        return privilegeStore.getPrivileges(RoleClaimReader.readRoles(json, RoleClaimReader.parsePaths(roleClaims)));
     }
 }

--- a/termx-app/src/main/java/org/termx/auth/RoleClaimReader.java
+++ b/termx-app/src/main/java/org/termx/auth/RoleClaimReader.java
@@ -1,0 +1,72 @@
+package org.termx.auth;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Reads role names out of an OAuth token payload, given dot-separated claim paths.
+ *
+ * <p>Providers disagree on where roles live. A flat {@code roles} claim is the simplest case, but
+ * Keycloak puts realm roles at {@code realm_access.roles} and per-client roles at
+ * {@code resource_access.<client>.roles}, so a single claim name isn't enough.
+ */
+public final class RoleClaimReader {
+  private RoleClaimReader() {}
+
+  /**
+   * Split a comma-separated property into claim paths, dropping blanks.
+   *
+   * <p>Falls back to the flat {@code roles} claim when the property is empty, so a deployment that
+   * blanks it out keeps working instead of silently authenticating everyone with no privileges.
+   */
+  public static List<String> parsePaths(String property) {
+    if (property == null || property.isBlank()) {
+      return List.of("roles");
+    }
+    List<String> paths = new ArrayList<>();
+    for (String part : property.split(",")) {
+      if (!part.isBlank()) {
+        paths.add(part.trim());
+      }
+    }
+    return paths.isEmpty() ? List.of("roles") : paths;
+  }
+
+  /**
+   * Collect role names from every configured path, in order, de-duplicated.
+   *
+   * <p>A path that is missing, or whose value isn't a list of strings, contributes nothing — token
+   * payloads are attacker-influenced, so a malformed claim must not fail authentication with a
+   * class-cast; it simply grants no roles.
+   */
+  public static List<String> readRoles(Map<String, Object> payload, List<String> paths) {
+    Set<String> roles = new LinkedHashSet<>();
+    if (payload == null || paths == null) {
+      return new ArrayList<>(roles);
+    }
+    for (String path : paths) {
+      resolve(payload, path).forEach(roles::add);
+    }
+    return new ArrayList<>(roles);
+  }
+
+  private static List<String> resolve(Map<String, Object> payload, String path) {
+    if (path == null || path.isBlank()) {
+      return List.of();
+    }
+    Object current = payload;
+    for (String segment : path.trim().split("\\.")) {
+      if (!(current instanceof Map<?, ?> map)) {
+        return List.of();
+      }
+      current = map.get(segment);
+    }
+    if (!(current instanceof List<?> list)) {
+      return List.of();
+    }
+    return list.stream().filter(String.class::isInstance).map(String.class::cast).toList();
+  }
+}

--- a/termx-app/src/main/java/org/termx/core/ReleaseAttachmentBobHandler.java
+++ b/termx-app/src/main/java/org/termx/core/ReleaseAttachmentBobHandler.java
@@ -9,6 +9,7 @@ import org.termx.bob.BobObjectService;
 import org.termx.bob.BobStorage;
 import org.termx.core.sys.release.ReleaseAttachmentStorageHandler;
 import org.termx.sys.release.ReleaseAttachment;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.http.server.types.files.StreamedFile;
 import jakarta.inject.Singleton;
 import java.util.List;
@@ -20,7 +21,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReleaseAttachmentBobHandler implements ReleaseAttachmentStorageHandler {
   private final BobObjectService objectService;
-  private final static String CONTAINER = "release";
+
+  /**
+   * Object-store container for release attachments. Configurable so a deployment sharing one
+   * object store across installations can isolate its own bucket without forking this handler.
+   * Package-private: Micronaut injects non-private fields without reflection.
+   */
+  @Value("${termx.release.attachment-container:release}")
+  String container;
 
   @Override
   public List<ReleaseAttachment> queryAttachments(ReleaseAttachmentQueryParams params) {
@@ -38,7 +46,7 @@ public class ReleaseAttachmentBobHandler implements ReleaseAttachmentStorageHand
     o.setContentType(a.getContentType());
     o.setMeta(meta);
     o.setStorage(new BobStorage()
-        .setContainer(CONTAINER)
+        .setContainer(container)
         .setPath(path)
         .setFilename(a.getFileName())
     );

--- a/termx-app/src/main/resources/application.yml
+++ b/termx-app/src/main/resources/application.yml
@@ -73,6 +73,12 @@ auth:
   oauth:
     jwks-url: ${OAUTH_JWKS_URL:fixme}
     jwks-cache-ttl-seconds: ${OAUTH_JWKS_CACHE_TTL_SECONDS:3600}
+  privilege:
+    mapper:
+      # Where role names live in the OAuth token, as dot-separated claim paths (comma-separated,
+      # tried in order and unioned). The default is a flat `roles` claim. Keycloak needs
+      # `realm_access.roles` for realm roles, or `resource_access.<client>.roles` for client roles.
+      role-claims: ${AUTH_ROLE_CLAIMS:roles}
   public:
     endpoints:
       - '/fhir-swagger'
@@ -167,6 +173,10 @@ termx:
   # default as just `http` and yield a malformed URL.
   web-url: ${TERMX_WEB_URL:`http://localhost:4200`}
   api-url: ${TERMX_API_URL:`http://localhost:8200/api`}
+  release:
+    # Object-store container for release attachments. Override when several installations share one
+    # object store and need their buckets kept apart.
+    attachment-container: ${TERMX_RELEASE_ATTACHMENT_CONTAINER:release}
   # FHIR terminology conformance testing (tx-ecosystem suite via the FHIR validator's txTests).
   # validator-jar: absolute path to validator_cli.jar (NOT bundled — provided by the deployment, e.g.
   # downloaded in the Dockerfile). tx-url: this server's externally-reachable FHIR base for -tx.


### PR DESCRIPTION
Two of the upstreamable items from `termx-agent/tehik/classifier-service-changes.md`. Both are config knobs a downstream deployment currently has to **fork a class** to get, and both defaults preserve today's behaviour exactly.

## 1. Role claims — `auth.privilege.mapper.role-claims`

`PrivilegeStoreOAuthSessionPrivilegeMapper` read a flat `roles` claim:

```java
return privilegeStore.getPrivileges((List<String>) json.get("roles"));
```

Real Keycloak puts realm roles at **`realm_access.roles`** and client roles at `resource_access.<client>.roles`, so any Keycloak deployment had to ship its own `OAuthSessionPrivilegeMapper` — which is exactly what AKK does, hardcoding two nested paths.

Now configurable: comma-separated dot-paths, tried in order and unioned, defaulting to `roles`.

```yaml
auth.privilege.mapper.role-claims: realm_access.roles,vormingud.roles
```

**It also stops trusting the token's shape.** That cast was unchecked, on an attacker-influenced payload — a `roles` claim that is a string, or a list containing non-strings, would blow up with a `ClassCastException` mid-authentication. A malformed claim now contributes no roles instead.

One deliberate choice worth review: the property is bound as a **`String` and split explicitly**, not as `List<String>`. This is the authentication path, and a binding that silently yielded an empty list would strip every user's privileges. For the same reason an empty or blank value falls back to `roles` rather than to nothing.

## 2. Release attachments — `termx.release.attachment-container`

The Bob container was `private final static String CONTAINER = "release"`, so a deployment sharing one object store across installations had to fork the whole handler to change one string. Now `@Value`, defaulting to `release`. (Package-private field, matching the one existing field-injection precedent in the repo — Micronaut injects non-private fields without reflection.)

## Verification

Against a **running server**, booted with both overridden (`TERMX_RELEASE_ATTACHMENT_CONTAINER=akk-release`, `AUTH_ROLE_CLAIMS='realm_access.roles,vormingud.roles'`):

- `Startup completed`, zero `BeanInstantiationException` / `DependencyInjectionException` / conversion errors; the only `ERROR` line is the pre-existing Log4j2 notice.
- `GET /info`, `GET /info/modules`, `GET /health` → **200**.
- Auth chain still rejects correctly: no-auth → **403**, malformed `Bearer not.a.jwt` → **403** (this forces the session-provider chain, and therefore the mapper, to construct).

Claim reading exercised across 20 cases: flat and nested paths, deep client-role paths, two-path union with de-duplication, missing path, path into a non-map, claim that isn't a list, list with non-strings, null payload/paths, blank and whitespace-padded entries, and the parse cases (empty/blank/comma-only → safe `roles` default). All pass.

## Dropped from this PR: the `GET /info` item

The report also listed "add a build-version endpoint — mainstream exposes only `/info/modules`". **That was wrong, and running it is how I found out.** Micronaut's built-in management endpoint is already enabled (`endpoints.info.enabled: true`) and auto-exposes the `info:` config prefix that PR #175 added, so `GET /info` already returns exactly what the web UI expects:

```
$ curl localhost:8200/info
{"pr":"99","commit":"abc1234","build-time":"2026-07-20T16:00:00Z","version":"3.4.0-test"}
```

My first draft added a controller method and got `DuplicateRouteException: More than 1 route matched /info` at runtime. Reverted — the item is **already-exists-upstream**, and I'll correct the report.