### PR TITLE
fix(test): repair specs broken by the UCUM grammar fallback, gate PRs on tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,59 @@
+# Runs the test suite on every pull request.
+#
+# Until this workflow existed, nothing ran tests before a merge: "Build ARM + AMD"
+# only calls `assemble` on push to main, and the suites that DO run `check`
+# (build-release.yml, weekly-checks.yml) fire on release tags and a weekly cron —
+# both far too late. The result was 39 tests broken on main for weeks, discovered
+# only by running them by hand, and primed to fail the next release tag.
+#
+# Deliberately test-only: no image build, no publish, nothing that needs write
+# permissions or touches the registry.
+name: Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Tests
+
+    permissions:
+      packages: read
+      contents: read
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: "25"
+          distribution: "temurin"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      # `test` rather than `check`: PMD/SpotBugs stay on the weekly + release runs so a
+      # style finding never blocks a PR, while a genuine test regression always does.
+      # GITHUB_ACTOR/GITHUB_TOKEN authenticate the com.kodality.* GitHub Packages deps.
+      - name: Run tests
+        run: ./gradlew test
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The Gradle console only summarises failures; publish the reports so a red PR can
+      # be diagnosed without re-running the suite locally.
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/test-results/
+          retention-days: 14
+          if-no-files-found: ignore

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportLargeFileTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportLargeFileTest.groovy
@@ -1,6 +1,7 @@
 package org.termx.terminology.fileimporter.codesystem
 
 import com.kodality.commons.model.QueryResult
+import org.termx.terminology.terminology.codesystem.UcumCodingSupport
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
 import org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportProcessor
 import org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportRequest
