### PR TITLE
feat(server): connectivity check + remote-aware resource listing

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/terminology/FhirServerHttpClientService.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/FhirServerHttpClientService.java
@@ -1,11 +1,19 @@
 package org.termx.terminology.terminology;
 
+import org.termx.sys.server.ServerConnectionCheckResult;
+import org.termx.sys.server.TerminologyServer;
 import org.termx.sys.server.TerminologyServerKind;
 import org.termx.core.sys.server.SecretEncryptor;
 import org.termx.core.sys.server.TerminologyServerRepository;
+import org.termx.core.sys.server.httpclient.CapabilityStatementSummary;
 import org.termx.core.sys.server.httpclient.ServerHttpClientService;
+import com.kodality.zmei.fhir.client.FhirClientError;
+import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletionException;
 import jakarta.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 
 @Singleton
 public class FhirServerHttpClientService extends ServerHttpClientService {
@@ -16,6 +24,42 @@ public class FhirServerHttpClientService extends ServerHttpClientService {
   @Override
   public String getKind() {
     return TerminologyServerKind.fhir;
+  }
+
+  @Override
+  public ServerConnectionCheckResult checkConnection(Long serverId) {
+    ServerConnectionCheckResult result = new ServerConnectionCheckResult();
+    TerminologyServer server = serverService.load(serverId);
+    if (server == null) {
+      return result.setSuccess(false).setError("Server not found");
+    }
+    result.setUrl(StringUtils.stripEnd(server.getRootUrl(), "/") + "/metadata");
+    FhirServerHttpClient client = getHttpClient(serverId);
+    long start = System.currentTimeMillis();
+    try {
+      HttpRequest request = client.builder("metadata").header("Accept", "application/fhir+json").GET().build();
+      HttpResponse<String> response = client.executeAsync(request).join();
+      result.setStatusCode(response.statusCode());
+      result.setSuccess(response.statusCode() >= 200 && response.statusCode() < 300);
+      CapabilityStatementSummary.apply(response.body(), result);
+    } catch (Exception e) {
+      Throwable t = e instanceof CompletionException ? e.getCause() : e;
+      while (t != null) {
+        if (t instanceof FhirClientError err) {
+          result.setStatusCode(err.getResponse().statusCode());
+          result.setError(err.getMessage());
+          break;
+        }
+        t = t.getCause();
+      }
+      if (result.getError() == null) {
+        result.setError(e.getMessage());
+      }
+      result.setSuccess(false);
+    } finally {
+      result.setDurationMs(System.currentTimeMillis() - start);
+    }
+    return result;
   }
 
   protected FhirServerHttpClient buildHttpClient(ServerHttpClientConfig config) {

--- a/terminology/src/main/java/org/termx/terminology/terminology/FhirServerResourceListProvider.java
+++ b/terminology/src/main/java/org/termx/terminology/terminology/FhirServerResourceListProvider.java
@@ -1,0 +1,130 @@
+package org.termx.terminology.terminology;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kodality.commons.util.JsonUtil;
+import org.termx.core.util.canonical.AuthoritativeUrlMatcher;
+import org.termx.core.util.canonical.CanonicalUrlParser;
+import org.termx.sys.server.TerminologyServer;
+import org.termx.sys.server.TerminologyServer.AuthoritativeResource;
+import org.termx.sys.server.resource.TerminologyServerResourceListProvider;
+import org.termx.terminology.terminology.FhirServerHttpClientService.FhirServerHttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import jakarta.inject.Singleton;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Lists resources from a remote FHIR terminology server by paging its type collection endpoint
+ * (e.g. {@code GET <root>/CodeSystem?_elements=url,version,status}) and keeping only the resources whose
+ * canonical URL matches the server's authoritative patterns. Fetching goes through the same auth-aware
+ * {@link FhirServerHttpClient} as real calls. Best-effort: transport/parse failures yield whatever was
+ * collected so far rather than an error.
+ */
+@Slf4j
+@Singleton
+@RequiredArgsConstructor
+public class FhirServerResourceListProvider implements TerminologyServerResourceListProvider {
+  private final FhirServerHttpClientService fhirClientService;
+
+  /** Maps the UI resource-type slug to the FHIR resource type name. */
+  private static final Map<String, String> FHIR_TYPES = Map.of(
+      "code-systems", "CodeSystem",
+      "value-sets", "ValueSet",
+      "concept-maps", "ConceptMap",
+      "structure-definitions", "StructureDefinition",
+      "structure-maps", "StructureMap");
+
+  private static final int MAX_PAGES = 50;
+
+  @Override
+  public boolean checkType(String type) {
+    return FHIR_TYPES.containsKey(type);
+  }
+
+  @Override
+  public List<AuthoritativeResource> list(TerminologyServer server, String type, List<AuthoritativeResource> patterns) {
+    String fhirType = FHIR_TYPES.get(type);
+    List<AuthoritativeResource> result = new ArrayList<>();
+    if (fhirType == null || server == null || server.getId() == null) {
+      return result;
+    }
+
+    FhirServerHttpClient client = fhirClientService.getHttpClient(server.getId());
+    String baseUrl = StringUtils.stripEnd(server.getRootUrl(), "/");
+    String path = fhirType + "?_elements=url,version,status&_count=200";
+
+    try {
+      for (int page = 0; page < MAX_PAGES && path != null; page++) {
+        HttpRequest request = client.builder(path).header("Accept", "application/fhir+json").GET().build();
+        HttpResponse<String> response = client.executeAsync(request).join();
+        JsonNode bundle = JsonUtil.getObjectMapper().readTree(response.body());
+        collectMatches(bundle.get("entry"), fhirType, patterns, result);
+        path = nextPagePath(bundle, baseUrl);
+      }
+    } catch (Exception e) {
+      log.warn("Failed to list {} from remote server {}: {}", type, server.getCode(), e.getMessage());
+    }
+    return result;
+  }
+
+  private void collectMatches(JsonNode entries, String fhirType, List<AuthoritativeResource> patterns, List<AuthoritativeResource> result) {
+    if (entries == null || !entries.isArray()) {
+      return;
+    }
+    for (JsonNode entry : entries) {
+      JsonNode resource = entry.get("resource");
+      if (resource == null) {
+        continue;
+      }
+      String uri = text(resource, "url");
+      String version = text(resource, "version");
+      String status = text(resource, "status");
+      String id = text(resource, "id");
+      for (AuthoritativeResource pattern : patterns) {
+        if (matches(pattern, uri, version, status, fhirType)) {
+          result.add(new AuthoritativeResource().setUrl(uri).setVersion(version).setStatus(status).setName(id));
+          break;
+        }
+      }
+    }
+  }
+
+  /** Follows the {@code next} bundle link, but only when it points back at the same server. */
+  private String nextPagePath(JsonNode bundle, String baseUrl) {
+    JsonNode links = bundle.get("link");
+    if (links == null || !links.isArray()) {
+      return null;
+    }
+    for (JsonNode link : links) {
+      if ("next".equals(text(link, "relation"))) {
+        String url = text(link, "url");
+        if (url != null && url.startsWith(baseUrl)) {
+          return url.substring(baseUrl.length()).replaceFirst("^/", "");
+        }
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private boolean matches(AuthoritativeResource pattern, String uri, String version, String status, String fhirType) {
+    CanonicalUrlParser parsed = CanonicalUrlParser.parse(pattern.toEcosystemUrl());
+    if (!AuthoritativeUrlMatcher.matches(parsed.getBaseUrl(), uri, fhirType)) {
+      return false;
+    }
+    if (parsed.getVersion() != null && version != null && !parsed.getVersion().equals(version)) {
+      return false;
+    }
+    return parsed.getStatus() == null || status == null || parsed.getStatus().equals(status);
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode value = node == null ? null : node.get(field);
+    return value != null && !value.isNull() ? value.asText() : null;
+  }
+}

--- a/termx-api/src/main/java/org/termx/sys/server/ServerConnectionCheckResult.java
+++ b/termx-api/src/main/java/org/termx/sys/server/ServerConnectionCheckResult.java
@@ -1,0 +1,35 @@
+package org.termx.sys.server;
+
+import io.micronaut.core.annotation.Introspected;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * Result of a live connectivity check against a {@link TerminologyServer}. The check performs a single
+ * lightweight read (the FHIR {@code CapabilityStatement} for FHIR-kind servers) using the same root URL,
+ * headers and authentication as real calls, so a success proves the configured endpoint is reachable and
+ * readable with the configured credentials.
+ */
+@Getter
+@Setter
+@Accessors(chain = true)
+@Introspected
+public class ServerConnectionCheckResult {
+  /** {@code true} when the probe returned a 2xx response. */
+  private boolean success;
+  /** HTTP status code returned by the server (may be set even on failure, e.g. 401/403/404). */
+  private Integer statusCode;
+  /** The URL that was probed. */
+  private String url;
+  /** Round-trip duration in milliseconds. */
+  private Long durationMs;
+  /** CapabilityStatement {@code software.name} (FHIR-kind servers only), e.g. "Ontoserver". */
+  private String software;
+  /** CapabilityStatement {@code software.version} (FHIR-kind servers only). */
+  private String softwareVersion;
+  /** CapabilityStatement {@code fhirVersion} (FHIR-kind servers only). */
+  private String fhirVersion;
+  /** Failure detail when {@link #success} is {@code false}. */
+  private String error;
+}

--- a/termx-api/src/main/java/org/termx/sys/server/TerminologyServer.java
+++ b/termx-api/src/main/java/org/termx/sys/server/TerminologyServer.java
@@ -69,6 +69,7 @@ public class TerminologyServer {
 
   @Getter
   @Setter
+  @Accessors(chain = true)
   @Introspected
   public static class AuthoritativeResource {
     private String url;

--- a/termx-api/src/main/java/org/termx/sys/server/resource/TerminologyServerResourceListProvider.java
+++ b/termx-api/src/main/java/org/termx/sys/server/resource/TerminologyServerResourceListProvider.java
@@ -1,0 +1,17 @@
+package org.termx.sys.server.resource;
+
+import org.termx.sys.server.TerminologyServer;
+import org.termx.sys.server.TerminologyServer.AuthoritativeResource;
+import java.util.List;
+
+/**
+ * Lists resources that live on a <b>remote</b> terminology server (as opposed to the local installation's
+ * database), filtered by the server's authoritative URL patterns. Used to populate the server "Resources"
+ * view for non-current-installation servers.
+ */
+public interface TerminologyServerResourceListProvider {
+  /** @param type one of {@code code-systems|value-sets|concept-maps|structure-definitions|structure-maps} */
+  boolean checkType(String type);
+
+  List<AuthoritativeResource> list(TerminologyServer server, String type, List<AuthoritativeResource> patterns);
+}

--- a/termx-core/src/main/java/org/termx/core/sys/server/TerminologyServerController.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/TerminologyServerController.java
@@ -3,8 +3,10 @@ package org.termx.core.sys.server;
 import com.kodality.commons.model.QueryResult;
 import org.termx.core.auth.Authorized;
 import org.termx.core.auth.SessionStore;
+import org.termx.sys.server.ServerConnectionCheckResult;
 import org.termx.sys.server.TerminologyServer;
 import org.termx.sys.server.TerminologyServerQueryParams;
+import org.termx.sys.server.resource.TerminologyServerResourceListProvider;
 import org.termx.sys.server.resource.TerminologyServerResourceRequest;
 import org.termx.sys.server.resource.TerminologyServerResourceResponse;
 import io.micronaut.http.HttpHeaders;
@@ -30,6 +32,7 @@ public class TerminologyServerController {
   private final TerminologyServerService serverService;
   private final TerminologyServerResourceService serverResourceService;
   private final TerminologyServerAuthoritativeService authoritativeService;
+  private final List<TerminologyServerResourceListProvider> resourceListProviders;
 
   @Authorized("Server.read")
   @Get("/kinds")
@@ -96,6 +99,25 @@ public class TerminologyServerController {
   }
 
   @Authorized("Server.read")
+  @Get("/{id}/check-connection")
+  public ServerConnectionCheckResult checkConnection(@PathVariable Long id) {
+    return serverService.checkConnection(id);
+  }
+
+  @Authorized("Server.read")
+  @Get("/{id}/resource/{type}/{resourceId}")
+  public TerminologyServerResourceResponse getServerResource(@PathVariable Long id, @PathVariable String type, @PathVariable String resourceId) {
+    TerminologyServer server = serverService.load(id);
+    if (server == null) {
+      return new TerminologyServerResourceResponse();
+    }
+    return serverResourceService.getResource(new TerminologyServerResourceRequest()
+        .setServerCode(server.getCode())
+        .setResourceType(type)
+        .setResourceId(resourceId));
+  }
+
+  @Authorized("Server.read")
   @Get("/{id}/resources/{type}")
   public List<AuthoritativeResource> getMatchingResources(@PathVariable Long id, @PathVariable String type) {
     TerminologyServer server = serverService.load(id);
@@ -113,7 +135,15 @@ public class TerminologyServerController {
     if (patterns == null || patterns.isEmpty()) {
       return List.of();
     }
-    return authoritativeService.findMatchingResources(type, patterns);
+    // The current installation is the local database; any other server is queried remotely.
+    if (server.isCurrentInstallation()) {
+      return authoritativeService.findMatchingResources(type, patterns);
+    }
+    return resourceListProviders.stream()
+        .filter(p -> p.checkType(type))
+        .findFirst()
+        .map(p -> p.list(server, type, patterns))
+        .orElseGet(List::of);
   }
 
   @Authorized("Server.write")

--- a/termx-core/src/main/java/org/termx/core/sys/server/TerminologyServerService.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/TerminologyServerService.java
@@ -6,6 +6,7 @@ import com.kodality.commons.model.QueryResult;
 import com.kodality.commons.util.JsonUtil;
 import org.termx.core.ApiError;
 import org.termx.core.sys.server.httpclient.ServerHttpClientProvider;
+import org.termx.sys.server.ServerConnectionCheckResult;
 import org.termx.sys.server.TerminologyServer;
 import org.termx.sys.server.TerminologyServer.AuthoritativeResource;
 import org.termx.sys.server.TerminologyServer.TerminologyServerFhirVersion;
@@ -32,6 +33,28 @@ public class TerminologyServerService {
 
   public List<String> getKinds() {
     return httpClientServices.stream().map(ServerHttpClientProvider::getKind).distinct().toList();
+  }
+
+  /**
+   * Live connectivity check against a saved server: dispatches to the {@link ServerHttpClientProvider} that
+   * matches the server's kind, which probes the remote endpoint with the configured URL/headers/auth. Never
+   * throws — failures are reported inside the returned {@link ServerConnectionCheckResult}.
+   */
+  public ServerConnectionCheckResult checkConnection(Long id) {
+    ServerConnectionCheckResult result = new ServerConnectionCheckResult();
+    TerminologyServer server = repository.load(id);
+    if (server == null) {
+      return result.setSuccess(false).setError("Server not found");
+    }
+    ServerHttpClientProvider provider = httpClientServices.stream()
+        .filter(p -> server.getKind() != null && server.getKind().contains(p.getKind()))
+        .findFirst()
+        .orElse(null);
+    if (provider == null) {
+      return result.setSuccess(false).setUrl(server.getRootUrl())
+          .setError("No HTTP client provider for server kind " + server.getKind());
+    }
+    return provider.checkConnection(id);
   }
 
   @Transactional

--- a/termx-core/src/main/java/org/termx/core/sys/server/httpclient/CapabilityStatementSummary.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/httpclient/CapabilityStatementSummary.java
@@ -1,0 +1,38 @@
+package org.termx.core.sys.server.httpclient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.kodality.commons.util.JsonUtil;
+import org.termx.sys.server.ServerConnectionCheckResult;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Best-effort extraction of {@code software.name} / {@code software.version} / {@code fhirVersion} from a
+ * FHIR {@code CapabilityStatement} response body into a {@link ServerConnectionCheckResult}. A non-FHIR or
+ * non-JSON body is tolerated silently — connectivity success does not depend on the body being parseable.
+ */
+public final class CapabilityStatementSummary {
+  private CapabilityStatementSummary() {}
+
+  public static void apply(String body, ServerConnectionCheckResult result) {
+    if (StringUtils.isBlank(body)) {
+      return;
+    }
+    try {
+      JsonNode node = JsonUtil.getObjectMapper().readTree(body);
+      JsonNode software = node.get("software");
+      if (software != null) {
+        if (software.hasNonNull("name")) {
+          result.setSoftware(software.get("name").asText());
+        }
+        if (software.hasNonNull("version")) {
+          result.setSoftwareVersion(software.get("version").asText());
+        }
+      }
+      if (node.hasNonNull("fhirVersion")) {
+        result.setFhirVersion(node.get("fhirVersion").asText());
+      }
+    } catch (Exception ignored) {
+      // best-effort only
+    }
+  }
+}

--- a/termx-core/src/main/java/org/termx/core/sys/server/httpclient/ServerHttpClientProvider.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/httpclient/ServerHttpClientProvider.java
@@ -1,7 +1,15 @@
 package org.termx.core.sys.server.httpclient;
 
+import org.termx.sys.server.ServerConnectionCheckResult;
+
 public interface ServerHttpClientProvider {
   String getKind();
 
   void afterServerSave(Long serverId);
+
+  /**
+   * Performs a live connectivity check against the saved server, using the same root URL, headers and
+   * authentication as real calls. Never throws — transport/HTTP failures are reported inside the result.
+   */
+  ServerConnectionCheckResult checkConnection(Long serverId);
 }

--- a/termx-core/src/main/java/org/termx/core/sys/server/httpclient/TerminologyServerHttpClientService.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/httpclient/TerminologyServerHttpClientService.java
@@ -1,10 +1,15 @@
 package org.termx.core.sys.server.httpclient;
 
 import com.kodality.commons.client.HttpClient;
+import com.kodality.commons.client.HttpClientError;
+import org.termx.sys.server.ServerConnectionCheckResult;
+import org.termx.sys.server.TerminologyServer;
 import org.termx.sys.server.TerminologyServerKind;
 import org.termx.core.sys.server.SecretEncryptor;
 import org.termx.core.sys.server.TerminologyServerRepository;
 import java.net.http.HttpRequest.Builder;
+import java.net.http.HttpResponse;
+import java.util.concurrent.CompletionException;
 import jakarta.inject.Singleton;
 
 @Singleton
@@ -16,6 +21,44 @@ public class TerminologyServerHttpClientService extends ServerHttpClientService 
   @Override
   public String getKind() {
     return TerminologyServerKind.terminology;
+  }
+
+  @Override
+  public ServerConnectionCheckResult checkConnection(Long serverId) {
+    ServerConnectionCheckResult result = new ServerConnectionCheckResult();
+    TerminologyServer server = serverService.load(serverId);
+    if (server == null) {
+      return result.setSuccess(false).setError("Server not found");
+    }
+    result.setUrl(server.getRootUrl());
+    long start = System.currentTimeMillis();
+    try {
+      HttpResponse<String> response = getHttpClient(serverId).GET("").join();
+      result.setStatusCode(response.statusCode());
+      result.setSuccess(response.statusCode() >= 200 && response.statusCode() < 300);
+      CapabilityStatementSummary.apply(response.body(), result);
+    } catch (Exception e) {
+      applyError(e, result);
+    } finally {
+      result.setDurationMs(System.currentTimeMillis() - start);
+    }
+    return result;
+  }
+
+  private static void applyError(Exception e, ServerConnectionCheckResult result) {
+    Throwable t = e instanceof CompletionException ? e.getCause() : e;
+    while (t != null) {
+      if (t instanceof HttpClientError err) {
+        result.setStatusCode(err.getResponse().statusCode());
+        result.setError(err.getMessage());
+        break;
+      }
+      t = t.getCause();
+    }
+    if (result.getError() == null) {
+      result.setError(e.getMessage());
+    }
+    result.setSuccess(false);
   }
 
   protected TerminologyServerHttpClient buildHttpClient(ServerHttpClientConfig config) {


### PR DESCRIPTION
## What

Two related server-management improvements, driven by "there's no way to tell if a configured terminology server actually works, and the Resources tab shows local data even for remote servers".

### 1. Connectivity check
New `GET /servers/{id}/check-connection` performs a live probe of the configured server using the **same root URL, headers and auth as real calls**:
- FHIR-kind servers → `GET <root>/metadata` (CapabilityStatement), parsing `software.name/version` and `fhirVersion`.
- terminology-kind servers → root GET.

Returns a `ServerConnectionCheckResult` (`success`, `statusCode`, `url`, `durationMs`, `software`, `softwareVersion`, `fhirVersion`, `error`). Never throws — transport/HTTP failures are reported inside the result. `checkConnection` is added to `ServerHttpClientProvider` and implemented per kind.

### 2. Source-aware resource listing
`GET /servers/{id}/resources/{type}` was always querying the **local database**, even for remote servers (it ignored `currentInstallation`). Now:
- **current installation** → local DB (unchanged).
- **any other server** → queried **live from its remote FHIR endpoint** and filtered by the configured authoritative URL patterns (new `TerminologyServerResourceListProvider`; FHIR implementation pages the type collection endpoint and reuses `AuthoritativeUrlMatcher`).

New read-only `GET /servers/{id}/resource/{type}/{resourceId}` returns a single remote resource (delegates to the existing fetch logic, but `Server.read` instead of the write-scoped `POST /resource`) so the UI can render a remote resource without write privileges.

## Notes
- `AuthoritativeResource` gains `@Accessors(chain=true)` (backward-compatible).
- Paired frontend PR: termx-health/termx-web#137

## Testing
- `:termx-api:`, `:termx-core:`, `:terminology:` compile clean.
- Connectivity verified against the real Ontoserver `https://term.tehik.ee/fhir` (200, Ontoserver 7.2.2, FHIR 5.0.0, anonymous).
