### PR TITLE
fix(import): accept grammar-valid UCUM codes not materialised as concepts

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
+++ b/terminology/src/main/java/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportService.java
@@ -15,6 +15,7 @@ import org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportR
 import org.termx.core.http.BinaryHttpClient;
 import org.termx.terminology.terminology.codesystem.CodeSystemImportService;
 import org.termx.terminology.terminology.codesystem.CodeSystemService;
+import org.termx.terminology.terminology.codesystem.UcumCodingSupport;
 import org.termx.terminology.terminology.codesystem.validator.CodeSystemValidationService;
 import org.termx.terminology.terminology.codesystem.version.CodeSystemVersionService;
 import org.termx.terminology.terminology.codesystem.concept.ConceptService;
@@ -76,6 +77,7 @@ public class CodeSystemFileImportService {
   private final CodeSystemVersionService codeSystemVersionService;
   private final ConceptService conceptService;
   private final ValueSetVersionConceptService valueSetVersionConceptService;
+  private final UcumCodingSupport ucumCodingSupport;
   private final Optional<FhirFshConverter> fhirFshConverter;
 
   private final BinaryHttpClient client = new BinaryHttpClient();
@@ -303,12 +305,32 @@ public class CodeSystemFileImportService {
     } else if (matchedDesignations > 1) {
       log.debug("\ttoo many designation candidates.");
       errs.add(ApiError.TE714.toIssue(Map.of("value", codingCode)));
+    } else if (resolveUcumByGrammar(propertyValue, ep, codingCode)) {
+      log.debug("\tresolved \"{}\" via UCUM grammar validation", codingCode);
     } else {
       log.debug("\tdesignation search failed");
       errs.add(ApiError.TE715.toIssue(Map.of("code", codingCode, "codeSystem", ruleString(ep.getRule()))));
     }
 
     return errs;
+  }
+
+  /**
+   * UCUM is a fragment code system: its concepts are defined by grammar, not enumerated. The concept query in
+   * {@link #decorateExternalCodingProperties} only matches materialised units (UCUM essence atoms + any codes a
+   * UCUM supplement enumerates), so a valid-but-non-materialised expression (e.g. {@code %{vol}}, {@code [CFU]/g},
+   * {@code mg/mmol{creat}}) is otherwise reported as an unknown reference. When the property rule targets UCUM
+   * (the base {@code ucum} or a supplement of it), fall back to UCUM grammar validation and, if the code is a valid
+   * UCUM expression, accept the value keeping the code system the rule declared.
+   */
+  private boolean resolveUcumByGrammar(EntityPropertyValue propertyValue, EntityProperty ep, String codingCode) {
+    Optional<String> ucumSystem = ucumCodingSupport.ucumSystemOfRule(ep.getRule());
+    if (ucumSystem.isEmpty() || !ucumCodingSupport.isValidUcumCode(codingCode)) {
+      return false;
+    }
+    // Accept the value keeping the code system the rule declared (base "ucum" or the referenced supplement).
+    propertyValue.setValue(new EntityPropertyValueCodingValue(codingCode, ucumSystem.get()));
+    return true;
   }
 
   // validation helpers

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/UcumCodingSupport.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/UcumCodingSupport.java
@@ -1,0 +1,53 @@
+package org.termx.terminology.terminology.codesystem;
+
+import org.termx.terminology.terminology.codesystem.concept.ConceptService;
+import org.termx.ts.codesystem.CodeSystem;
+import org.termx.ts.codesystem.ConceptQueryParams;
+import org.termx.ts.codesystem.EntityPropertyRule;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Helper for resolving UCUM coding property values.
+ * <p>
+ * UCUM is a {@code fragment} code system: its concepts are defined by grammar, not enumerated. A concept query
+ * ({@code code_system=ucum}, list of codes) only matches materialised units — the UCUM essence atoms plus any codes
+ * a UCUM supplement (e.g. {@code ucum-lt}) enumerates — so a valid-but-non-materialised expression such as
+ * {@code %{vol}}, {@code [CFU]/g} or {@code mg/mmol{creat}} resolves to nothing and is otherwise reported as an
+ * unknown reference on import/validation. This helper lets both the file importer and the concept validator fall
+ * back to UCUM grammar validation for property rules that target UCUM (the base {@code ucum} or a supplement of it).
+ */
+@Singleton
+@RequiredArgsConstructor
+public class UcumCodingSupport {
+  public static final String UCUM = "ucum";
+
+  private final ConceptService conceptService;
+  private final CodeSystemService codeSystemService;
+
+  /** The first UCUM code system referenced by the rule (the base {@code ucum} or a supplement whose base is UCUM). */
+  public Optional<String> ucumSystemOfRule(EntityPropertyRule rule) {
+    if (rule == null || CollectionUtils.isEmpty(rule.getCodeSystems())) {
+      return Optional.empty();
+    }
+    return rule.getCodeSystems().stream().filter(this::isUcumOrSupplement).findFirst();
+  }
+
+  /** True when {@code codeSystem} is the base {@code ucum} or a supplement whose base code system is UCUM. */
+  public boolean isUcumOrSupplement(String codeSystem) {
+    if (UCUM.equals(codeSystem)) {
+      return true;
+    }
+    return codeSystemService.load(codeSystem).map(CodeSystem::getBaseCodeSystem).filter(UCUM::equals).isPresent();
+  }
+
+  /** True when {@code code} is a valid UCUM expression by grammar, even if it is not materialised as a concept. */
+  public boolean isValidUcumCode(String code) {
+    // The UCUM provider answers only for the base "ucum" and validates a single code against the grammar.
+    return StringUtils.isNotEmpty(code)
+        && CollectionUtils.isNotEmpty(conceptService.query(new ConceptQueryParams().setCodeSystem(UCUM).setCode(code)).getData());
+  }
+}

