### PR TITLE
fix(fhir): read a code system whose designations have no use (#445)

### DIFF
--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapper.java
@@ -336,7 +336,9 @@ public class CodeSystemFhirMapper extends BaseFhirMapper {
           return fd;
         })
         .sorted(Comparator.comparing(d -> d.getLanguage() == null ? "" : d.getLanguage()))
-        .sorted(Comparator.comparing(d -> d.getUse().getCode()))
+        // A use-less designation (the internal `alternate` marker) exports with no use at all — see
+        // designationUseCoding. Sort it first rather than dereferencing the absent Coding.
+        .sorted(Comparator.comparing(d -> d.getUse() == null || d.getUse().getCode() == null ? "" : d.getUse().getCode()))
         .toList();
   }
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/codesystem/CodeSystemResourceStorage.java
@@ -103,6 +103,12 @@ public class CodeSystemResourceStorage extends BaseFhirResourceHandler {
     long start = System.currentTimeMillis();
     CodeSystemVersion version = versionNumber == null ? codeSystemVersionService.loadLastVersion(codeSystemId) :
         codeSystemVersionService.load(codeSystemId, versionNumber).orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "resource not found"));
+    if (version == null) {
+      // loadLastVersion only considers active/draft versions, so a code system whose versions are all
+      // retired/inactive resolves to none. There is nothing to read — 404 like the explicit-version
+      // branch above, rather than NPEing on setEntities below and surfacing as a 500.
+      throw new FhirException(404, IssueType.NOTFOUND, "resource not found");
+    }
     log.info("Code System load took " + (System.currentTimeMillis() - start) / 1000 + " seconds");
     start = System.currentTimeMillis();
 

--- a/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/conceptmap/ConceptMapResourceStorage.java
@@ -74,6 +74,11 @@ public class ConceptMapResourceStorage extends BaseFhirResourceHandler {
     }
     MapSetVersion version = versionNumber == null ? mapSetVersionService.loadLastVersion(id) :
         mapSetVersionService.load(id, versionNumber).orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "resource not found"));
+    if (version == null) {
+      // loadLastVersion only considers active/draft versions — an all-retired map set resolves to
+      // none. 404 like the explicit-version branch instead of NPEing below. Mirrors CodeSystem.
+      throw new FhirException(404, IssueType.NOTFOUND, "resource not found");
+    }
     // Skip the (potentially-large) per-association query when the caller asked for a
     // lightweight summary. Same pattern as the search path at line 86, and the matching
     // CodeSystem and ValueSet read-side fixes. Without entities the resulting FHIR

--- a/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
+++ b/terminology/src/main/java/org/termx/terminology/fhir/valueset/ValueSetResourceStorage.java
@@ -80,6 +80,11 @@ public class ValueSetResourceStorage extends BaseFhirResourceHandler {
     }
     ValueSetVersion version = versionNumber == null ? valueSetVersionService.loadLastVersion(vsId) :
         valueSetVersionService.load(vsId, versionNumber).orElseThrow(() -> new FhirException(404, IssueType.NOTFOUND, "resource not found"));
+    if (version == null) {
+      // loadLastVersion only considers active/draft versions — an all-retired value set resolves to
+      // none. 404 like the explicit-version branch instead of NPEing below. Mirrors CodeSystem.
+      throw new FhirException(404, IssueType.NOTFOUND, "resource not found");
+    }
     // Mirror CodeSystemResourceStorage: when the caller asked for a lightweight summary
     // (?_summary=true / text / count), null out the per-rule explicit concept lists so
     // we never serialise a potentially-huge compose.include.concept array that kefhir's

--- a/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fhir/codesystem/CodeSystemFhirMapperSpec.groovy
@@ -279,6 +279,33 @@ class CodeSystemFhirMapperSpec extends Specification {
     designationTypeOf(cs, "a", "A syn") == "snomed-synonym"
   }
 
+  def "a designation imported without a use round-trips to FHIR without throwing"() {
+    given: "FHIR-valid content whose designation omits the optional `use`"
+    def fhir = com.kodality.zmei.fhir.FhirMapper.fromJson('''
+      {"resourceType":"CodeSystem","url":"http://example.org/x","status":"active","content":"complete","language":"en","concept":[
+        {"code":"a","display":"A","designation":[
+          {"language":"en","value":"A alt"},
+          {"use":{"system":"http://snomed.info/sct","code":"900000000000013009"},"language":"en","value":"A syn"}]}]}''',
+        com.kodality.zmei.fhir.resource.terminology.CodeSystem)
+    conceptService.load(_, _) >> Optional.empty()
+    codeSystemService.query(_) >> new QueryResult<CodeSystem>([])
+
+    and: "it is stored under the internal `alternate` marker, which exports with no use"
+    def cs = mapper.fromFhirCodeSystem(fhir)
+    designationTypeOf(cs, "a", "A alt") == "alternate"
+
+    when: "the stored code system is read back out as FHIR"
+    def version = cs.versions.first().setEntities(cs.concepts.collect { it.versions.first().setCode(it.code) })
+    def exported = mapper.toFhir(cs, version, null)
+
+    then: "the use-less designation sorts and exports with no use, rather than NPEing"
+    noExceptionThrown()
+    def designations = exported.concept.find { it.code == "a" }.designation
+    designations*.value == ["A alt", "A syn"]
+    designations.find { it.value == "A alt" }.use == null
+    designations.find { it.value == "A syn" }.use.code == "900000000000013009"
+  }
+
   private static String displayOf(cs, String code) {
     def concept = cs.concepts.find { it.code == code }
     concept?.versions?.first()?.designations?.find { it.designationType == "display" }?.name


### PR DESCRIPTION
Backport of #445 to `r3.3`, so the fix can reach the LMB fork's `:latest` image.

Clean cherry-pick of `4820127e` — the diff is byte-identical to what merged on `main`, and `r3.3` carries both defects at the same lines (`CodeSystemFhirMapper:339`, `CodeSystemResourceStorage:104`, plus the matching ValueSet/ConceptMap gaps).

## What it fixes

1. **`GET /fhir/CodeSystem/{id}` 500s** when the code system holds a designation stored under the internal `alternate` marker. The 2023 sort comparator dereferences `d.getUse().getCode()`; #369 made `designationUseCoding` return `null` for `alternate` (a designation imported with no `use`) without updating it. Not a data bug — `fromFhir` re-mints the marker for any FHIR-valid designation that omits the optional `use`, so a data correction would be undone by the next import.
2. **The same endpoint 500s** for a code system whose versions are all `retired`: `loadLastVersion` filters to active/draft, returns null, and the next line NPEs on `setEntities`. Now 404, matching the explicit-version branch above. ValueSet and ConceptMap reads had the identical gap.

## Verification

Re-ran on this branch rather than trusting the cherry-pick: `CodeSystemFhirMapperSpec` 12/12 green, including the new round-trip spec, which fails with the old comparator and reproduces the reported NPE exactly.

Note there is no PR test CI in this repo (`build.yml` runs on push to `main` and tags only), so this was verified locally.