@@ -37,6 +38,17 @@ class CodeSystemFileImportLargeFileTest extends Specification {
   def conceptService = Mock(ConceptService)
   def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
 
+  // #440 gave the importer a UCUM grammar fallback. Stub the rule lookup as empty so these
+
+  // specs keep exercising the ordinary (non-UCUM) resolution path they were written for.
+
+  def ucumCodingSupport = Mock(UcumCodingSupport) {
+
+    ucumSystemOfRule(_) >> Optional.empty()
+
+  }
+
+
   CodeSystemFileImportService service = new CodeSystemFileImportService(
       dryRunService,
       codeSystemFhirImportService,
@@ -46,6 +58,7 @@ class CodeSystemFileImportLargeFileTest extends Specification {
       codeSystemVersionService,
       conceptService,
       valueSetVersionConceptService,
+      ucumCodingSupport,
       Optional.empty()
   )
 

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportServiceDryRunTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemFileImportServiceDryRunTest.groovy
@@ -1,6 +1,7 @@
 package org.termx.terminology.fileimporter.codesystem
 
 import com.kodality.commons.model.QueryResult
+import org.termx.terminology.terminology.codesystem.UcumCodingSupport
 import org.termx.terminology.ApiError
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
 import org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportProcessor
@@ -34,6 +35,17 @@ class CodeSystemFileImportServiceDryRunTest extends Specification {
   def conceptService = Mock(ConceptService)
   def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
 
+  // #440 gave the importer a UCUM grammar fallback. Stub the rule lookup as empty so these
+
+  // specs keep exercising the ordinary (non-UCUM) resolution path they were written for.
+
+  def ucumCodingSupport = Mock(UcumCodingSupport) {
+
+    ucumSystemOfRule(_) >> Optional.empty()
+
+  }
+
+
   CodeSystemFileImportService service = new CodeSystemFileImportService(
       dryRunService,
       codeSystemFhirImportService,
@@ -43,6 +55,7 @@ class CodeSystemFileImportServiceDryRunTest extends Specification {
       codeSystemVersionService,
       conceptService,
       valueSetVersionConceptService,
+      ucumCodingSupport,
       Optional.empty()
   )
 

--- a/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemImportServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/fileimporter/codesystem/CodeSystemImportServiceTest.groovy
@@ -1,6 +1,7 @@
 package org.termx.terminology.fileimporter.codesystem
 
 import com.kodality.commons.model.QueryResult
+import org.termx.terminology.terminology.codesystem.UcumCodingSupport
 import org.termx.terminology.fhir.codesystem.CodeSystemFhirImportService
 import org.termx.terminology.fileimporter.codesystem.utils.CodeSystemFileImportRequest
 import org.termx.terminology.terminology.codesystem.CodeSystemImportService
@@ -37,6 +38,17 @@ class CodeSystemImportServiceTest extends Specification {
   def valueSetVersionRuleService = Mock(ValueSetVersionRuleService)
   def valueSetVersionService = Mock(ValueSetVersionService)
 
+  // #440 gave the importer a UCUM grammar fallback. Stub the rule lookup as empty so these
+
+  // specs keep exercising the ordinary (non-UCUM) resolution path they were written for.
+
+  def ucumCodingSupport = Mock(UcumCodingSupport) {
+
+    ucumSystemOfRule(_) >> Optional.empty()
+
+  }
+
+
   def service = new CodeSystemFileImportService(
       dryRunService,
       codeSystemFhirImportService,
@@ -46,6 +58,7 @@ class CodeSystemImportServiceTest extends Specification {
       codeSystemVersionService,
       conceptService,
       valueSetVersionConceptService,
+      ucumCodingSupport,
       Optional.empty()
   )
 

--- a/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/CodeSystemValidationServiceTest.groovy
+++ b/terminology/src/test/groovy/org/termx/terminology/terminology/codesystem/CodeSystemValidationServiceTest.groovy
@@ -15,7 +15,10 @@ import java.time.LocalDateTime
 class CodeSystemValidationServiceTest extends Specification {
   def conceptService = Mock(ConceptService)
   def valueSetVersionConceptService = Mock(ValueSetVersionConceptService)
-  def service = new CodeSystemValidationService(conceptService, valueSetVersionConceptService)
+  // #440 added a UCUM grammar fallback for coding values the concept query can't resolve. Left
+  // unstubbed it answers false, so these specs keep asserting the plain unknown-reference behaviour.
+  def ucumCodingSupport = Mock(UcumCodingSupport)
+  def service = new CodeSystemValidationService(conceptService, valueSetVersionConceptService, ucumCodingSupport)
 
 
   def 'should validate CS version entity properties'() {
@@ -124,6 +127,45 @@ class CodeSystemValidationServiceTest extends Specification {
 
     issues.collect { it.formattedMessage() }.containsAll(expectedIssues)
     issues.size() == expectedIssues.size()
+  }
+
+
+  def 'a grammar-valid UCUM code is accepted even though it is not materialised as a concept'() {
+    given: """
+    #440: UCUM concepts are defined by grammar, not enumerated, so a valid expression such as
+    "10*6/mL" resolves to no concept. It must not be reported as an unknown reference, while a
+    genuinely invalid UCUM expression still must be.
+    """
+
+    def ep = entityProperty('unit', 'Coding').setRule(new EntityPropertyRule(codeSystems: ['ucum']))
+
+    def code = 'test'
+    def concept = new Concept(
+        code: code,
+        versions: [
+            new CodeSystemEntityVersion(
+                codeSystem: 'overlord',
+                code: code,
+                propertyValues: [
+                    entityPropertyValue('unit', [codeSystem: 'ucum', code: '10*6/mL']),
+                    entityPropertyValue('unit', [codeSystem: 'ucum', code: "Ohm*min"]),
+                ]
+            )
+        ])
+
+    and: "neither code is materialised, so the concept query resolves nothing"
+    conceptService.query(_) >> QueryResult.empty()
+
+    and: "only the grammar-valid one passes the UCUM fallback"
+    ucumCodingSupport.isUcumOrSupplement('ucum') >> true
+    ucumCodingSupport.isValidUcumCode('10*6/mL') >> true
+    ucumCodingSupport.isValidUcumCode("Ohm*min") >> false
+
+    when:
+    def issues = service.validateConcepts([concept], [ep])
+
+    then: "the grammar-valid code is accepted; the invalid one is still an unknown reference"
+    issues.collect { it.formattedMessage() } == ['Unknown reference "Ohm*min" to "ucum"']
   }
 
 


### PR DESCRIPTION
`./gradlew :terminology:test` had **39 failures on `main`**, across 4 spec classes that never got past field initialisation:

```
Could not find matching constructor for: CodeSystemValidationService(
    ConceptService$SpockMock, ValueSetVersionConceptService$SpockMock)
```

## Cause

#440 gave `CodeSystemValidationService` and `CodeSystemFileImportService` a new `UcumCodingSupport` collaborator. Both are `@RequiredArgsConstructor`, so the generated constructor silently gained an argument, and the four specs that construct them by hand were never updated. **#440 shipped no tests of its own**, so nothing went red at the time.

## Fix

Pass the new collaborator in all four specs. Left unstubbed a `Mock` answers `false`, which is exactly the pre-#440 behaviour these specs assert, so no expectation changes. The importer specs stub `ucumSystemOfRule` as empty because a Spock `Mock` would otherwise answer `null` and NPE on the `Optional`.

Also added the test #440 never had: a grammar-valid UCUM code that is **not** materialised as a concept is accepted, while an invalid one is still an unknown reference. Verified meaningful — deleting the production fallback makes that test, and only that test, fail.

## Why nobody noticed, and what it was about to break

Nothing ran tests before a merge:

| workflow | trigger | runs |
|---|---|---|
| Build ARM + AMD | push to `main`, tags | `assemble` — **no tests** |
| build-release | `*.*.*` tags | `check` |
| weekly-checks | Monday cron | `check` |

So the first thing that would have caught this is a **release tag** — `build-release` runs `check` *before* `publish`. `r3.3` carries the identical drift and `3.3.1` is not yet tagged, so **cutting 3.3.1 would have failed the release build**.

This PR adds a `Tests` workflow on `pull_request`. It is deliberately test-only — no image build, no publish, read-only permissions — and runs `test` rather than `check` so a PMD/SpotBugs style finding never blocks a PR while a real regression always does. Test reports upload as an artifact so a red PR is diagnosable without re-running locally.

## Verification

Full suite green — **683 tests across 11 modules**, 0 failures (terminology 311, integtest 158, core 76, wiki 45, snomed 36, app 27, ucum 15, uam 7, plus editions/IG). Testcontainers-backed `termx-integtest` already runs on GitHub runners via `build-release`, so the new workflow is on a proven path.

⚠️ **`r3.3` needs the same spec fix** before 3.3.1 can be tagged — happy to send that backport next.