### PR TITLE
Configurable guest identity (AUTH_GUEST_NAME)

### DIFF
--- a/docs/features/deployment-configuration.md
+++ b/docs/features/deployment-configuration.md
@@ -42,6 +42,7 @@ compose stack, the public installation guide, and the feature docs in this folde
 | `OAUTH_JWKS_URL` | `fixme` | OIDC JWKS endpoint used to validate incoming JWTs. **Set this** (or enable mock auth). |
 | `OAUTH_JWKS_CACHE_TTL_SECONDS` | `3600` | JWKS cache TTL |
 | `GUEST_DISABLED` | `false` | `true` blocks unauthenticated/guest access |
+| `AUTH_GUEST_NAME` | `guest` | Identity of the anonymous session — both the username and the privilege role it's granted. Defaults to the `guest` role seeded by the UAM changelog; set to match a deployment whose seed names its anonymous role differently (e.g. `KKL-GUEST`). Only relevant when `GUEST_DISABLED=false`. |
 
 Development-only auth (do **not** use in production):
 | Env var | Default | Purpose |

--- a/termx-app/src/main/java/org/termx/auth/GuestSessionProvider.java
+++ b/termx-app/src/main/java/org/termx/auth/GuestSessionProvider.java
@@ -3,6 +3,7 @@ package org.termx.auth;
 import org.termx.core.auth.SessionInfo;
 import org.termx.uam.privilege.PrivilegeStore;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.annotation.Value;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import java.util.Set;
@@ -15,8 +16,16 @@ import lombok.extern.slf4j.Slf4j;
 @Requires(property = "auth.guest.disabled", notEquals = StringUtils.TRUE)
 @RequiredArgsConstructor
 public class GuestSessionProvider extends SessionProvider {
-  public static final String GUEST = "guest";
   private final PrivilegeStore privilegeStore;
+
+  /**
+   * Identity of the anonymous session: both the username shown and the privilege role looked up.
+   * Defaults to {@code guest} (the role seeded by the default UAM changelog). A deployment whose
+   * seed names its anonymous role differently (e.g. {@code KKL-GUEST}) sets this so the guest
+   * gets that role's privileges. Package-private for Micronaut field injection.
+   */
+  @Value("${auth.guest.name:guest}")
+  String guestName;
 
   @Override
   public int getOrder() {
@@ -25,10 +34,10 @@ public class GuestSessionProvider extends SessionProvider {
 
   @Override
   public SessionInfo authenticate(HttpRequest<?> request) {
-    Set<String> privileges = privilegeStore.getPrivileges(GUEST);
+    Set<String> privileges = privilegeStore.getPrivileges(guestName);
     SessionInfo info = new SessionInfo();
     info.setPrivileges(privileges);
-    info.setUsername(GUEST);
+    info.setUsername(guestName);
     return info;
   }
 }


### PR DESCRIPTION
The last of the AKK Bucket B items (item 6, "smaller knobs") from `termx-agent/tehik/classifier-service-changes.md`.

## Configurable guest identity

`GuestSessionProvider` hardcoded `"guest"` for both the anonymous session's username *and* the privilege role it looks up. A deployment whose UAM seed names its anonymous role differently — AKK's is `KKL-GUEST` — had to fork the provider.

Now `auth.guest.name` (default `"guest"`), driving both the username and the `PrivilegeStore` lookup, so the guest gets that role's seeded privileges. Default preserved — existing deployments unchanged.

### Verified against a running server

| Boot | `GET /auth/userinfo` |
|---|---|
| default | `{"username":"guest","privileges":[]}` |
| `AUTH_GUEST_NAME=KKL-GUEST` | `{"username":"KKL-GUEST","privileges":[]}` |

Privileges are empty in the second case because no `KKL-GUEST` role is seeded in this DB — which **confirms the property drives the role lookup, not just the display label** (AKK seeds a `KKL-GUEST` privilege and would get its grants). Clean startup, zero bean-injection errors.

## The other "minor knob" needs no change

The AKK analysis also listed "document the import-sizing profile so the next deployment doesn't rediscover it." That is **already covered** in `deployment-configuration.md`: §1.6 gives the 600 MB `max-request-size` / `multipart.max-file-size` default with the SNOMED RF2 ≈ 549 MB rationale, and §7's operational gotcha says to raise both these *and* the reverse-proxy body limit for larger archives. The value is env-overridable (`MICRONAUT_SERVER_MAX_REQUEST_SIZE`). Nothing to add — noted in the report.

With this, **every upstreamable item across both AKK reports is delivered.**