### PR TITLE
fix(server): probe /metadata for terminology-kind connectivity check

### DIFF
--- a/termx-core/src/main/java/org/termx/core/sys/server/httpclient/TerminologyServerHttpClientService.java
+++ b/termx-core/src/main/java/org/termx/core/sys/server/httpclient/TerminologyServerHttpClientService.java
@@ -7,10 +7,12 @@ import org.termx.sys.server.TerminologyServer;
 import org.termx.sys.server.TerminologyServerKind;
 import org.termx.core.sys.server.SecretEncryptor;
 import org.termx.core.sys.server.TerminologyServerRepository;
+import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.util.concurrent.CompletionException;
 import jakarta.inject.Singleton;
+import org.apache.commons.lang3.StringUtils;
 
 @Singleton
 public class TerminologyServerHttpClientService extends ServerHttpClientService {
@@ -30,10 +32,14 @@ public class TerminologyServerHttpClientService extends ServerHttpClientService 
     if (server == null) {
       return result.setSuccess(false).setError("Server not found");
     }
-    result.setUrl(server.getRootUrl());
+    // Terminology-kind servers are FHIR endpoints too, so probe the CapabilityStatement rather than the
+    // base URL (a GET on the base returns 400 "this is the base URL of the FHIR server").
+    result.setUrl(StringUtils.stripEnd(server.getRootUrl(), "/") + "/metadata");
+    TerminologyServerHttpClient client = getHttpClient(serverId);
     long start = System.currentTimeMillis();
     try {
-      HttpResponse<String> response = getHttpClient(serverId).GET("").join();
+      HttpRequest request = client.builder("metadata").header("Accept", "application/fhir+json").GET().build();
+      HttpResponse<String> response = client.executeAsync(request).join();
       result.setStatusCode(response.statusCode());
       result.setSuccess(response.statusCode() >= 200 && response.statusCode() < 300);
       CapabilityStatementSummary.apply(response.body(), result);


### PR DESCRIPTION
## Problem

The "Check connection" button failed for server `ontotoodang` (id 2509) with:
```
Request to https://term.tehik.ee/fhir/ returned 400
HAPI-0287: This is the base URL of FHIR server. Unable to handle this request...
```

That server has `kind: ["terminology"]`, so the **terminology-kind** probe runs. It did a `GET` on the server **root**, which a FHIR endpoint rejects with 400. (The FHIR-kind probe was already correct — it hits `/metadata`.)

## Fix

Terminology-kind servers are FHIR endpoints too, so probe the `CapabilityStatement` at `/metadata` (with `Accept: application/fhir+json`), exactly like the FHIR-kind provider. Same software/version/FHIR-version parsing applies.

## Verification

Ran the fixed probe against the live Ontoserver with the real classpath:
```
URI = https://term.tehik.ee/fhir/metadata
status = 200   (body identifies "Ontoserver")
```
`:termx-core:compileJava` passes.

Follow-up to #443.
