### PR TITLE
Group-scoped user enumeration + unified public-endpoint allowlist

### DIFF
--- a/docs/features/deployment-configuration.md
+++ b/docs/features/deployment-configuration.md
@@ -57,6 +57,7 @@ Development-only auth (do **not** use in production):
 | `KEYCLOAK_SSO_URL` | `keycloak.sso-url` | Token/OIDC endpoint (`…/realms/<realm>/protocol/openid-connect`) |
 | `KEYCLOAK_CLIENT_ID` | `keycloak.client-id` | Service client id used to query users |
 | `KEYCLOAK_CLIENT_SECRET` | `keycloak.client-secret` | Service client secret |
+| `KEYCLOAK_USERS_GROUP_SEARCH` | `keycloak.users.group-search` | Optional. When set, user enumeration is **scoped to Keycloak groups** matching this term (groups resolved, members unioned) instead of a realm-wide `GET /users` — which is unbounded and page-truncates on a large realm. Unset keeps the realm-wide default. |
 
 ### 1.4 SNOMED CT / Snowstorm (optional; required for SNOMED features)
 | Env var | Default | Purpose |

--- a/termx-app/src/main/java/org/termx/user/OAuthUserHttpClient.java
+++ b/termx-app/src/main/java/org/termx/user/OAuthUserHttpClient.java
@@ -7,10 +7,12 @@ import io.micronaut.context.annotation.Value;
 import io.micronaut.core.util.StringUtils;
 import jakarta.inject.Singleton;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -18,16 +20,45 @@ import lombok.Setter;
 @Requires(property = "keycloak.url")
 @Requires(property = "auth.mock.enabled", notEquals = StringUtils.TRUE)
 @Singleton
