### PR TITLE
fix(import): resolve UCUM coding property values case-sensitively

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
@@ -389,13 +389,16 @@ public class CodeSystemFileImportService {
     }).toList();
   }
 
+  // Case-sensitive: UCUM (and its supplements) are case-sensitive, so an external coding must match a concept
+  // code or one of its (alias/display) designations exactly — e.g. the alias "10^3/l" resolves to 10*3/L, but
+  // "10^3/L" must not. Matching case-insensitively silently accepted wrong-case unit strings on import.
   private List<MiniConcept> findConceptByCode(List<MiniConcept> concepts, String codingCode) {
-    return concepts.stream().filter(c -> c.getCode().equalsIgnoreCase(codingCode)).toList();
+    return concepts.stream().filter(c -> c.getCode().equals(codingCode)).toList();
   }
 
   private List<MiniConcept> findConceptByDesignation(List<MiniConcept> designationConcepts, String codingText) {
     return designationConcepts.stream().filter(c -> {
-      return c.getDesignations().stream().anyMatch(d -> d.getName().equalsIgnoreCase(codingText));
+      return c.getDesignations().stream().anyMatch(d -> codingText.equals(d.getName()));
     }).toList();
   }
 


### PR DESCRIPTION
UCUM and its supplements are case-sensitive, but the importer matched external Coding values against concept codes and alias/display designations with equalsIgnoreCase, silently accepting wrong-case units. In ucum-lt, 10*3/L carries alias 10^3/l and {CAG_repeats} carries 'CAG pasikartojimai'; before the fix 10^3/L and 'cag pasikartojimai' also resolved.

Fix: findConceptByCode/findConceptByDesignation compare with equals — exact code/alias match only; wrong-case input is an unknown reference.

Verified locally (fresh DB + ucum-lt, real CSV import → Coding → ucum-lt): 10^3/l → 10*3/L (display 'Tūkstantis Litre'); 'CAG pasikartojimai' → {CAG_repeats}; 10^3/L and 'cag pasikartojimai' rejected. Canonical-code matches unaffected. compileJava clean.

Supersedes #434 (grammar fallback) — intended behaviour is curated supplement-alias resolution. Also targeting r3.3.