--- a/terminology/src/main/java/org/termx/terminology/terminology/codesystem/validator/CodeSystemValidationService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/codesystem/validator/CodeSystemValidationService.java
@@ -4,6 +4,7 @@ import com.kodality.commons.model.Issue;
 import com.kodality.commons.util.JsonUtil;
 import com.kodality.commons.util.MapUtil;
 import org.termx.terminology.ApiError;
+import org.termx.terminology.terminology.codesystem.UcumCodingSupport;
 import org.termx.terminology.terminology.codesystem.concept.ConceptService;
 import org.termx.terminology.terminology.valueset.expansion.ValueSetVersionConceptService;
 import org.termx.ts.PublicationStatus;
@@ -52,6 +53,7 @@ public class CodeSystemValidationService {
 
   private final ConceptService conceptService;
   private final ValueSetVersionConceptService valueSetVersionConceptService;
+  private final UcumCodingSupport ucumCodingSupport;
 
 
   public List<Issue> validateConcepts(List<Concept> csConcepts, List<EntityProperty> csProperties) {
@@ -161,7 +163,13 @@ public class CodeSystemValidationService {
 
 
       List<ValueSetVersionConceptValue> concepts = epExternalConcepts.get(ep.getName()).stream().filter(c -> c.getCode().equals(external.getCode())).toList();
-      if (concepts.size() != 1 || !concepts.get(0).getCodeSystem().equals(external.getCodeSystem())) {
+      boolean resolved = concepts.size() == 1 && concepts.get(0).getCodeSystem().equals(external.getCodeSystem());
+      // UCUM concepts are grammar-defined, not enumerated: accept a valid UCUM expression referencing UCUM (or a
+      // UCUM supplement) even when it is not materialised as a concept. Mirrors the file importer's fallback.
+      if (!resolved && ucumCodingSupport.isUcumOrSupplement(external.getCodeSystem()) && ucumCodingSupport.isValidUcumCode(external.getCode())) {
+        resolved = true;
+      }
+      if (!resolved) {
         errs.add(ApiError.TE217.toIssue(MapUtil.toMap("codeSystem", external.getCodeSystem(), "code", external.getCode())));
       }
     }


### PR DESCRIPTION
## Problem

Importing a CodeSystem CSV with a `Coding` property whose rule targets `ucum` (e.g. the LMB `lt-lab-klt-nomenclature` `units` column) fails with `Unknown reference "<unit>" to "ucum"` for most unit strings, followed by `Value "{code=…}" does not match data type "Coding"` and `Coding "…" is missing the "codeSystem" field`.

The importer resolves all coding values in one batch query (`ConceptQueryParams.setCodes([...])`). For `ucum` that batch path (`UcumConceptResolver.search`) only returns **materialised** units — the UCUM essence atoms, the library-defined units, and codes enumerated by a UCUM supplement. UCUM is a *fragment* code system: valid composite/annotation expressions (`mm`, `10*6/mL`, `%{vol}`, `{CAG_repeats}`, `[CFU]/g`, `mg/(24.h)`, …) are grammar-defined, not materialised, so the batch lookup returns nothing and the value is rejected — even though the single-code path validates each of them fine.

## Fix

When the batch lookup and the designation fallback both miss and the property rule targets UCUM (base `ucum` or a supplement of it), fall back to UCUM **grammar** validation (`UcumCodingSupport.isValidUcumCode`) and accept the value, keeping the code system the rule declared. Mirrored in both the file importer (`CodeSystemFileImportService`) and the concept validator (`CodeSystemValidationService`).

## Verification

Reproduced end-to-end against a clean r3.3 instance using the customer's real `nomenclature-1.0.10` units and `lt-lab-ucum-1.0.2`, with `units → ucum`:

- **Before:** 51 distinct unit codes fail (`Unknown reference … to "ucum"`), matching the customer log line-for-line.
- **After:** **51 → 2**. The only remaining failures are `Ohm*min` and `k[arb'U]/L`, which are genuinely invalid UCUM (`*` is not a UCUM operator → `Ohm.min`; `[arb'U]` is a non-metric unit and cannot take the `k` prefix → `[arb'U]/L`). These are data errors in the source UCUM list and cannot be resolved by grammar or by a supplement.

Rebased onto current `r3.3` (includes #437 case-sensitive resolution); both changes coexist and the batch → designation → grammar fallback order is preserved.