-@RequiredArgsConstructor
 public class OAuthUserHttpClient {
   private final OAuthenticatedHttpClient httpClient;
 
-  public OAuthUserHttpClient(@Value("${keycloak.url}") String url, TermxOAuthTokenClient tokenClient) {
-    httpClient = new OAuthenticatedHttpClient(url, tokenClient);
+  /**
+   * When set, enumerate users by Keycloak group rather than realm-wide. Groups whose name matches
+   * this search term are resolved (`GET /groups?search=`), then their members unioned
+   * (`GET /groups/{id}/members`). Unset (default) keeps the realm-wide `GET /users` — which is
+   * unbounded and page-truncates on a large realm, so a deployment scoping its users to one group
+   * sets this instead of forking the client.
+   */
+  private final String groupSearch;
+
+  public OAuthUserHttpClient(@Value("${keycloak.url}") String url,
+                             @Value("${keycloak.users.group-search:}") String groupSearch,
+                             TermxOAuthTokenClient tokenClient) {
+    this.httpClient = new OAuthenticatedHttpClient(url, tokenClient);
+    this.groupSearch = groupSearch;
   }
 
   public CompletableFuture<List<OAuthUser>> getUsers() {
-    return httpClient.GET("/users", JsonUtil.getListType(OAuthUser.class));
+    if (StringUtils.isEmpty(groupSearch)) {
+      return httpClient.GET("/users", JsonUtil.getListType(OAuthUser.class));
+    }
+    return getGroups().thenCompose(groups ->
+        forkJoin(groups.stream().map(g -> getGroupMembers(g.id)).toList())
+            .thenApply(members -> members.stream()
+                .flatMap(Collection::stream)
+                // A user in several matched groups is returned once (OAuthUser has no value equality,
+                // so dedup on the Keycloak id, keeping first occurrence).
+                .collect(Collectors.toMap(OAuthUser::getId, u -> u, (first, dup) -> first, LinkedHashMap::new))
+                .values().stream().toList()));
+  }
+
+  private CompletableFuture<List<GroupRepresentation>> getGroups() {
+    return httpClient.GET("/groups?search=" + groupSearch, JsonUtil.getListType(GroupRepresentation.class));
+  }
+
+  private CompletableFuture<List<OAuthUser>> getGroupMembers(String groupId) {
+    return httpClient.GET("/groups/" + groupId + "/members", JsonUtil.getListType(OAuthUser.class));
   }
 
   public List<String> getUserRoles(String kcUserId) {

--- a/termx-core/src/main/java/org/termx/core/auth/AuthorizationFilter.java
+++ b/termx-core/src/main/java/org/termx/core/auth/AuthorizationFilter.java
@@ -1,6 +1,5 @@
 package org.termx.core.auth;
 
-import io.micronaut.context.annotation.Value;
 import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpMethod;
@@ -15,10 +14,8 @@ import io.micronaut.web.router.MethodBasedRouteMatch;
 import io.micronaut.web.router.RouteMatch;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringSubstitutor;
@@ -27,12 +24,12 @@ import org.reactivestreams.Publisher;
 @Filter("/**")
 @RequiredArgsConstructor
 public class AuthorizationFilter implements HttpServerFilter {
-  @Value("${auth.public.endpoints:[]}")
-  private List<String> publicEndpoints;
-  private static final List<String> DEFAULT_PUBLIC = Arrays.asList("/health", "/info", "/public", "/metrics", "/prometheus");
+  private final PublicEndpointMatcher publicEndpointMatcher;
 
+  /** @deprecated register on {@link PublicEndpointMatcher} directly; kept for existing callers. */
+  @Deprecated
   public void addPublicEndpoint(String path) {
-    this.publicEndpoints.add(path);
+    publicEndpointMatcher.addPublicEndpoint(path);
   }
 
   @Override
@@ -56,7 +53,7 @@ public class AuthorizationFilter implements HttpServerFilter {
       return true;
     }
 
-    if (Stream.concat(DEFAULT_PUBLIC.stream(), publicEndpoints.stream()).anyMatch(prefix -> startsWith(request.getPath(), prefix))) {
+    if (publicEndpointMatcher.isPublic(request.getPath())) {
       return true;
     }
 
@@ -92,9 +89,5 @@ public class AuthorizationFilter implements HttpServerFilter {
       return List.of(aa.get("resource", String.class).orElseThrow() + "." + aa.getValues().get("privilege"));
     }
     return List.of(aa.get("value", String[].class).orElse(new String[]{}));
-  }
-
-  private boolean startsWith(String path, String prefix) {
-    return path.equals(prefix) || path.startsWith(prefix + "/");
   }
 }

--- a/termx-core/src/main/java/org/termx/core/auth/PublicEndpointMatcher.java
+++ b/termx-core/src/main/java/org/termx/core/auth/PublicEndpointMatcher.java
@@ -1,0 +1,41 @@
+package org.termx.core.auth;
+
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * The single source of truth for which request paths are public (need no session/privilege).
+ *
+ * <p>Both {@link AuthorizationFilter} and any downstream {@code SessionProvider} that grants
+ * anonymous access to the same endpoints consume this bean, so the two layers can't drift — a path
+ * added here is public everywhere, avoiding the "allowed by one layer, 403 by the other" trap.
+ *
+ * <p>The set is the built-in defaults plus {@code auth.public.endpoints}, plus any registered at
+ * runtime via {@link #addPublicEndpoint} (e.g. the kefhir interceptor opening {@code /fhir}).
+ */
+@Singleton
+public class PublicEndpointMatcher {
+  private static final List<String> DEFAULT_PUBLIC = List.of("/health", "/info", "/public", "/metrics", "/prometheus");
+
+  private final List<String> configuredEndpoints;
+
+  public PublicEndpointMatcher(@Value("${auth.public.endpoints:[]}") List<String> configuredEndpoints) {
+    // Copy into a mutable list so addPublicEndpoint works regardless of how the value was bound.
+    this.configuredEndpoints = new ArrayList<>(configuredEndpoints != null ? configuredEndpoints : List.of());
+  }
+
+  /** Register an additional public prefix at runtime (e.g. once a module decides its routes are open). */
+  public void addPublicEndpoint(String path) {
+    configuredEndpoints.add(path);
+  }
+
+  /** Whether {@code path} is under a public prefix — an exact match or a `/`-delimited descendant. */
+  public boolean isPublic(String path) {
+    return Stream.concat(DEFAULT_PUBLIC.stream(), configuredEndpoints.stream())
+        .anyMatch(prefix -> path.equals(prefix) || path.startsWith(prefix + "/"));
+  }
+}


### PR DESCRIPTION
The two remaining server-side items from `termx-agent/tehik/classifier-service-changes.md` (Bucket B items 4 and 5). Two independent, backwards-compatible changes; two commits so the auth refactor reviews on its own.

## 1. Unified public-endpoint allowlist (`refactor(auth)`)

`auth.public.endpoints` matching lived inline in `AuthorizationFilter`. A downstream deployment that also grants anonymous access to those endpoints (AKK's `PublicEndpointSessionProvider`, and LMB's) copied the same `DEFAULT_PUBLIC` list and `startsWith` logic — **two implementations of one rule**, which drift: a path added to one layer but not the other is allowed at one and 403'd at the other.

Extracted into a single `@Singleton PublicEndpointMatcher.isPublic(path)`. `AuthorizationFilter` consumes it; a downstream session provider injects the same bean. `addPublicEndpoint` stays on the filter as a deprecated delegate, so `KefhirAuthHttpInterceptor` (opens `/fhir` at runtime) is untouched.

**No behaviour change — verified against a running server:**
| Request | Result |
|---|---|
| `/info`, `/info/modules`, `/health` | 200 (matcher) |
| `/fhir/metadata` | 200 — the runtime `/fhir` registration still reaches the matcher via the delegate |
| `/ts/code-systems` (unprivileged guest) | **403** — auth still enforced |
| startup | zero bean-injection errors |

## 2. Group-scoped user enumeration (`feat(user)`)

`OAuthUserHttpClient.getUsers()` did a realm-wide `GET /users` — unbounded, page-truncates on a large realm. AKK forks the client to enumerate by group instead.

`keycloak.users.group-search`: when set, groups matching the term are resolved (`GET /groups?search=`) and members unioned (`GET /groups/{id}/members`), deduped by Keycloak id. Unset (default) keeps the realm-wide `GET /users`, so existing deployments are unchanged. Documented in `deployment-configuration.md`.

One improvement over AKK's version: it didn't dedup, so a user in two matched groups appeared twice. This dedups by id (`OAuthUser` has no value equality, so `distinct()` would be a no-op — collect on id, keep first).

The group path isn't instantiated without `keycloak.url`, so it wasn't exercised at runtime; the composition is type-checked and the transform is straightforward. Both modules compile clean.